### PR TITLE
Fix JsonPointer for properties transferred from $ref composition branches

### DIFF
--- a/src/Utils/PropertyAttributeSynthesizer.php
+++ b/src/Utils/PropertyAttributeSynthesizer.php
@@ -9,6 +9,7 @@ use PHPModelGenerator\Attributes\JsonSchema as JsonSchemaAttribute;
 use PHPModelGenerator\Model\Attributes\PhpAttribute;
 use PHPModelGenerator\Model\GeneratorConfiguration;
 use PHPModelGenerator\Model\Schema;
+use PHPModelGenerator\Model\SchemaDefinition\JsonSchema;
 use PHPModelGenerator\Model\Validator\AbstractComposedPropertyValidator;
 use PHPModelGenerator\Model\Validator\ConditionalPropertyValidator;
 use PHPModelGenerator\Model\Validator\Factory\Composition\AllOfValidatorFactory;
@@ -78,7 +79,13 @@ class PropertyAttributeSynthesizer
 
                 foreach ($branch->getNestedSchema()->getProperties() as $branchProperty) {
                     if ($branchProperty->getName() === $propertyName) {
-                        $branchPointers[] = $branchProperty->getJsonSchema()->getPointer();
+                        // Use the composition branch position (e.g. /allOf/0) rather than the
+                        // property's own pointer: for a $ref'd branch the latter resolves to the
+                        // referenced definition (/$defs/…) instead of the branch it was merged from.
+                        $branchPointer = $branch->getBranchSchema()->getPointer();
+                        $branchPointers[] = $branchPointer !== ''
+                            ? $branchPointer . '/properties/' . JsonSchema::encodePointer($propertyName)
+                            : $branchProperty->getJsonSchema()->getPointer();
                         break;
                     }
                 }

--- a/tests/CompositionBranchJsonPointerTest.php
+++ b/tests/CompositionBranchJsonPointerTest.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PHPModelGenerator\Tests;
+
+use PHPModelGenerator\Attributes\JsonPointer;
+use ReflectionClass;
+
+/**
+ * A property transferred from a composition branch into the merge class must carry a #[JsonPointer]
+ * that reflects its position within the composition, not the location it happens to be defined at.
+ *
+ * For a $ref'd branch the synthesizer previously used the referenced definition's pointer
+ * (e.g. /$defs/Extra/properties/age) instead of the branch position (/allOf/0/properties/age).
+ */
+class CompositionBranchJsonPointerTest extends AbstractPHPModelGeneratorTestCase
+{
+    public function testTransferredPropertyFromRefBranchHasCorrectJsonPointer(): void
+    {
+        $schema = json_encode([
+            'type' => 'object',
+            'properties' => [
+                'name' => ['type' => 'string'],
+            ],
+            'allOf' => [
+                ['$ref' => '#/$defs/Extra'],
+            ],
+            '$defs' => [
+                'Extra' => [
+                    'type' => 'object',
+                    'properties' => [
+                        'age' => ['type' => 'integer'],
+                    ],
+                ],
+            ],
+        ]);
+
+        $className = $this->generateClass($schema);
+        $ageAttr = (new ReflectionClass($className))->getProperty('age')->getAttributes(JsonPointer::class);
+
+        $this->assertCount(1, $ageAttr);
+        $this->assertSame(
+            '/allOf/0/properties/age',
+            $ageAttr[0]->getArguments()[0],
+            'Property "age" from a $ref allOf branch must carry the composition-branch pointer',
+        );
+    }
+
+    public function testTransferredPropertyFromInlineBranchHasCorrectJsonPointer(): void
+    {
+        $schema = json_encode([
+            'type' => 'object',
+            'properties' => [
+                'name' => ['type' => 'string'],
+            ],
+            'allOf' => [
+                [
+                    'properties' => [
+                        'age' => ['type' => 'integer'],
+                    ],
+                ],
+            ],
+        ]);
+
+        $className = $this->generateClass($schema);
+        $reflection = new ReflectionClass($className);
+
+        $this->assertSame(
+            '/properties/name',
+            $reflection->getProperty('name')->getAttributes(JsonPointer::class)[0]->getArguments()[0],
+        );
+        $this->assertSame(
+            '/allOf/0/properties/age',
+            $reflection->getProperty('age')->getAttributes(JsonPointer::class)[0]->getArguments()[0],
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Rebased onto current `master` and reduced to the one fix that still reproduces there.

A property merged into a composed schema's class from a **`$ref`'d composition branch** received the referenced definition's JSON pointer (e.g. `/$defs/Extra/properties/age`) instead of its position within the composition (`/allOf/0/properties/age`). `PropertyAttributeSynthesizer` now takes the pointer from the composition branch schema, falling back to the property's own pointer for inline branches.

## Test

`CompositionBranchJsonPointerTest`:
- `testTransferredPropertyFromRefBranchHasCorrectJsonPointer` — fails on `master`, passes with this change.
- `testTransferredPropertyFromInlineBranchHasCorrectJsonPointer` — regression guard for inline branches.

## What was dropped from the earlier version of this PR

The `RenderQueue::addRenderJob` deduplication + `RenderJob` changes were removed. Investigation showed the duplicate render they guarded against does not occur on `master` (the full suite renders with zero duplicates once the guard is removed) — it was an artifact of the class-name cache-key change from the now-closed B5 PR (#152), not an independent issue. Per the "fix the root cause, not a workaround" review note, only the synthesizer fix remains.