### PR TITLE
Fix code typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ $generator = new ModelGenerator(
 );
 
 $generator
-    ->generateModelDirectory(__DIR__ . '/result');
+    ->generateModelDirectory(__DIR__ . '/result')
     ->generateModels(new RecursiveDirectoryProvider(__DIR__ . '/schema'), __DIR__ . '/result');
 ```
 


### PR DESCRIPTION
The semi-colon is invalid.  (Including "use" statements in that block would be good too, but this is a syntax error.)