### PR TITLE
Sort schema files

### DIFF
--- a/src/SchemaProvider/RecursiveDirectoryProvider.php
+++ b/src/SchemaProvider/RecursiveDirectoryProvider.php
@@ -58,7 +58,7 @@ class RecursiveDirectoryProvider implements SchemaProviderInterface
             $jsonSchema = file_get_contents($file);
 
             if (!$jsonSchema || !($decodedJsonSchema = json_decode($jsonSchema, true))) {
-                throw new SchemaException("Invalid JSON-Schema file {$file[0]}");
+                throw new SchemaException("Invalid JSON-Schema file $file");
             }
 
             yield new JsonSchema($file, $decodedJsonSchema);


### PR DESCRIPTION
This ensures a consistent model generation order as the RecursiveDirectoryIterator might iterate over files without a specific order, [see comment](https://www.php.net/manual/de/class.recursivedirectoryiterator.php#120971).