### PR TITLE
Isolate PropertyProxy attribute mutations from the shared underlying property

### DIFF
--- a/src/Model/Attributes/AttributesTrait.php
+++ b/src/Model/Attributes/AttributesTrait.php
@@ -8,8 +8,8 @@ use PHPModelGenerator\Model\GeneratorConfiguration;
 
 trait AttributesTrait
 {
-    /** @var PhpAttribute[] */
-    private array $phpAttributes = [];
+    /** @var PhpAttribute[] Protected so PropertyProxy::getAttributes() can merge it with the underlying property */
+    protected array $phpAttributes = [];
 
     public function filterAttributes(callable $filter): static
     {

--- a/src/Model/Property/PropertyProxy.php
+++ b/src/Model/Property/PropertyProxy.php
@@ -371,13 +371,17 @@ class PropertyProxy extends AbstractProperty
 
     /**
      * @inheritdoc
+     *
+     * Stores the attribute on the proxy itself (via AttributesTrait) rather than on the shared
+     * underlying property, so adding an attribute to one proxy does not leak to sibling proxies
+     * that reference the same $ref definition.
      */
     public function addAttribute(
         PhpAttribute $attribute,
         ?GeneratorConfiguration $generatorConfiguration = null,
         ?int $enablementFlag = null,
     ): static {
-        $this->getProperty()->addAttribute($attribute);
+        parent::addAttribute($attribute, $generatorConfiguration, $enablementFlag);
 
         return $this;
     }
@@ -396,13 +400,12 @@ class PropertyProxy extends AbstractProperty
     /**
      * @inheritdoc
      *
-     * Replaces the SchemaName attribute from the underlying shared property with one that
-     * carries the proxy's own name. Two proxies sharing the same $ref definition would
-     * otherwise both report the first property's name via the shared underlying attribute.
-     *
-     * When a JsonPointer override is set, all existing JsonPointer attributes (there may be
-     * multiple when the underlying property was synthesised from composition branches) are
-     * removed and replaced with a single attribute pointing to the reference site.
+     * Merges three sources, later ones winning by attribute type:
+     *  - the underlying property's attributes (ReadOnly, WriteOnly, Deprecated, …), with its
+     *    SchemaName replaced by this proxy's own name so sibling proxies of the same $ref do not
+     *    all report the first property's name;
+     *  - the JsonPointer override, when set, pointing at this reference site;
+     *  - attributes added directly to this proxy, stored locally so they do not leak to siblings.
      */
     public function getAttributes(): array
     {
@@ -419,6 +422,18 @@ class PropertyProxy extends AbstractProperty
                 static fn(PhpAttribute $attribute): bool => $attribute->getFqcn() !== JsonPointer::class,
             ));
             $attributes[] = $this->overrideJsonPointer;
+        }
+
+        if ($this->phpAttributes !== []) {
+            $localFqcns = array_map(
+                static fn(PhpAttribute $attribute): string => $attribute->getFqcn(),
+                $this->phpAttributes,
+            );
+            $attributes = array_values(array_filter(
+                $attributes,
+                static fn(PhpAttribute $attribute): bool => !in_array($attribute->getFqcn(), $localFqcns, true),
+            ));
+            $attributes = array_merge($attributes, $this->phpAttributes);
         }
 
         return $attributes;

--- a/tests/Issues/Issue/Issue151Test.php
+++ b/tests/Issues/Issue/Issue151Test.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PHPModelGenerator\Tests\Issues\Issue;
+
+use PHPModelGenerator\Attributes\Deprecated;
+use PHPModelGenerator\Model\Attributes\PhpAttribute;
+use PHPModelGenerator\Model\GeneratorConfiguration;
+use PHPModelGenerator\Model\Schema;
+use PHPModelGenerator\ModelGenerator;
+use PHPModelGenerator\SchemaProcessor\PostProcessor\PostProcessor;
+use PHPModelGenerator\Tests\AbstractPHPModelGeneratorTestCase;
+use ReflectionClass;
+
+/**
+ * When two properties reference the same $def, the second is generated as a PropertyProxy sharing
+ * the first property's underlying object. An attribute added to one proxy (here via a post
+ * processor) must stay on that proxy and not leak onto the shared underlying — otherwise every
+ * sibling reference to the same $def inherits it.
+ */
+class Issue151Test extends AbstractPHPModelGeneratorTestCase
+{
+    public function testAttributeAddedToOneProxyDoesNotLeakToSiblingReference(): void
+    {
+        $schema = json_encode([
+            'type' => 'object',
+            'properties' => [
+                'ref_one' => ['$ref' => '#/$defs/Foo'],
+                'ref_two' => ['$ref' => '#/$defs/Foo'],
+            ],
+            '$defs' => [
+                'Foo' => ['type' => 'string'],
+            ],
+        ]);
+
+        $deprecateRefTwo = new class extends PostProcessor {
+            public function process(Schema $schema, GeneratorConfiguration $generatorConfiguration): void
+            {
+                foreach ($schema->getProperties() as $property) {
+                    if ($property->getName() === 'ref_two') {
+                        $property->addAttribute(new PhpAttribute(Deprecated::class));
+                    }
+                }
+            }
+        };
+
+        $this->modifyModelGenerator = static function (ModelGenerator $generator) use ($deprecateRefTwo): void {
+            $generator->addPostProcessor($deprecateRefTwo);
+        };
+
+        $className = $this->generateClass($schema);
+        $reflection = new ReflectionClass($className);
+
+        $this->assertCount(
+            1,
+            $reflection->getProperty('refTwo')->getAttributes(Deprecated::class),
+            'ref_two must carry the Deprecated attribute added to it',
+        );
+        $this->assertCount(
+            0,
+            $reflection->getProperty('refOne')->getAttributes(Deprecated::class),
+            'ref_one must not inherit the Deprecated attribute added only to ref_two',
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Rebased onto current `master` and narrowed to the one issue that still reproduces there.

The attribute **merge-on-read** you asked for in the original B4 review is already present on `master` — `PropertyProxy::getAttributes()` reads from the underlying property, so `ReadOnly`, `WriteOnly` and `Deprecated` are already inherited. Verified with tests; those pass on `master` unchanged.

What still reproduces on `master` is an attribute **leak**: `PropertyProxy::addAttribute()` delegates to the *shared* underlying property. So when two properties `$ref` the same `$def` (the second becomes a `PropertyProxy` sharing the first's underlying object) and something adds an attribute to one proxy — e.g. a post processor tagging a single property `Deprecated` — it lands on the shared underlying and every sibling reference inherits it.

## Fix

`PropertyProxy` now stores added attributes on itself (via `AttributesTrait`, whose backing array is made `protected`) instead of on the underlying, and `getAttributes()` merges them in with local attributes winning by type. The existing `SchemaName` rename and `overrideJsonPointer` behaviour are unchanged.

## Test

`tests/Issues/Issue/Issue151Test.php` — a post processor adds `Deprecated` to `ref_two`; the test asserts `ref_one` does not inherit it. Fails on `master`, passes with this change.