### PR TITLE
Restore MediaStringFilter/ImmutableMediaStringFilter filter registrations

### DIFF
--- a/src/Model/GeneratorConfiguration.php
+++ b/src/Model/GeneratorConfiguration.php
@@ -382,6 +382,12 @@ class GeneratorConfiguration
             ->addFilter(new DateTimeFilter())
             ->addFilter(new NotEmptyFilter())
             ->addFilter(new TrimFilter())
+            // Register the MediaString and ImmutableMediaString filters (and their production
+            // library callable classes PHPModelGenerator\Filter\MediaString and
+            // PHPModelGenerator\Filter\ImmutableMediaString) which enable the contentMediaType
+            // and contentEncoding schema keywords.  These registrations were previously removed
+            // under the assumption that the production library classes did not exist, but they
+            // do — see packages/php-json-schema-model-generator-production/src/Filter/.
             ->addFilter(new MediaStringFilter())
             ->addFilter(new ImmutableMediaStringFilter());
     }


### PR DESCRIPTION
## Summary

Restore the default registration of MediaStringFilter and ImmutableMediaStringFilter in GeneratorConfiguration::initFilter(). These were previously removed under the assumption that the production library classes did not exist, but they do — see `packages/php-json-schema-model-generator-production/src/Filter/MediaString.php` and `ImmutableMediaString.php`.

## What the maintainer asked

> "Why are MediaStringFilter and ImmutableMediaStringFilter being removed?"

**Response**: They shouldn't have been removed. The production library has `Filter\MediaString` and `Filter\ImmutableMediaString` classes. This restores the registrations. The `getAcceptedTypes()` methods that were added back to filter files were also removed — the upstream uses `FilterReflection::getAcceptedTypes()` via reflection instead.
