### PR TITLE
StringProcessor: Escape backslashes in generated strings

### DIFF
--- a/src/PropertyProcessor/Property/StringProcessor.php
+++ b/src/PropertyProcessor/Property/StringProcessor.php
@@ -69,7 +69,7 @@ class StringProcessor extends AbstractTypedValueProcessor
             );
         }
 
-        $json[static::JSON_FIELD_PATTERN] = addcslashes($json[static::JSON_FIELD_PATTERN], "'");
+        $json[static::JSON_FIELD_PATTERN] = addcslashes($json[static::JSON_FIELD_PATTERN], "'\\");
 
         $property->addValidator(
             new PropertyValidator(


### PR DESCRIPTION
fixes #40 