### PR TITLE
Replaced the function empty with a more strict comparison

### DIFF
--- a/src/Utils/NormalizedName.php
+++ b/src/Utils/NormalizedName.php
@@ -28,7 +28,7 @@ class NormalizedName
 
         $attributeName = join('', $elements);
 
-        if (empty($attributeName)) {
+        if ($attributeName === '') {
             throw new SchemaException(
                 sprintf(
                     "Name '%s' results in an empty name in file %s",

--- a/tests/Basic/BasicSchemaGenerationTest.php
+++ b/tests/Basic/BasicSchemaGenerationTest.php
@@ -275,7 +275,8 @@ class BasicSchemaGenerationTest extends AbstractPHPModelGeneratorTestCase
             'space property' => '   ',
             'numeric42' => 13,
             '1000' => 1000,
-            '1000string' => '1000'
+            '1000string' => '1000',
+            '0' => 0,
         ]);
 
         $this->assertSame('___', $object->getUnderscoreProperty());
@@ -284,6 +285,7 @@ class BasicSchemaGenerationTest extends AbstractPHPModelGeneratorTestCase
         $this->assertSame(13, $object->getNumeric42());
         $this->assertSame(1000, $object->get1000());
         $this->assertSame('1000', $object->get1000string());
+        $this->assertSame(0, $object->get0());
     }
 
     public function testEmptyNormalizedPropertyNameThrowsAnException(): void

--- a/tests/Schema/BasicSchemaGenerationTest/NameNormalization.json
+++ b/tests/Schema/BasicSchemaGenerationTest/NameNormalization.json
@@ -21,6 +21,9 @@
     },
     "1000string": {
       "type": "string"
+    },
+    "0": {
+      "type": "integer"
     }
   }
 }


### PR DESCRIPTION
Hi! I am actively using the library to generate classes in my project and I have found a minor bug. Properties with the name "0" throw an error. 
Because PHP will consider a string containing a zero as empty, it makes the empty() function an unsuitable solution. I replaced function empty() with a check that it is explicitly equal to an empty string.