### PR TITLE
Added caching setting to GeneratorConfiguration

### DIFF
--- a/src/Model/GeneratorConfiguration.php
+++ b/src/Model/GeneratorConfiguration.php
@@ -41,6 +41,8 @@ class GeneratorConfiguration
     protected $errorRegistryClass = ErrorRegistryException::class;
     /** @var bool */
     protected $serialization = false;
+    /** @var bool */
+    protected $cacheEnabled = true;
 
     /** @var ClassNameGeneratorInterface */
     protected $classNameGenerator;
@@ -252,6 +254,18 @@ class GeneratorConfiguration
         $this->allowImplicitNull = $allowImplicitNull;
 
         return $this;
+    }
+
+    public function setCacheEnabled(bool $cacheEnabled): self
+    {
+        $this->cacheEnabled = $cacheEnabled;
+
+        return $this;
+    }
+
+    public function isCacheEnabled(): bool
+    {
+        return $this->cacheEnabled;
     }
 
     private function initFilter(): void

--- a/src/Model/SchemaDefinition/SchemaDefinition.php
+++ b/src/Model/SchemaDefinition/SchemaDefinition.php
@@ -67,7 +67,10 @@ class SchemaDefinition
 
         $key = implode('-', $originalPath);
 
-        if (!$this->resolvedPaths->offsetExists($key)) {
+        $isCacheEnabled = $this->schemaProcessor->getGeneratorConfiguration()->isCacheEnabled();
+        $isResolvedPath = $this->resolvedPaths->offsetExists($key);
+
+        if (!$isCacheEnabled || !$isResolvedPath) {
             // create a dummy entry for the path first. If the path is used recursive the recursive usages will point
             // to the currently created property
             $this->resolvedPaths->offsetSet($key, null);

--- a/tests/AbstractPHPModelGeneratorTestCase.php
+++ b/tests/AbstractPHPModelGeneratorTestCase.php
@@ -130,6 +130,7 @@ abstract class AbstractPHPModelGeneratorTestCase extends TestCase
         bool $originalClassNames = false,
         bool $implicitNull = true,
         string $schemaProviderClass = RecursiveDirectoryProvider::class,
+        bool $cacheEnabled = true,
     ): string {
         return $this->generateClass(
             file_get_contents($this->getSchemaFilePath($file)),
@@ -137,6 +138,7 @@ abstract class AbstractPHPModelGeneratorTestCase extends TestCase
             $originalClassNames,
             $implicitNull,
             $schemaProviderClass,
+            $cacheEnabled
         );
     }
 
@@ -156,6 +158,7 @@ abstract class AbstractPHPModelGeneratorTestCase extends TestCase
         bool $escape = true,
         bool $implicitNull = true,
         string $schemaProviderClass = RecursiveDirectoryProvider::class,
+        bool $cacheEnabled = true,
     ): string {
         return $this->generateClass(
             sprintf(
@@ -170,6 +173,7 @@ abstract class AbstractPHPModelGeneratorTestCase extends TestCase
             false,
             $implicitNull,
             $schemaProviderClass,
+            $cacheEnabled
         );
     }
 
@@ -186,10 +190,12 @@ abstract class AbstractPHPModelGeneratorTestCase extends TestCase
         bool $originalClassNames = false,
         bool $implicitNull = true,
         string $schemaProviderClass = RecursiveDirectoryProvider::class,
+        bool $cacheEnabled = true,
     ): string {
         $generatorConfiguration = ($generatorConfiguration ?? (new GeneratorConfiguration())->setCollectErrors(false))
             ->setImplicitNull($implicitNull)
-            ->setOutputEnabled(false);
+            ->setOutputEnabled(false)
+            ->setCacheEnabled($cacheEnabled);
 
         $baseDir = sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'PHPModelGeneratorTest';
 

--- a/tests/Objects/ReferencePropertyTest.php
+++ b/tests/Objects/ReferencePropertyTest.php
@@ -6,6 +6,7 @@ namespace PHPModelGenerator\Tests\Objects;
 
 use PHPModelGenerator\Exception\ErrorRegistryException;
 use PHPModelGenerator\Exception\FileSystemException;
+use PHPModelGenerator\Exception\Object\RequiredValueException;
 use PHPModelGenerator\Exception\ValidationException;
 use PHPModelGenerator\Exception\RenderException;
 use PHPModelGenerator\Exception\SchemaException;
@@ -546,5 +547,41 @@ Invalid type for personB. Requires object, got integer
 ERROR
             ],
         ];
+    }
+
+    /**
+     * @throws FileSystemException
+     * @throws RenderException
+     * @throws SchemaException
+     */
+    public function testValidCreateObjectRequiredAndOptionalPropertiesWithDefinitionValue(): void
+    {
+        $className = $this->generateClassFromFile(
+            'RequiredAndOptionalPropertiesWithDefinitionValue.json',
+            cacheEnabled: false,
+        );
+
+        $object = new $className(['requiredProperty' => 'red']);
+
+        $this->assertSame('red', $object->getRequiredProperty());
+        $this->assertNull($object->getOptionalProperty());
+    }
+
+    /**
+     * @throws FileSystemException
+     * @throws RenderException
+     * @throws SchemaException
+     */
+    public function testInvalidCreateObjectRequiredAndOptionalPropertiesWithDefinitionValue(): void
+    {
+        $className = $this->generateClassFromFile(
+            'RequiredAndOptionalPropertiesWithDefinitionValue.json',
+            cacheEnabled: true,
+        );
+
+        $this->expectException(RequiredValueException::class);
+        $this->expectExceptionMessage('Missing required value for optionalProperty');
+
+        new $className(['requiredProperty' => 'red']);
     }
 }

--- a/tests/Schema/ReferencePropertyTest/RequiredAndOptionalPropertiesWithDefinitionValue.json
+++ b/tests/Schema/ReferencePropertyTest/RequiredAndOptionalPropertiesWithDefinitionValue.json
@@ -1,0 +1,19 @@
+{
+  "definitions": {
+    "forOptionalAndRequiredAtTheSameTime": {
+      "type": "string"
+    }
+  },
+  "type": "object",
+  "properties": {
+    "requiredProperty": {
+      "$ref": "#/definitions/forOptionalAndRequiredAtTheSameTime"
+    },
+    "optionalProperty": {
+      "$ref": "#/definitions/forOptionalAndRequiredAtTheSameTime"
+    }
+  },
+  "required": [
+    "requiredProperty"
+  ]
+}


### PR DESCRIPTION
Hi! I encountered an incorrect behavior when using $ref references. There are two fields in the schema that reference the same subschema. First field is marked as required, and the second is not. In the generated class, the second field is mistakenly set as required.
I suggest considering the "cacheEnabled" setting to solve the problem, as the easiest way.