### PR TITLE
Execute tests when we need no coverage

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,6 +27,11 @@ jobs:
       - name: Install dependencies
         run: composer update --no-interaction
 
+      - name: Execute tests
+        if: ${{ ! matrix.coverage }}
+        run: |
+          ./vendor/bin/phpunit --testdox
+
       - name: Upload the reports to codeclimate
         if: ${{ matrix.coverage }}
         env:


### PR DESCRIPTION
Oh no!
Unit tests were not running when not generating coverage.
