### PR TITLE
Fix issue #70

### DIFF
--- a/src/Templates/Model.phptpl
+++ b/src/Templates/Model.phptpl
@@ -20,7 +20,7 @@ declare(strict_types = 1);
 {% if schema.getDescription() %} * {{ schema.getDescription() }}
  *{% endif %}
  * This is an auto-implemented class implemented by the php-json-schema-model-generator.
- * If you need to implement something in this class use inheritance. Else you will loose your changes if the classes
+ * If you need to implement something in this class use inheritance. Else you will lose your changes if the classes
  * are re-generated.
  */
 class {{ class }} {% if schema.getInterfaces() %}implements {{ viewHelper.joinClassNames(schema.getInterfaces()) }}{% endif %}

--- a/src/Templates/Validator/ComposedItem.phptpl
+++ b/src/Templates/Validator/ComposedItem.phptpl
@@ -12,6 +12,7 @@
     $validatorComponentIndex = 0;
     $originalModelData = $value;
     $proposedValue = null;
+    $modifiedValues = [];
 
     {% if not generatorConfiguration.isImmutable() %}
         $originalPropertyValidationState = $this->_propertyValidationState ?? [];
@@ -90,6 +91,9 @@
                     $proposedValue = $proposedValue ?? $value;
                 {% endif %}
 
+                if (is_object($value)) {
+                    $modifiedValues = array_merge($modifiedValues, $this->_getModifiedValues($originalModelData, $value));
+                }
             {% if not generatorConfiguration.isImmutable() %}
                 {% if not generatorConfiguration.collectErrors() %}
                     if (isset($validatorIndex)) {
@@ -118,6 +122,10 @@
 
     {% if mergedProperty %}
         if (is_object($proposedValue)) {
+            if ($modifiedValues) {
+                $value = array_merge($value, $modifiedValues);
+            }
+
             {{ viewHelper.resolvePropertyDecorator(mergedProperty) }}
         } else {
             $value = $proposedValue;

--- a/tests/Issues/Issue/Issue70Test.php
+++ b/tests/Issues/Issue/Issue70Test.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PHPModelGenerator\Tests\Issues\Issue;
+
+use PHPModelGenerator\Filter\TransformingFilterInterface;
+use PHPModelGenerator\Model\GeneratorConfiguration;
+use PHPModelGenerator\Tests\Issues\AbstractIssueTest;
+
+class Issue70Test extends AbstractIssueTest
+{
+    /**
+     * @dataProvider validInputDataProvider
+     */
+    public function testValidInput(string $filter, array $input, $expectedOutput): void
+    {
+        $className = $this->generateClassFromFileTemplate(
+            'filterInCompositionInArray.json',
+            [$filter],
+            (new GeneratorConfiguration())->addFilter($this->getFilter())
+        );
+
+        $object = new $className($input);
+
+        $this->assertCount(1, $object->getItems());
+        $this->assertSame('Hello', $object->getItems()[0]->getTitle());
+        $this->assertSame($expectedOutput, $object->getItems()[0]->getProperty());
+    }
+
+    public function validInputDataProvider(): array
+    {
+        return [
+            'basic filter - default value' => ['trim', ['items' => [['title' => 'Hello']]], 'now'],
+            'basic filter - custom value - not modified' => ['trim', ['items' => [['title' => 'Hello', 'property' => 'later']]], 'later'],
+            'basic filter - custom value - modified' => ['trim', ['items' => [['title' => 'Hello', 'property' => '   later   ']]], 'later'],
+            'basic filter - null' => ['trim', ['items' => [['title' => 'Hello', 'property' => null]]], null],
+            'transforming filter - default value' => ['countChars', ['items' => [['title' => 'Hello']]], 3],
+            'transforming filter - transformed value' => ['countChars', ['items' => [['title' => 'Hello', 'property' => 5]]], 5],
+            'transforming filter - custom value' => ['countChars', ['items' => [['title' => 'Hello', 'property' => 'Hello World']]], 11],
+            'transforming filter - null' => ['countChars', ['items' => [['title' => 'Hello', 'property' => null]]], null],
+        ];
+    }
+
+    public function getFilter(): TransformingFilterInterface
+    {
+        return new class () implements TransformingFilterInterface {
+            public function getAcceptedTypes(): array
+            {
+                return ['string', 'null'];
+            }
+
+            public function getToken(): string
+            {
+                return 'countChars';
+            }
+
+            public function getFilter(): array
+            {
+                return [Issue70Test::class, 'filter'];
+            }
+
+            public function getSerializer(): array
+            {
+                return [Issue70Test::class, 'filter'];
+            }
+        };
+    }
+
+    public static function filter(?string $input): ?int
+    {
+        return $input === null ? null : strlen($input);
+    }
+}

--- a/tests/Schema/Issues/70/filterInCompositionInArray.json
+++ b/tests/Schema/Issues/70/filterInCompositionInArray.json
@@ -1,0 +1,33 @@
+{
+  "type": "object",
+  "properties": {
+    "items": {
+      "type": "array",
+      "items":{
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "title": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "title"
+            ]
+          },
+          {
+            "type": "object",
+            "properties": {
+              "property": {
+                "type": "string",
+                "filter": "%s",
+                "default": "now"
+              }
+            }
+          }
+        ]
+      }
+    }
+  }
+}


### PR DESCRIPTION
Merged properties of a composition are filled up with the provided values without further validation execution after the single composition branches are validated separately. Consequently,changes applied to the values from filters are missing. The new added method _getModifiedValues sets up a diff with all changed values from the nested composition branch. All modified values are applied to the merged property afterwards so changes from filters are kept.