### PR TITLE
Fix duplicate builder methods when two properties share a $ref (#130)

### DIFF
--- a/src/Model/Property/PropertyProxy.php
+++ b/src/Model/Property/PropertyProxy.php
@@ -63,7 +63,9 @@ class PropertyProxy extends AbstractProperty
         ?PropertyType $outputType = null,
         bool $reset = false,
     ): PropertyInterface {
-        return $this->getProperty()->setType($type, $outputType, $reset);
+        $this->getProperty()->setType($type, $outputType, $reset);
+
+        return $this;
     }
 
     /**
@@ -79,7 +81,9 @@ class PropertyProxy extends AbstractProperty
      */
     public function addTypeHintDecorator(TypeHintDecoratorInterface $typeHintDecorator): PropertyInterface
     {
-        return $this->getProperty()->addTypeHintDecorator($typeHintDecorator);
+        $this->getProperty()->addTypeHintDecorator($typeHintDecorator);
+
+        return $this;
     }
 
     /**
@@ -122,7 +126,9 @@ class PropertyProxy extends AbstractProperty
         int $priority = 99,
         ?string $sourceKey = null,
     ): PropertyInterface {
-        return $this->getProperty()->addValidator($validator, $priority, $sourceKey);
+        $this->getProperty()->addValidator($validator, $priority, $sourceKey);
+
+        return $this;
     }
 
     /**
@@ -138,7 +144,9 @@ class PropertyProxy extends AbstractProperty
      */
     public function filterValidators(callable $filter): PropertyInterface
     {
-        return $this->getProperty()->filterValidators($filter);
+        $this->getProperty()->filterValidators($filter);
+
+        return $this;
     }
 
     /**
@@ -158,7 +166,9 @@ class PropertyProxy extends AbstractProperty
      */
     public function addDecorator(PropertyDecoratorInterface $decorator): PropertyInterface
     {
-        return $this->getProperty()->addDecorator($decorator);
+        $this->getProperty()->addDecorator($decorator);
+
+        return $this;
     }
 
     /**
@@ -166,7 +176,9 @@ class PropertyProxy extends AbstractProperty
      */
     public function filterDecorators(callable $filter): PropertyInterface
     {
-        return $this->getProperty()->filterDecorators($filter);
+        $this->getProperty()->filterDecorators($filter);
+
+        return $this;
     }
 
     /**
@@ -194,7 +206,9 @@ class PropertyProxy extends AbstractProperty
      */
     public function setRequired(bool $isPropertyRequired): PropertyInterface
     {
-        return $this->getProperty()->setRequired($isPropertyRequired);
+        $this->getProperty()->setRequired($isPropertyRequired);
+
+        return $this;
     }
 
     /**
@@ -210,7 +224,9 @@ class PropertyProxy extends AbstractProperty
      */
     public function setReadOnly(bool $isPropertyReadOnly): PropertyInterface
     {
-        return $this->getProperty()->setReadOnly($isPropertyReadOnly);
+        $this->getProperty()->setReadOnly($isPropertyReadOnly);
+
+        return $this;
     }
 
     /**
@@ -226,7 +242,9 @@ class PropertyProxy extends AbstractProperty
      */
     public function setWriteOnly(bool $isPropertyWriteOnly): PropertyInterface
     {
-        return $this->getProperty()->setWriteOnly($isPropertyWriteOnly);
+        $this->getProperty()->setWriteOnly($isPropertyWriteOnly);
+
+        return $this;
     }
 
     /**
@@ -242,7 +260,9 @@ class PropertyProxy extends AbstractProperty
      */
     public function setDefaultValue($defaultValue, bool $raw = false): PropertyInterface
     {
-        return $this->getProperty()->setDefaultValue($defaultValue, $raw);
+        $this->getProperty()->setDefaultValue($defaultValue, $raw);
+
+        return $this;
     }
 
     /**
@@ -258,7 +278,9 @@ class PropertyProxy extends AbstractProperty
      */
     public function setNestedSchema(Schema $schema): PropertyInterface
     {
-        return $this->getProperty()->setNestedSchema($schema);
+        $this->getProperty()->setNestedSchema($schema);
+
+        return $this;
     }
 
     /**
@@ -282,7 +304,9 @@ class PropertyProxy extends AbstractProperty
      */
     public function setInternal(bool $isPropertyInternal): PropertyInterface
     {
-        return $this->getProperty()->setInternal($isPropertyInternal);
+        $this->getProperty()->setInternal($isPropertyInternal);
+
+        return $this;
     }
 
     /**

--- a/tests/Issues/Issue/Issue130Test.php
+++ b/tests/Issues/Issue/Issue130Test.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PHPModelGenerator\Tests\Issues\Issue;
+
+use PHPModelGenerator\Model\GeneratorConfiguration;
+use PHPModelGenerator\ModelGenerator;
+use PHPModelGenerator\SchemaProcessor\PostProcessor\BuilderClassPostProcessor;
+use PHPModelGenerator\Tests\Issues\AbstractIssueTestCase;
+
+/**
+ * Regression test for https://github.com/wol-soft/php-json-schema-model-generator/issues/130
+ *
+ * When two properties of an object reference the same nested schema via $ref, the
+ * BuilderClassPostProcessor used to emit a duplicate getter/setter pair under the first
+ * property's name, producing a fatal "Cannot redeclare" error at require time.
+ *
+ * The defect was in PropertyProxy: its fluent setters returned the wrapped inner property
+ * rather than $this, so a chain like `(clone $proxy)->setReadOnly(false)->...` silently
+ * escaped to the underlying Property — which still carried the first property's name.
+ */
+class Issue130Test extends AbstractIssueTestCase
+{
+    public function testTwoPropertiesReferencingSameDefinitionProduceDistinctBuilderMethods(): void
+    {
+        $this->modifyModelGenerator = static function (ModelGenerator $generator): void {
+            $generator->addPostProcessor(new BuilderClassPostProcessor());
+        };
+
+        $className = $this->generateClassFromFile(
+            'DuplicateRef.json',
+            (new GeneratorConfiguration())->setImmutable(false),
+        );
+
+        $builderClassName = $className . 'Builder';
+        $builderObject = new $builderClassName();
+
+        // Both setter/getter pairs must exist with distinct names derived from the
+        // outer property names — not collapsed onto the referenced definition's name.
+        $this->assertTrue(method_exists($builderObject, 'getCollectionList'));
+        $this->assertTrue(method_exists($builderObject, 'setCollectionList'));
+        $this->assertTrue(method_exists($builderObject, 'getCollectionListExclude'));
+        $this->assertTrue(method_exists($builderObject, 'setCollectionListExclude'));
+
+        // Setting one must not bleed into the other, and the validated model must hold
+        // two distinct nested objects.
+        $builderObject
+            ->setCollectionList(['items' => ['a', 'b']])
+            ->setCollectionListExclude(['items' => ['c']]);
+
+        $validated = $builderObject->validate();
+
+        $this->assertSame(['a', 'b'], $validated->getCollectionList()->getItems());
+        $this->assertSame(['c'], $validated->getCollectionListExclude()->getItems());
+        $this->assertNotSame($validated->getCollectionList(), $validated->getCollectionListExclude());
+    }
+}

--- a/tests/Schema/Issues/130/DuplicateRef.json
+++ b/tests/Schema/Issues/130/DuplicateRef.json
@@ -1,0 +1,24 @@
+{
+  "type": "object",
+  "definitions": {
+    "collectionList": {
+      "type": "object",
+      "properties": {
+        "items": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    }
+  },
+  "properties": {
+    "collection_list": {
+      "$ref": "#/definitions/collectionList"
+    },
+    "collection_list_exclude": {
+      "$ref": "#/definitions/collectionList"
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Closes #130.

Two properties of the same object that `$ref` the same schema caused
`BuilderClassPostProcessor` to emit duplicate `get*`/`set*` methods,
producing a fatal `Cannot redeclare …Builder::getCollectionList()` at
`require` time.

Root cause: every fluent setter on `PropertyProxy` was implemented as
`return \$this->getProperty()->setX(...)`, which returns the wrapped
inner `Property`, not `\$this`. A chain like
`(clone \$proxy)->setReadOnly(false)->addTypeHintDecorator(...)` therefore
escaped to the underlying property on the very first call — and the two
schema properties collapsed onto the same underlying object, which still
carried the *first* property's name.

Fix: each fluent setter on `PropertyProxy` now mutates the inner property
and returns `\$this`. This also corrects the same latent bug at four other
call sites that use the `(clone \$property)->setX(...)->...` pattern
(composition merge, transferred properties, additional-properties accessor,
schema dependencies); no behavioural change for non-proxy properties.

## Test plan

- [x] Regression test `tests/Issues/Issue/Issue130Test.php` reproduces the
  fatal on `master` (verified by reverting the fix) and passes with the fix.
- [x] Schema is a single self-contained file using internal
  `#/definitions/` refs — the bug has nothing to do with cross-file refs;
  it only needs two properties to resolve to the same `\$ref` cache key.
- [x] Full suite green (2682 tests, 6629 assertions).
- [x] `phpcs --standard=phpcs.xml` clean on changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)