### PR TITLE
Support JSON Schema Draft 2019-09 $defs keyword

### DIFF
--- a/docs/source/generic/references.rst
+++ b/docs/source/generic/references.rst
@@ -7,16 +7,17 @@ Supported reference types
 -------------------------
 
 * internal (in a single file) reference by id (example: `"$ref": "#IdOfMyObject"`)
-* internal (in a single file) reference by path (example: `"$ref": "#/definitions/myObject"`)
+* internal (in a single file) reference by path using ``definitions`` (Draft 7, example: `"$ref": "#/definitions/myObject"`)
+* internal (in a single file) reference by path using ``$defs`` (Draft 2019-09, example: `"$ref": "#/$defs/myObject"`)
 * relative reference based on the location on the file system to a complete file (example: `"$ref": "./../modules/myObject.json"`)
 * relative reference based on the location on the file system to an object by id (example: `"$ref": "./../modules/myObject.json#IdOfMyObject"`)
-* relative reference based on the location on the file system to an object by path (example: `"$ref": "./../modules/myObject.json#/definitions/myObject"`)
+* relative reference based on the location on the file system to an object by path (example: `"$ref": "./../modules/myObject.json#/definitions/myObject"` or `"$ref": "./../modules/myObject.json#/$defs/myObject"`)
 * absolute reference based on the location on the file system to a complete file (example: `"$ref": "/modules/myObject.json"`)
 * absolute reference based on the location on the file system to an object by id (example: `"$ref": "/modules/myObject.json#IdOfMyObject"`)
-* absolute reference based on the location on the file system to an object by path (example: `"$ref": "/modules/myObject.json#/definitions/myObject"`)
+* absolute reference based on the location on the file system to an object by path (example: `"$ref": "/modules/myObject.json#/definitions/myObject"` or `"$ref": "/modules/myObject.json#/$defs/myObject"`)
 * network reference to a complete file (example: `"$ref": "https://my.domain.com/schema/modules/myObject.json"`)
 * network reference to an object by id (example: `"$ref": "https://my.domain.com/schema/modules/myObject.json#IdOfMyObject"`)
-* network reference to an object by path (example: `"$ref": "https://my.domain.com/schema/modules/myObject.json#/definitions/myObject"`)
+* network reference to an object by path (example: `"$ref": "https://my.domain.com/schema/modules/myObject.json#/definitions/myObject"` or `"$ref": "https://my.domain.com/schema/modules/myObject.json#/$defs/myObject"`)
 
 If an `$id` is present in the schema, the `$ref` will be resolved relative to the `$id` (except the `$ref` already is an absolute reference, e.g. a full URL).
 The behaviour of `$ref` resolving can be overwritten by implementing a custom **SchemaProviderInterface**, for example when you want to use network references behind an authorization.
@@ -28,7 +29,7 @@ The behaviour of `$ref` resolving can be overwritten by implementing a custom **
 Object reference
 ----------------
 
-An example for properties referring to a definition inside the same schema:
+An example for properties referring to a definition inside the same schema (Draft 7 using ``definitions``):
 
 .. code-block:: json
 
@@ -59,6 +60,38 @@ An example for properties referring to a definition inside the same schema:
         }
     }
 
+Draft 2019-09 introduced ``$defs`` as the standard replacement for ``definitions``. Both keywords are supported and behave identically:
+
+.. code-block:: json
+
+    {
+        "$schema": "https://json-schema.org/draft/2019-09/schema",
+        "$defs": {
+            "person": {
+                "$id": "#person",
+                "type": "object",
+                "properties": {
+                    "name": {
+                        "type": "string"
+                    }
+                }
+            }
+        },
+        "$id": "team",
+        "type": "object",
+        "properties": {
+            "leader": {
+                "$ref": "#person"
+            },
+            "members": {
+                "type": "array",
+                "items": {
+                    "$ref": "#/$defs/person"
+                }
+            }
+        }
+    }
+
 Base Reference
 --------------
 
@@ -68,6 +101,27 @@ The whole model may contain a reference. In this case all base validations (eg. 
 
     {
         "definitions": {
+            "person": {
+                "$id": "#person",
+                "type": "object",
+                "properties": {
+                    "name": {
+                        "type": "string"
+                    }
+                }
+            }
+        },
+        "$id": "#Citizen",
+        "$ref": "#person"
+    }
+
+The same pattern works with ``$defs`` (Draft 2019-09):
+
+.. code-block:: json
+
+    {
+        "$schema": "https://json-schema.org/draft/2019-09/schema",
+        "$defs": {
             "person": {
                 "$id": "#person",
                 "type": "object",

--- a/src/Model/Schema.php
+++ b/src/Model/Schema.php
@@ -190,27 +190,40 @@ class Schema
     public function addProperty(PropertyInterface $property, ?string $compositionProcessor = null): self
     {
         if (!isset($this->properties[$property->getName()])) {
-            $attribute = $property->getAttribute();
-
-            $existingRawName = $this->attributeIndex[$attribute] ?? null;
-            if ($existingRawName !== null && $existingRawName !== $property->getName()) {
-                throw new SchemaException(
-                    sprintf(
-                        "Property names '%s' and '%s' both normalize to attribute '%s' in file %s",
-                        $existingRawName,
-                        $property->getName(),
-                        $attribute,
-                        $this->jsonSchema->getFile(),
-                    ),
-                );
-            }
-
-            $this->attributeIndex[$attribute] = $property->getName();
+            // Register by name immediately — the name is always held locally on the property
+            // or proxy, independent of whether the proxy's target is resolved yet.
             $this->properties[$property->getName()] = $property;
 
             if ($compositionProcessor === null) {
                 $this->rootRegisteredPropertyNames[$property->getName()] = true;
             }
+
+            // getAttribute() → isInternal() delegates to getProperty() on a PropertyProxy, which
+            // returns null while the proxy's target is a dummy placeholder during recursive $ref
+            // resolution. Defer the attribute-collision check until the proxy is resolved — at
+            // that point the underlying property is guaranteed to be populated. For already-resolved
+            // properties (all Property/BaseProperty subclasses call $this->resolve() in their
+            // constructor) the closure is called immediately, preserving the existing behaviour.
+            $registerAttribute = function () use ($property): void {
+                $attribute = $property->getAttribute();
+
+                $existingRawName = $this->attributeIndex[$attribute] ?? null;
+                if ($existingRawName !== null && $existingRawName !== $property->getName()) {
+                    throw new SchemaException(
+                        sprintf(
+                            "Property names '%s' and '%s' both normalize to attribute '%s' in file %s",
+                            $existingRawName,
+                            $property->getName(),
+                            $attribute,
+                            $this->jsonSchema->getFile(),
+                        ),
+                    );
+                }
+
+                $this->attributeIndex[$attribute] = $property->getName();
+            };
+
+            $property->isResolved() ? $registerAttribute() : $property->onResolve($registerAttribute);
 
             $property->onResolve(function (): void {
                 if (++$this->resolvedProperties === count($this->properties)) {

--- a/tests/Objects/ReferencePropertyTest.php
+++ b/tests/Objects/ReferencePropertyTest.php
@@ -450,6 +450,181 @@ class ReferencePropertyTest extends AbstractPHPModelGeneratorTestCase
         new $className(['root' => 42]);
     }
 
+    // =========================================================================
+    // $defs keyword parity (Draft 2019-09)
+    // =========================================================================
+
+    public static function defsObjectReferenceProvider(): array
+    {
+        return [
+            // Internal path ref via $defs container
+            '$defs internal path ref' => ['#/$defs/person'],
+            // External $defs-only library file: no top-level type:object, so it becomes an
+            // ExternalSchema; the path ref navigates into its $defs section
+            '$defs external path ref (defs-only library)' => [
+                '../ReferencePropertyTest_external/defsLibrary.json#/$defs/person',
+            ],
+        ];
+    }
+
+    /**
+     * A property whose $ref targets a $defs entry (internal or external) must behave identically
+     * to one targeting a definitions entry: null when not provided, correct values when provided,
+     * and JsonPointer attributes reflecting /$defs/... path conventions.
+     *
+     * @throws FileSystemException
+     * @throws RenderException
+     * @throws SchemaException
+     */
+    #[DataProvider('defsObjectReferenceProvider')]
+    public function testDefsObjectRefPropertyBehavesCorrectly(string $reference): void
+    {
+        $className = $this->generateClassFromFileTemplate('DefsObjectReference.json', [$reference]);
+
+        // Not provided — optional property is null
+        $object = new $className([]);
+        $this->assertNull($object->getPerson());
+
+        // Valid: full object with all properties
+        $object = new $className(['person' => ['name' => 'Alice', 'age' => 30]]);
+        $this->assertSame('Alice', $object->getPerson()->getName());
+        $this->assertSame(30, $object->getPerson()->getAge());
+        $this->assertSame(['name' => 'Alice', 'age' => 30], $object->getPerson()->meta()->rawInput());
+
+        // Ref site pointer is always /properties/person regardless of where the definition lives
+        $this->assertPropertyHasJsonPointer($object, 'person', '/properties/person');
+        // Class pointer reflects /$defs/... for both internal and external $defs refs
+        $this->assertClassHasJsonPointer($object->getPerson(), '/$defs/person');
+        $this->assertPropertyHasJsonPointer($object->getPerson(), 'name', '/$defs/person/properties/name');
+    }
+
+    /**
+     * @throws FileSystemException
+     * @throws RenderException
+     * @throws SchemaException
+     */
+    #[DataProvider('defsObjectReferenceProvider')]
+    public function testDefsObjectRefInvalidTypeThrowsException(string $reference): void
+    {
+        $this->expectException(ValidationException::class);
+        $this->expectExceptionMessage('Invalid type for person. Requires object, got integer');
+
+        $className = $this->generateClassFromFileTemplate('DefsObjectReference.json', [$reference]);
+        new $className(['person' => 42]);
+    }
+
+    public static function defsRecursiveExternalReferenceProvider(): array
+    {
+        return [
+            // Direct-id recursion: $ref uses the $id anchor (#personDirect)
+            '$defs external path ref to direct recursion' => [
+                '../ReferencePropertyTest_external/defsRecursiveLibrary.json#/$defs/personDirect',
+            ],
+            '$defs external id ref to direct recursion' => [
+                '../ReferencePropertyTest_external/defsRecursiveLibrary.json#personDirect',
+            ],
+            // Path recursion: $ref uses the /$defs/personPath path; $id anchor also present
+            '$defs external path ref to path recursion' => [
+                '../ReferencePropertyTest_external/defsRecursiveLibrary.json#/$defs/personPath',
+            ],
+            '$defs external id ref to path recursion' => [
+                '../ReferencePropertyTest_external/defsRecursiveLibrary.json#personPath',
+            ],
+        ];
+    }
+
+    /**
+     * Recursive definitions under $defs with $id anchors must behave identically to equivalent
+     * recursive definitions under the definitions keyword.
+     *
+     * @throws FileSystemException
+     * @throws RenderException
+     * @throws SchemaException
+     */
+    #[DataProvider('defsRecursiveExternalReferenceProvider')]
+    public function testDefsExternalRecursiveRefWithIdAnchorBehavesCorrectly(string $reference): void
+    {
+        $className = $this->generateClassFromFileTemplate('RecursiveObjectReference.json', [$reference, $reference]);
+
+        // No children provided
+        $object = new $className(['person' => ['name' => 'Alice']]);
+        $this->assertSame('Alice', $object->getPerson()->getName());
+        $this->assertEmpty($object->getPerson()->getChildren());
+
+        // One level of recursion
+        $object = new $className([
+            'person' => [
+                'name' => 'Alice',
+                'children' => [
+                    ['name' => 'Bob', 'children' => []],
+                    ['name' => 'Carol'],
+                ],
+            ],
+        ]);
+        $this->assertSame('Alice', $object->getPerson()->getName());
+        $this->assertCount(2, $object->getPerson()->getChildren());
+        $this->assertSame('Bob', $object->getPerson()->getChildren()[0]->getName());
+        $this->assertSame('Carol', $object->getPerson()->getChildren()[1]->getName());
+    }
+
+    public static function defsBaseReferenceProvider(): array
+    {
+        return [
+            // Path ref into $defs
+            '$defs internal path ref' => ['#/$defs/person'],
+            // Id ref: $id anchor inside $defs is registered the same way as one inside definitions
+            '$defs internal id ref' => ['#person'],
+        ];
+    }
+
+    /**
+     * A root-level $ref targeting a $defs entry must merge the referenced object's properties
+     * into the generated class, identical to a definitions-based base reference.
+     *
+     * @throws FileSystemException
+     * @throws RenderException
+     * @throws SchemaException
+     */
+    #[DataProvider('defsBaseReferenceProvider')]
+    public function testDefsBaseReferenceGeneratesCorrectly(string $reference): void
+    {
+        $className = $this->generateClassFromFileTemplate('DefsBaseReference.json', [$reference]);
+
+        $object = new $className(['name' => 'Alice', 'age' => 30]);
+        $this->assertSame('Alice', $object->getName());
+        $this->assertSame(30, $object->getAge());
+        $this->assertSame(['name' => 'Alice', 'age' => 30], $object->meta()->rawInput());
+    }
+
+    /**
+     * A schema containing both definitions (Draft-07) and $defs (Draft 2019-09) must resolve
+     * refs from each container independently. Properties from definitions carry /definitions/...
+     * pointers; properties from $defs carry /$defs/... pointers.
+     *
+     * @throws FileSystemException
+     * @throws RenderException
+     * @throws SchemaException
+     */
+    public function testMixedDefsAndDefinitionsGeneratesCorrectly(): void
+    {
+        $className = $this->generateClassFromFile('MixedDefsAndDefinitions.json');
+
+        $object = new $className([
+            'contact' => ['name' => 'Alice'],
+            'user'    => ['email' => 'alice@example.com'],
+        ]);
+
+        $this->assertSame('Alice', $object->getContact()->getName());
+        $this->assertSame('alice@example.com', $object->getUser()->getEmail());
+
+        // Ref site pointers reflect where each $ref appears in the root schema
+        $this->assertPropertyHasJsonPointer($object, 'contact', '/properties/contact');
+        $this->assertPropertyHasJsonPointer($object, 'user', '/properties/user');
+        // Definition pointers reflect which container keyword was used
+        $this->assertClassHasJsonPointer($object->getContact(), '/definitions/legacyPerson');
+        $this->assertClassHasJsonPointer($object->getUser(), '/$defs/modernPerson');
+    }
+
     /**
      * @throws FileSystemException
      * @throws RenderException

--- a/tests/Objects/ReferencePropertyTest.php
+++ b/tests/Objects/ReferencePropertyTest.php
@@ -391,6 +391,65 @@ class ReferencePropertyTest extends AbstractPHPModelGeneratorTestCase
         );
     }
 
+    public static function recursivePathRefSchemaProvider(): array
+    {
+        return [
+            // definitions keyword (Draft-07): self-ref via path only, no $id anchor
+            'definitions keyword' => ['RecursivePathDefinitionsRef.json'],
+            // $defs keyword (Draft 2019-09): self-ref via path only, no $id anchor
+            '$defs keyword' => ['RecursivePathDefsRef.json'],
+        ];
+    }
+
+    /**
+     * A definition that refers to itself by path (no $id anchor) must be generated correctly.
+     * This covers both the definitions (Draft-07) and $defs (Draft 2019-09) container keywords.
+     *
+     * @throws FileSystemException
+     * @throws RenderException
+     * @throws SchemaException
+     */
+    #[DataProvider('recursivePathRefSchemaProvider')]
+    public function testRecursivePathRefGeneratesAndWorksCorrectly(string $schemaFile): void
+    {
+        $className = $this->generateClassFromFile($schemaFile);
+
+        // No root provided — optional property is null
+        $object = new $className([]);
+        $this->assertNull($object->getRoot());
+
+        // Flat usage: root present, no child
+        $object = new $className(['root' => ['value' => 'hello']]);
+        $this->assertSame('hello', $object->getRoot()->getValue());
+        $this->assertNull($object->getRoot()->getChild());
+
+        // Nested usage: one level of recursion
+        $object = new $className([
+            'root' => [
+                'value'  => 'parent',
+                'child'  => ['value' => 'child'],
+            ],
+        ]);
+        $this->assertSame('parent', $object->getRoot()->getValue());
+        $this->assertSame('child', $object->getRoot()->getChild()->getValue());
+        $this->assertNull($object->getRoot()->getChild()->getChild());
+    }
+
+    /**
+     * @throws FileSystemException
+     * @throws RenderException
+     * @throws SchemaException
+     */
+    #[DataProvider('recursivePathRefSchemaProvider')]
+    public function testRecursivePathRefWithInvalidTypeThrowsException(string $schemaFile): void
+    {
+        $this->expectException(ValidationException::class);
+        $this->expectExceptionMessage('Invalid type for root. Requires object, got integer');
+
+        $className = $this->generateClassFromFile($schemaFile);
+        new $className(['root' => 42]);
+    }
+
     /**
      * @throws FileSystemException
      * @throws RenderException

--- a/tests/Schema/ReferencePropertyTest/DefsBaseReference.json
+++ b/tests/Schema/ReferencePropertyTest/DefsBaseReference.json
@@ -1,0 +1,18 @@
+{
+  "$schema": "https://json-schema.org/draft/2019-09/schema",
+  "$defs": {
+    "person": {
+      "$id": "#person",
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "age": {
+          "type": "integer"
+        }
+      }
+    }
+  },
+  "$ref": "%s"
+}

--- a/tests/Schema/ReferencePropertyTest/DefsObjectReference.json
+++ b/tests/Schema/ReferencePropertyTest/DefsObjectReference.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "https://json-schema.org/draft/2019-09/schema",
+  "$defs": {
+    "person": {
+      "$id": "#person",
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "age": {
+          "type": "integer"
+        }
+      }
+    }
+  },
+  "type": "object",
+  "properties": {
+    "person": {
+      "$ref": "%s"
+    }
+  }
+}

--- a/tests/Schema/ReferencePropertyTest/MixedDefsAndDefinitions.json
+++ b/tests/Schema/ReferencePropertyTest/MixedDefsAndDefinitions.json
@@ -1,0 +1,31 @@
+{
+  "definitions": {
+    "legacyPerson": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string"
+        }
+      }
+    }
+  },
+  "$defs": {
+    "modernPerson": {
+      "type": "object",
+      "properties": {
+        "email": {
+          "type": "string"
+        }
+      }
+    }
+  },
+  "type": "object",
+  "properties": {
+    "contact": {
+      "$ref": "#/definitions/legacyPerson"
+    },
+    "user": {
+      "$ref": "#/$defs/modernPerson"
+    }
+  }
+}

--- a/tests/Schema/ReferencePropertyTest/RecursivePathDefinitionsRef.json
+++ b/tests/Schema/ReferencePropertyTest/RecursivePathDefinitionsRef.json
@@ -1,0 +1,21 @@
+{
+  "definitions": {
+    "node": {
+      "type": "object",
+      "properties": {
+        "value": {
+          "type": "string"
+        },
+        "child": {
+          "$ref": "#/definitions/node"
+        }
+      }
+    }
+  },
+  "type": "object",
+  "properties": {
+    "root": {
+      "$ref": "#/definitions/node"
+    }
+  }
+}

--- a/tests/Schema/ReferencePropertyTest/RecursivePathDefsRef.json
+++ b/tests/Schema/ReferencePropertyTest/RecursivePathDefsRef.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "https://json-schema.org/draft/2019-09/schema",
+  "$defs": {
+    "node": {
+      "type": "object",
+      "properties": {
+        "value": {
+          "type": "string"
+        },
+        "child": {
+          "$ref": "#/$defs/node"
+        }
+      }
+    }
+  },
+  "type": "object",
+  "properties": {
+    "root": {
+      "$ref": "#/$defs/node"
+    }
+  }
+}

--- a/tests/Schema/ReferencePropertyTest_external/defsLibrary.json
+++ b/tests/Schema/ReferencePropertyTest_external/defsLibrary.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "https://json-schema.org/draft/2019-09/schema",
+  "$defs": {
+    "person": {
+      "$id": "#person",
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "age": {
+          "type": "integer"
+        }
+      }
+    }
+  }
+}

--- a/tests/Schema/ReferencePropertyTest_external/defsRecursiveLibrary.json
+++ b/tests/Schema/ReferencePropertyTest_external/defsRecursiveLibrary.json
@@ -1,0 +1,35 @@
+{
+  "$schema": "https://json-schema.org/draft/2019-09/schema",
+  "$defs": {
+    "personDirect": {
+      "$id": "#personDirect",
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "children": {
+          "type": "array",
+          "items": {
+            "$ref": "#personDirect"
+          }
+        }
+      }
+    },
+    "personPath": {
+      "$id": "#personPath",
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "children": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/personPath"
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- Fixes a crash when a recursive `$ref` uses a pure JSON Pointer path (e.g. `#/definitions/node` or `#/$defs/node`) to refer back to the containing definition. `Schema::addProperty()` was calling `getAttribute()` eagerly on an unresolved `PropertyProxy`, causing a `TypeError`. The fix defers the attribute-collision check via `onResolve` so it runs only once the proxy resolves.
- Adds test coverage confirming `$defs` (Draft 2019-09) works end-to-end: object refs, base refs, external recursive refs, and schemas that mix `definitions` and `$defs` in the same file.
- Updates `docs/source/generic/references.rst` to document `$defs` alongside `definitions` in all relevant sections.

## Details

`$defs` already resolved correctly through the generic `SchemaDefinitionDictionary` pointer mechanism — no code changes were needed for `$defs` itself. The only source change is the `addProperty` deferred-closure fix.

## Test plan

- [ ] `php -d memory_limit=128M ./vendor/bin/phpunit --no-coverage` — full suite passes
- [ ] `./vendor/bin/phpcs --standard=phpcs.xml src/Model/Schema.php` — no new violations
- [ ] Confirm `testRecursivePathRefGeneratesAndWorksCorrectly` covers both `definitions` and `$defs` schema variants
- [ ] Confirm `testDefsObjectRefPropertyBehavesCorrectly`, `testDefsExternalRecursiveRefWithIdAnchorBehavesCorrectly`, `testDefsBaseReferenceGeneratesCorrectly`, and `testMixedDefsAndDefinitionsGeneratesCorrectly` all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)