### PR TITLE
Use $rawModelDataInput as construct function parameter name 

### DIFF
--- a/src/Templates/Model.phptpl
+++ b/src/Templates/Model.phptpl
@@ -32,7 +32,7 @@ class {{ class }} {% if schema.getInterfaces() %}implements {{ viewHelper.joinCl
         {% if property.isInternal() %}private{% else %}protected{% endif %} ${{ property.getAttribute() }}{% if not viewHelper.isNull(property.getDefaultValue()) %} = {{ property.getDefaultValue() }}{% endif %};
     {% endforeach %}
     /** @var array */
-    protected $_rawModelDataInput = [];
+    protected $modelData = [];
 
     {% if generatorConfiguration.collectErrors() %}
         /** @var {{ viewHelper.getSimpleClassName(generatorConfiguration.getErrorRegistryClass()) }} Collect all validation errors */
@@ -70,7 +70,7 @@ class {{ class }} {% if schema.getInterfaces() %}implements {{ viewHelper.joinCl
             }
         {% endif %}
 
-        $this->_rawModelDataInput = $modelData;
+        $this->modelData = $modelData;
 
         {{ schemaHookResolver.resolveConstructorAfterValidationHook() }}
     }
@@ -100,7 +100,7 @@ class {{ class }} {% if schema.getInterfaces() %}implements {{ viewHelper.joinCl
      */
     public function getRawModelDataInput(): array
     {
-        return $this->_rawModelDataInput;
+        return $this->modelData;
     }
 
     {% foreach schema.getProperties() as property %}
@@ -154,7 +154,7 @@ class {{ class }} {% if schema.getInterfaces() %}implements {{ viewHelper.joinCl
                     {% endif %}
 
                     $this->{{ property.getAttribute() }} = $value;
-                    $this->_rawModelDataInput['{{ property.getName() }}'] = ${{ property.getAttribute() }};
+                    $this->modelData['{{ property.getName() }}'] = ${{ property.getAttribute() }};
 
                     {{ schemaHookResolver.resolveSetterAfterValidationHook(property) }}
 


### PR DESCRIPTION
Use $rawModelDataInput as construct function parameter name  in Modelphptpl

1. The reason: 
Because when Symfony deserializer the serialized object will not find the parameter value in the saved data and use the default parameter value(empty array). 
Then the model construct function will get the error: `Typed property must not be accessed before initialization` since PHP 7.4, The error description and explanation: [stackoverflow](https://stackoverflow.com/questions/59265625/why-i-am-suddenly-getting-a-typed-property-must-not-be-accessed-before-initiali)

2. The Symfony serializer: 
see: https://github.com/symfony/symfony/blob/44db49fb8f6d70c4341120a3f8f1b1a1a0dfa014/src/Symfony/Component/Serializer/Normalizer/AbstractNormalizer.php#L380
and
https://github.com/symfony/symfony/blob/44db49fb8f6d70c4341120a3f8f1b1a1a0dfa014/src/Symfony/Component/Serializer/Normalizer/AbstractNormalizer.php#L355

3. How to reproduce the error:
    - Use [Symfony Messenger Transport Serialier](https://github.com/symfony/symfony/blob/6.1/src/Symfony/Component/Messenger/Transport/Serialization/Serializer.php) as a symfony messenger transport serializer 
    - After the message has been saved for async handling, when the message handler tries to deserialize the saved message, the error will be raised. 
