### PR TITLE
Removed obsolete @var in ExtendObjectPropertiesMatchingPatternPropert…

### DIFF
--- a/src/SchemaProcessor/PostProcessor/Internal/ExtendObjectPropertiesMatchingPatternPropertiesPostProcessor.php
+++ b/src/SchemaProcessor/PostProcessor/Internal/ExtendObjectPropertiesMatchingPatternPropertiesPostProcessor.php
@@ -50,7 +50,6 @@ class ExtendObjectPropertiesMatchingPatternPropertiesPostProcessor extends PostP
 
                     $matchesAnyPattern = false;
 
-                    /** @var PatternPropertiesValidator $patternPropertiesValidator */
                     foreach (array_keys($json['patternProperties']) as $pattern) {
                         if (preg_match("/{$pattern}/", $property->getName())) {
                             $matchesAnyPattern = true;


### PR DESCRIPTION
…iesPostProcessor

There's no variable in this scope by that name.

This was found by [PHPStan](https://phpstan.org) on level 2.