### PR TITLE
Added strict validation because null can implicitly convert to zero, …

### DIFF
--- a/src/PropertyProcessor/Property/AbstractPropertyProcessor.php
+++ b/src/PropertyProcessor/Property/AbstractPropertyProcessor.php
@@ -117,7 +117,7 @@ abstract class AbstractPropertyProcessor implements PropertyProcessorInterface
             $property->addTypeHintDecorator(new TypeHintDecorator($typesOfEnum));
         }
 
-        if ($this->isImplicitNullAllowed($property) && !in_array(null, $allowedValues)) {
+        if ($this->isImplicitNullAllowed($property) && !in_array(null, $allowedValues, true)) {
             $allowedValues[] = null;
         }
 

--- a/tests/Objects/EnumPropertyTest.php
+++ b/tests/Objects/EnumPropertyTest.php
@@ -223,8 +223,27 @@ class EnumPropertyTest extends AbstractPHPModelGeneratorTestCase
         return [
             "string 'red'" => ['red'],
             'null' => [null],
+            'int 0' => [0],
             'int 10' => [10],
         ];
+    }
+
+    /**
+     * @throws FileSystemException
+     * @throws RenderException
+     * @throws SchemaException
+     */
+    public function testSuccessCreateObjectWithOptionalFieldsContainingZero(): void
+    {
+        $className = $this->generateClassFromFile('TypedEnumPropertyWithZeroValue.json', null, false, true);
+        $object = new $className(['property' => 10]);
+
+        $this->assertSame(10, $object->getProperty());
+        $this->assertSame(null, $object->getPropertyWithZero());
+
+        $returnType = $this->getReturnType($object, 'getPropertyWithZero');
+        $this->assertSame('int', $returnType->getName());
+        $this->assertTrue($returnType->allowsNull());
     }
 
     /**

--- a/tests/Schema/EnumPropertyTest/TypedEnumPropertyWithZeroValue.json
+++ b/tests/Schema/EnumPropertyTest/TypedEnumPropertyWithZeroValue.json
@@ -1,0 +1,13 @@
+{
+  "type": "object",
+  "properties": {
+    "property": {
+      "type": "integer",
+      "enum": [10, 20]
+    },
+    "propertyWithZero": {
+      "type": "integer",
+      "enum": [0, 1]
+    }
+  }
+}

--- a/tests/Schema/EnumPropertyTest/UntypedEnumProperty.json
+++ b/tests/Schema/EnumPropertyTest/UntypedEnumProperty.json
@@ -2,7 +2,7 @@
   "type": "object",
   "properties": {
     "property": {
-      "enum": ["red", 10]
+      "enum": ["red", 0, 10]
     }
   }
 }


### PR DESCRIPTION
…and that didn't work for enums containing zero.