### PR TITLE
Fixed PropertyInterface::setType() signature mismatch

### DIFF
--- a/src/Model/Property/PropertyInterface.php
+++ b/src/Model/Property/PropertyInterface.php
@@ -42,7 +42,7 @@ interface PropertyInterface
      *
      * @return PropertyInterface
      */
-    public function setType(PropertyType $type, PropertyType $outputType = null): PropertyInterface;
+    public function setType(PropertyType $type = null, PropertyType $outputType = null): PropertyInterface;
 
     /**
      * @param bool $outputType If set to true the output type hint will be returned (may differ from the base type)


### PR DESCRIPTION
the doc comment (as well as all the implementors) say it should be this. In addition, null may be passed in multiple places where this is used.

This was found using [PHPStan](https://phpstan.org), along with a few other errors.