### PR TITLE
Throw exceptions from nested objects

### DIFF
--- a/src/Model/RenderJob.php
+++ b/src/Model/RenderJob.php
@@ -27,30 +27,25 @@ class RenderJob
     protected $classPath;
     /** @var string */
     protected $fileName;
-    /** @var bool */
-    protected $initialClass;
 
     /**
      * Create a new class render job
      *
-     * @param string $fileName     The file name
-     * @param string $classPath    The relative path of the class for namespace generation
-     * @param string $className    The class name
-     * @param Schema $schema       The Schema object which holds properties and validators
-     * @param bool   $initialClass Render job for an initial class or render job for a nested class?
+     * @param string $fileName  The file name
+     * @param string $classPath The relative path of the class for namespace generation
+     * @param string $className The class name
+     * @param Schema $schema    The Schema object which holds properties and validators
      */
     public function __construct(
         string $fileName,
         string $classPath,
         string $className,
-        Schema $schema,
-        bool $initialClass
+        Schema $schema
     ) {
         $this->fileName = $fileName;
         $this->classPath = $classPath;
         $this->className = $className;
         $this->schema = $schema;
-        $this->initialClass = $initialClass;
     }
 
     /**
@@ -151,7 +146,6 @@ class RenderJob
                     'schema'                 => $this->schema,
                     'generatorConfiguration' => $generatorConfiguration,
                     'viewHelper'             => new RenderHelper($generatorConfiguration),
-                    'initialClass'           => $this->initialClass,
                     // one hack a day keeps the problems away. Make true literal available for the templating. Easy fix
                     'true'                   => true,
                 ]

--- a/src/Model/Validator/AbstractPropertyValidator.php
+++ b/src/Model/Validator/AbstractPropertyValidator.php
@@ -4,7 +4,6 @@ declare(strict_types = 1);
 
 namespace PHPModelGenerator\Model\Validator;
 
-use PHPModelGenerator\Model\Property\Property;
 use PHPModelGenerator\Model\Property\PropertyInterface;
 use PHPModelGenerator\Model\Validator;
 
@@ -19,6 +18,18 @@ abstract class AbstractPropertyValidator implements PropertyValidatorInterface
     protected $exceptionClass;
     /** @var array */
     protected $exceptionParams;
+
+    /**
+     * AbstractPropertyValidator constructor.
+     *
+     * @param string $exceptionClass
+     * @param array $exceptionParams
+     */
+    public function __construct(string $exceptionClass, array $exceptionParams = [])
+    {
+        $this->exceptionClass = $exceptionClass;
+        $this->exceptionParams = $exceptionParams;
+    }
 
     /**
      * @inheritDoc

--- a/src/Model/Validator/InstanceOfValidator.php
+++ b/src/Model/Validator/InstanceOfValidator.php
@@ -22,7 +22,10 @@ class InstanceOfValidator extends PropertyValidator
     public function __construct(PropertyInterface $property)
     {
         parent::__construct(
-            sprintf('is_object($value) && !($value instanceof %s)', $property->getType()),
+            sprintf(
+                'is_object($value) && !($value instanceof \Exception) && !($value instanceof %s)',
+                $property->getType()
+            ),
             InvalidInstanceOfException::class,
             [$property->getName(), $property->getType()]
         );

--- a/src/Model/Validator/PropertyTemplateValidator.php
+++ b/src/Model/Validator/PropertyTemplateValidator.php
@@ -39,8 +39,7 @@ class PropertyTemplateValidator extends AbstractPropertyValidator
         $this->template = $template;
         $this->templateValues = $templateValues;
 
-        $this->exceptionClass = $exceptionClass;
-        $this->exceptionParams = $exceptionParams;
+        parent::__construct($exceptionClass, $exceptionParams);
     }
 
     /**

--- a/src/Model/Validator/PropertyValidator.php
+++ b/src/Model/Validator/PropertyValidator.php
@@ -24,8 +24,8 @@ class PropertyValidator extends AbstractPropertyValidator
     public function __construct(string $check, string $exceptionClass, array $exceptionParams = [])
     {
         $this->check = $check;
-        $this->exceptionClass = $exceptionClass;
-        $this->exceptionParams = $exceptionParams;
+
+        parent::__construct($exceptionClass, $exceptionParams);
     }
 
     /**

--- a/src/PropertyProcessor/Decorator/Property/ObjectInstantiationDecorator.php
+++ b/src/PropertyProcessor/Decorator/Property/ObjectInstantiationDecorator.php
@@ -7,7 +7,6 @@ namespace PHPModelGenerator\PropertyProcessor\Decorator\Property;
 use PHPMicroTemplate\Render;
 use PHPModelGenerator\Model\GeneratorConfiguration;
 use PHPModelGenerator\Model\Property\PropertyInterface;
-use PHPModelGenerator\Utils\RenderHelper;
 
 /**
  * Class ObjectInstantiationDecorator
@@ -46,12 +45,15 @@ class ObjectInstantiationDecorator implements PropertyDecoratorInterface
      */
     public function decorate(string $input, PropertyInterface $property): string
     {
+        $template = $this->generatorConfiguration->collectErrors()
+            ? 'ObjectInstantiationDecoratorErrorRegistry.phptpl'
+            : 'ObjectInstantiationDecoratorDirectException.phptpl';
+
         return static::$renderer->renderTemplate(
-            DIRECTORY_SEPARATOR . 'Decorator' . DIRECTORY_SEPARATOR . 'ObjectInstantiationDecorator.phptpl',
+            DIRECTORY_SEPARATOR . 'Decorator' . DIRECTORY_SEPARATOR . $template,
             [
                 'input' => $input,
                 'className' => $this->className,
-                'generatorConfiguration' => $this->generatorConfiguration,
             ]
         );
     }

--- a/src/SchemaProcessor/PostProcessor/Templates/Populate.phptpl
+++ b/src/SchemaProcessor/PostProcessor/Templates/Populate.phptpl
@@ -12,7 +12,7 @@ public function populate(array $modelData): self
 {
     {% if generatorConfiguration.collectErrors() %}
         $this->errorRegistry = new {{ viewHelper.getSimpleClassName(generatorConfiguration.getErrorRegistryClass()) }}();
-    {% endif%}
+    {% endif %}
     $rollbackValues = [];
 
     {% if schema.getBaseValidators() %}

--- a/src/SchemaProcessor/PostProcessor/Templates/RemoveAdditionalProperty.phptpl
+++ b/src/SchemaProcessor/PostProcessor/Templates/RemoveAdditionalProperty.phptpl
@@ -17,7 +17,7 @@ public function removeAdditionalProperty(string $property): bool
     {% if minPropertyValidator %}
         {% if generatorConfiguration.collectErrors() %}
             $this->errorRegistry = new {{ viewHelper.getSimpleClassName(generatorConfiguration.getErrorRegistryClass()) }}();
-        {% endif%}
+        {% endif %}
 
         if ({{ minPropertyValidator.getCheck() }}) {
             {{ viewHelper.validationError(minPropertyValidator) }}

--- a/src/SchemaProcessor/SchemaProcessor.php
+++ b/src/SchemaProcessor/SchemaProcessor.php
@@ -162,7 +162,7 @@ class SchemaProcessor
             $jsonSchema->withJson($json)
         );
 
-        $this->generateClassFile($classPath, $className, $schema, $initialClass);
+        $this->generateClassFile($classPath, $className, $schema);
 
         return $schema;
     }
@@ -173,20 +173,18 @@ class SchemaProcessor
      * @param string $classPath
      * @param string $className
      * @param Schema $schema
-     * @param bool   $initialClass
      */
     public function generateClassFile(
         string $classPath,
         string $className,
-        Schema $schema,
-        bool $initialClass = false
+        Schema $schema
     ): void {
         $fileName = join(
             DIRECTORY_SEPARATOR,
             [$this->destination, str_replace('\\', DIRECTORY_SEPARATOR, $classPath), $className]
         ) . '.php';
 
-        $this->renderQueue->addRenderJob(new RenderJob($fileName, $classPath, $className, $schema, $initialClass));
+        $this->renderQueue->addRenderJob(new RenderJob($fileName, $classPath, $className, $schema));
 
         if ($this->generatorConfiguration->isOutputEnabled()) {
             echo "Generated class {$this->generatorConfiguration->getNamespacePrefix()}\\$classPath\\$className\n";

--- a/src/Templates/Decorator/ObjectInstantiationDecorator.phptpl
+++ b/src/Templates/Decorator/ObjectInstantiationDecorator.phptpl
@@ -1,7 +1,0 @@
-(is_array($param = {{ input }})
-   ? new {{ className }}(
-        $param
-        {% if generatorConfiguration.collectErrors() %}, $this->errorRegistry{% endif %}
-     )
-   : $param
-)

--- a/src/Templates/Decorator/ObjectInstantiationDecoratorDirectException.phptpl
+++ b/src/Templates/Decorator/ObjectInstantiationDecoratorDirectException.phptpl
@@ -1,0 +1,1 @@
+(is_array($param = {{ input }}) ? new {{ className }}($param) : $param)

--- a/src/Templates/Decorator/ObjectInstantiationDecoratorErrorRegistry.phptpl
+++ b/src/Templates/Decorator/ObjectInstantiationDecoratorErrorRegistry.phptpl
@@ -1,0 +1,11 @@
+(function ($value) {
+    try {
+        return is_array($value) ? new {{ className }}($value) : $value;
+    } catch (\Exception $instantiationException) {
+        foreach($instantiationException->getErrors() as $nestedValidationError) {
+            $this->errorRegistry->addError($nestedValidationError);
+        }
+
+        return $instantiationException;
+    }
+})({{ input }})

--- a/src/Templates/Model.phptpl
+++ b/src/Templates/Model.phptpl
@@ -36,25 +36,14 @@ class {{ class }} {% if schema.getInterfaces() %}implements {{ viewHelper.joinCl
      * {{ class }} constructor.
      *
      * @param array $modelData
-     {% if generatorConfiguration.collectErrors() %}{% if not initialClass %}* @param {{ viewHelper.getSimpleClassName(generatorConfiguration.getErrorRegistryClass()) }} $errorRegistry{% endif %}{% endif %}
      *
      * @throws {% if generatorConfiguration.collectErrors() %}{{ viewHelper.getSimpleClassName(generatorConfiguration.getErrorRegistryClass()) }}{% else %}ValidationException{% endif %}
      */
-    public function __construct(
-        array $modelData = []
+    public function __construct(array $modelData = [])
+    {
         {% if generatorConfiguration.collectErrors() %}
-            {% if not initialClass %}
-                , {{ viewHelper.getSimpleClassName(generatorConfiguration.getErrorRegistryClass()) }} $errorRegistry = null
-            {% endif %}
+            $this->errorRegistry = new {{ viewHelper.getSimpleClassName(generatorConfiguration.getErrorRegistryClass()) }}();
         {% endif %}
-    ) {
-        {% if generatorConfiguration.collectErrors() %}
-            {% if initialClass %}
-                $this->errorRegistry = new {{ viewHelper.getSimpleClassName(generatorConfiguration.getErrorRegistryClass()) }}();
-            {% else %}
-                $this->errorRegistry = $errorRegistry;
-            {% endif %}
-        {% endif%}
 
         {% if schema.getBaseValidators() %}
             $this->executeBaseValidators($modelData);
@@ -65,12 +54,10 @@ class {{ class }} {% if schema.getInterfaces() %}implements {{ viewHelper.joinCl
         {% endforeach %}
 
         {% if generatorConfiguration.collectErrors() %}
-            {% if initialClass %}
-                if (count($this->errorRegistry->getErrors())) {
-                    throw $this->errorRegistry;
-                }
-            {% endif%}
-        {% endif%}
+            if (count($this->errorRegistry->getErrors())) {
+                throw $this->errorRegistry;
+            }
+        {% endif %}
 
         $this->rawModelDataInput = $modelData;
     }
@@ -130,7 +117,7 @@ class {{ class }} {% if schema.getInterfaces() %}implements {{ viewHelper.joinCl
 
                 {% if generatorConfiguration.collectErrors() %}
                     $this->errorRegistry = new {{ viewHelper.getSimpleClassName(generatorConfiguration.getErrorRegistryClass()) }}();
-                {% endif%}
+                {% endif %}
 
                 $value = $this->validate{{ viewHelper.ucfirst(property.getAttribute()) }}($value, $modelData);
 
@@ -138,7 +125,7 @@ class {{ class }} {% if schema.getInterfaces() %}implements {{ viewHelper.joinCl
                     if ($this->errorRegistry->getErrors()) {
                         throw $this->errorRegistry;
                     }
-                {% endif%}
+                {% endif %}
 
                 $this->{{ property.getAttribute() }} = $value;
 

--- a/src/Templates/Validator/ArrayContains.phptpl
+++ b/src/Templates/Validator/ArrayContains.phptpl
@@ -5,7 +5,7 @@ is_array($value) && (function (&$items) {
 
     {% if generatorConfiguration.collectErrors() %}
         $originalErrorRegistry = $this->errorRegistry;
-    {% endif%}
+    {% endif %}
 
     foreach ($items as &$value) {
         try {
@@ -28,7 +28,7 @@ is_array($value) && (function (&$items) {
                 }
 
                 $this->errorRegistry = $originalErrorRegistry;
-            {% endif%}
+            {% endif %}
 
             // one matched item is enough to pass the contains check
             return false;
@@ -39,7 +39,7 @@ is_array($value) && (function (&$items) {
 
     {% if generatorConfiguration.collectErrors() %}
         $this->errorRegistry = $originalErrorRegistry;
-    {% endif%}
+    {% endif %}
 
     return true;
 })($value)

--- a/src/Templates/Validator/ArrayItem.phptpl
+++ b/src/Templates/Validator/ArrayItem.phptpl
@@ -1,12 +1,12 @@
 is_array($value) && (function (&$items) use (&$invalidItems{{ suffix }}) {
     {% if generatorConfiguration.collectErrors() %}
         $originalErrorRegistry = $this->errorRegistry;
-    {% endif%}
+    {% endif %}
 
     foreach ($items as $index => &$value) {
         {% if generatorConfiguration.collectErrors() %}
             $this->errorRegistry = new {{ viewHelper.getSimpleClassName(generatorConfiguration.getErrorRegistryClass()) }}();
-        {% endif%}
+        {% endif %}
 
         try {
             {{ viewHelper.resolvePropertyDecorator(nestedProperty) }}

--- a/src/Templates/Validator/ArrayTuple.phptpl
+++ b/src/Templates/Validator/ArrayTuple.phptpl
@@ -1,7 +1,7 @@
 is_array($value) && (function (&$items) use (&$invalidTuples) {
     {% if generatorConfiguration.collectErrors() %}
         $originalErrorRegistry = $this->errorRegistry;
-    {% endif%}
+    {% endif %}
 
     $index = 0;
     {% foreach tupleProperties as tuple %}

--- a/src/Templates/Validator/SchemaDependency.phptpl
+++ b/src/Templates/Validator/SchemaDependency.phptpl
@@ -4,7 +4,7 @@ array_key_exists('{{ propertyName }}', $modelData) && (function () use ($modelDa
         $this->errorRegistry = new {{ viewHelper.getSimpleClassName(generatorConfiguration.getErrorRegistryClass()) }}();
     {% else %}
         try {
-    {% endif%}
+    {% endif %}
 
     $value = $modelData;
     {{ viewHelper.resolvePropertyDecorator(nestedProperty) }}


### PR DESCRIPTION
Don't pass an error registry exception into a nested object and add errors to the passed exception. Instead always throw an exception from generated objects and catch those exceptions inside a parent model.