### PR TITLE
feat: improve nested class naming with $anchor, property, and array-item levels

### DIFF
--- a/docs/source/complexTypes/object.rst
+++ b/docs/source/complexTypes/object.rst
@@ -127,8 +127,8 @@ For the class name of a nested class the following priority order applies:
 
     Set ``title``, ``$id``, or ``$anchor`` on nested schemas, or use named
     ``definitions``/``$defs`` entries, to get the most explicit and predictable class names.
-    Schemas with large ``definitions`` blocks that lack these keywords (e.g. the Atlassian
-    Document Format schema) will automatically receive names derived from their definition key.
+    Schemas with large ``definitions`` blocks that lack these keywords will automatically
+    receive names derived from their definition key.
 
     For full control over class naming, implement ``ClassNameGeneratorInterface`` and pass it
     to the generator configuration via

--- a/docs/source/complexTypes/object.rst
+++ b/docs/source/complexTypes/object.rst
@@ -99,9 +99,40 @@ Otherwise, if an `$id` is present, the basename of the $id and as a last fallbac
 Naming of nested classes
 ^^^^^^^^^^^^^^^^^^^^^^^^
 
-For the class name of a nested class the `title` property (fallback to `$id`) of the nested object is used.
-If neither the title nor the $id property is present the property key will be prefixed with the parent class.
-If an object `Person` has a nested object `car` without a `title` and an `$id` the class for car will be named **Person_Car**.
+For the class name of a nested class the following priority order applies:
+
+1. **title** — used as-is if present on the nested schema.
+2. **$id** — the basename of the ``$id`` URI is used if present.
+3. **$anchor** — the ``$anchor`` value is used if present (Draft 2019-09 and later). ``$anchor``
+   is a plain-string identifier with the same intent as ``$id`` but without URI semantics.
+4. **Definition key** — when the nested schema is referenced from a named ``definitions`` or
+   ``$defs`` slot (e.g. ``$ref: "#/definitions/address"``), the definition key is used
+   (e.g. ``address``). This produces stable, readable names even for schemas that carry no
+   ``title``, ``$id``, or ``$anchor``.
+5. **Inline property name** — when the schema is defined inline directly under a ``properties``
+   keyword, the property key is used without a content hash. Property keys are unique within
+   their containing object, so the combination of parent class name and property key is
+   already collision-free. For example, an inline ``car`` object inside ``Person`` becomes
+   **Person_Car**.
+6. **Array items** — when the schema is the ``items`` of a named array property, the array
+   property name is extracted and ``Item`` is appended, making it clear that the class
+   represents one element of the array rather than the array itself. For example, the items
+   of a ``tags`` array property become **{Parent}_TagsItem**.
+7. **Property name + content hash** — final fallback for schemas that do not match any of the
+   above (e.g. inline schemas inside composition branches like ``anyOf``/``oneOf``). The
+   property key is prefixed with the parent class name and a short content hash is appended
+   to avoid collisions between branches that share the same property name.
+
+.. hint::
+
+    Set ``title``, ``$id``, or ``$anchor`` on nested schemas, or use named
+    ``definitions``/``$defs`` entries, to get the most explicit and predictable class names.
+    Schemas with large ``definitions`` blocks that lack these keywords (e.g. the Atlassian
+    Document Format schema) will automatically receive names derived from their definition key.
+
+    For full control over class naming, implement ``ClassNameGeneratorInterface`` and pass it
+    to the generator configuration via
+    `setClassNameGenerator() <../gettingStarted.html#class-name-generator>`__.
 
 Property Name Normalization
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/docs/source/gettingStarted.rst
+++ b/docs/source/gettingStarted.rst
@@ -415,6 +415,21 @@ Draft class   Description
 
     :doc:`generator/custom/customDraft` — how to implement a custom draft or modifier.
 
+Class name generator
+^^^^^^^^^^^^^^^^^^^^
+
+.. code-block:: php
+
+    setClassNameGenerator(ClassNameGeneratorInterface $classNameGenerator);
+
+Replace the built-in class naming strategy with a custom implementation. The generator calls
+``getClassName()`` on the provided object for every nested class it creates. This gives you
+complete control over naming: you can derive names from external sources, enforce project
+conventions, strip prefixes, and so on.
+
+See `Naming of nested classes <complexTypes/object.html#naming-of-nested-classes>`__ for a
+description of the built-in priority order.
+
 Custom filter
 ^^^^^^^^^^^^^
 

--- a/src/Utils/ClassNameGenerator.php
+++ b/src/Utils/ClassNameGenerator.php
@@ -6,11 +6,6 @@ namespace PHPModelGenerator\Utils;
 
 use PHPModelGenerator\Model\SchemaDefinition\JsonSchema;
 
-/**
- * Class ClassNameGenerator
- *
- * @package PHPModelGenerator\Utils
- */
 class ClassNameGenerator implements ClassNameGeneratorInterface
 {
     /**
@@ -22,20 +17,98 @@ class ClassNameGenerator implements ClassNameGeneratorInterface
         bool $isMergeClass,
         string $currentClassName = '',
     ): string {
-        $json = $isMergeClass && isset($schema->getJson()['propertySchema'])
-            ? $schema->getJson()['propertySchema']->getJson()
-            : $schema->getJson();
+        $innerSchema = $isMergeClass && isset($schema->getJson()['propertySchema'])
+            ? $schema->getJson()['propertySchema']
+            : $schema;
+
+        $json               = $innerSchema->getJson();
+        $pointer            = $innerSchema->getPointer();
+        $definitionName     = $this->extractDefinitionName($pointer);
+        $inlinePropertyName = $this->extractInlinePropertyName($pointer);
+        $arrayItemBaseName  = $this->extractArrayItemBaseName($pointer);
 
         $className = sprintf(
             $isMergeClass ? '%s_Merged_%s' : '%s_%s',
             $currentClassName,
             ucfirst((string) match (true) {
-                isset($json['title']) => $json['title'],
-                isset($json['$id']) => basename((string) $json['$id']),
-                default => ($propertyName . ($currentClassName ? md5(json_encode($json)) : '')),
+                isset($json['title'])        => $json['title'],
+                isset($json['$id'])          => basename((string) $json['$id']),
+                isset($json['$anchor'])      => $json['$anchor'],
+                $definitionName !== null     => $definitionName,
+                $inlinePropertyName !== null => $inlinePropertyName,
+                $arrayItemBaseName !== null  => $arrayItemBaseName . 'Item',
+                default                      => ($propertyName . ($currentClassName ? md5(json_encode($json)) : '')),
             }),
         );
 
         return ucfirst((string) preg_replace('/\W/', '', ucwords(trim($className, '_'), '_-. ')));
+    }
+
+    /**
+     * Extract a class name from a JSON pointer when the schema lives at a named definition slot
+     * (i.e. the pointer's second-to-last segment is "definitions" or "$defs"). Returns null for
+     * every other path — inline schemas, array indices, and composition branch positions — so the
+     * caller falls through to subsequent naming levels.
+     */
+    private function extractDefinitionName(string $pointer): ?string
+    {
+        $segments = array_values(array_filter(explode('/', $pointer)));
+        $count    = count($segments);
+
+        if (
+            $count >= 2 &&
+            in_array($segments[$count - 2], ['definitions', '$defs'], true) &&
+            !is_numeric($segments[$count - 1])
+        ) {
+            return $segments[$count - 1];
+        }
+
+        return null;
+    }
+
+    /**
+     * Extract a class name from a JSON pointer when the schema is an inline object inside a
+     * "properties" slot (i.e. the pointer's second-to-last segment is "properties"). Returns the
+     * property key without appending a content hash: within a single object, property keys are
+     * unique, so the combination of parent class name and property key is already collision-free.
+     * Returns null for any other pointer shape.
+     */
+    private function extractInlinePropertyName(string $pointer): ?string
+    {
+        $segments = array_values(array_filter(explode('/', $pointer)));
+        $count    = count($segments);
+
+        if (
+            $count >= 2 &&
+            $segments[$count - 2] === 'properties' &&
+            !is_numeric($segments[$count - 1])
+        ) {
+            return $segments[$count - 1];
+        }
+
+        return null;
+    }
+
+    /**
+     * Extract the base name for an array-items schema from its JSON pointer. When the last pointer
+     * segment is "items" and the preceding segment is a non-numeric identifier (i.e. the array
+     * lives in a named property or definition, not inside a composition branch index), returns that
+     * identifier so the caller can append "Item". Returns null for tuple items (numeric predecessor)
+     * and any other pointer shape that does not end in "items".
+     */
+    private function extractArrayItemBaseName(string $pointer): ?string
+    {
+        $segments = array_values(array_filter(explode('/', $pointer)));
+        $count    = count($segments);
+
+        if (
+            $count >= 2 &&
+            $segments[$count - 1] === 'items' &&
+            !is_numeric($segments[$count - 2])
+        ) {
+            return $segments[$count - 2];
+        }
+
+        return null;
     }
 }

--- a/tests/Basic/ClassNameGeneratorTest.php
+++ b/tests/Basic/ClassNameGeneratorTest.php
@@ -1,0 +1,86 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PHPModelGenerator\Tests\Basic;
+
+use PHPModelGenerator\Model\GeneratorConfiguration;
+use PHPModelGenerator\Tests\AbstractPHPModelGeneratorTestCase;
+
+class ClassNameGeneratorTest extends AbstractPHPModelGeneratorTestCase
+{
+    /**
+     * All six named naming levels are exercised in a single generation run:
+     *
+     *  1. title      — "labeled" definition carries title "PostalAddress"; title wins.
+     *  2. $id        — not exercised here (covered by existing object tests).
+     *  3. $anchor    — "anchored" carries $anchor "AnchoredContent"; wins over pointer fallbacks.
+     *  4. Definition — "address" and "contact_info" have no title/$id/$anchor; definition key used.
+     *  5. Inline     — "location" is an inline object under "properties"; key used, no hash suffix.
+     *  6. Array item — "tags" items schema sits at /properties/tags/items; "tags" + "Item" suffix.
+     */
+    public function testNamingLevels(): void
+    {
+        $this->generateDirectory(
+            'NamingLevels',
+            (new GeneratorConfiguration())
+                ->setNamespacePrefix('ClassNameGeneratorTest')
+                ->setOutputEnabled(false),
+        );
+
+        $rootFqcn        = 'ClassNameGeneratorTest\NamingLevels';
+        $addressFqcn     = 'ClassNameGeneratorTest\NamingLevels_Address';
+        $postalFqcn      = 'ClassNameGeneratorTest\NamingLevels_PostalAddress';
+        $contactInfoFqcn = 'ClassNameGeneratorTest\NamingLevels_Contact_Info';
+        $anchoredFqcn    = 'ClassNameGeneratorTest\NamingLevels_AnchoredContent';
+        $locationFqcn    = 'ClassNameGeneratorTest\NamingLevels_Location';
+        $tagItemFqcn     = 'ClassNameGeneratorTest\NamingLevels_TagsItem';
+
+        $object = new $rootFqcn([
+            'home'     => ['street' => 'Main St'],
+            'office'   => ['street' => 'Work Rd'],
+            'postal'   => ['zip' => '12345'],
+            'contact'  => ['email' => 'test@example.com'],
+            'anchored' => ['text' => 'hello'],
+            'location' => ['city' => 'Berlin'],
+            'tags'     => [['id' => 1, 'name' => 'php']],
+        ]);
+
+        // Level 4: definition key "address" used when no title/$id/$anchor
+        $this->assertSame($addressFqcn, $object->getHome()::class);
+
+        // Two properties referencing the same definition resolve to the same class
+        $this->assertSame($object->getHome()::class, $object->getOffice()::class);
+
+        // Level 1: title "PostalAddress" wins over the definition key "labeled"
+        $this->assertSame($postalFqcn, $object->getPostal()::class);
+
+        // Level 4: snake_case definition key "contact_info" preserved as Contact_Info
+        $this->assertSame($contactInfoFqcn, $object->getContact()::class);
+
+        // Level 3: $anchor "AnchoredContent" wins over the inline-property fallback
+        $this->assertSame($anchoredFqcn, $object->getAnchored()::class);
+
+        // Level 5: inline property key used without a hash suffix
+        $this->assertSame($locationFqcn, $object->getLocation()::class);
+
+        // Level 6: array property name "tags" + "Item" suffix, no hash
+        $tags = $object->getTags();
+        $this->assertSame($tagItemFqcn, $tags[0]::class);
+
+        // None of the named levels should produce a hex content hash
+        foreach ([$addressFqcn, $postalFqcn, $contactInfoFqcn, $anchoredFqcn, $locationFqcn, $tagItemFqcn] as $fqcn) {
+            $this->assertDoesNotMatchRegularExpression('/[0-9a-f]{13}/', $fqcn);
+        }
+
+        // Functional assertions
+        $this->assertSame('Main St', $object->getHome()->getStreet());
+        $this->assertSame('Work Rd', $object->getOffice()->getStreet());
+        $this->assertSame('12345', $object->getPostal()->getZip());
+        $this->assertSame('test@example.com', $object->getContact()->getEmail());
+        $this->assertSame('hello', $object->getAnchored()->getText());
+        $this->assertSame('Berlin', $object->getLocation()->getCity());
+        $this->assertSame(1, $tags[0]->getId());
+        $this->assertSame('php', $tags[0]->getName());
+    }
+}

--- a/tests/ComposedValue/ComposedAnyOfTest.php
+++ b/tests/ComposedValue/ComposedAnyOfTest.php
@@ -216,7 +216,7 @@ class ComposedAnyOfTest extends AbstractPHPModelGeneratorTestCase
             ],
             'Object with scalar type (no merged property - redirect to generated object)' => [
                 'ReferencedObjectSchema.json',
-                '/^string\|ComposedAnyOfTest[\w]*Property[\w]*\|null$/',
+                '/^string\|ComposedAnyOfTest[\w]*Person[\w]*\|null$/',
                 2,
             ],
             'Multiple objects (merged property created)' => [

--- a/tests/PostProcessor/BuilderClassPostProcessorTest.php
+++ b/tests/PostProcessor/BuilderClassPostProcessorTest.php
@@ -198,10 +198,16 @@ class BuilderClassPostProcessorTest extends AbstractPHPModelGeneratorTestCase
         $addressBuilderObject = new $addressBuilderClassName();
         $this->assertSame('string|null', $this->getParameterTypeAnnotation($addressBuilderObject, 'setStreet'));
         $this->assertSame('int|null', $this->getParameterTypeAnnotation($addressBuilderObject, 'setNumber'));
-        $this->assertSame('Address_Building|Address_BuildingBuilder|array|null', $this->getParameterTypeAnnotation($addressBuilderObject, 'setBuilding'));
+        $this->assertSame(
+            'Address_Building|Address_BuildingBuilder|array|null',
+            $this->getParameterTypeAnnotation($addressBuilderObject, 'setBuilding'),
+        );
         $this->assertSame('string|null', $this->getReturnTypeAnnotation($addressBuilderObject, 'getStreet'));
         $this->assertSame('int|null', $this->getReturnTypeAnnotation($addressBuilderObject, 'getNumber'));
-        $this->assertSame('Address_Building|Address_BuildingBuilder|array|null', $this->getReturnTypeAnnotation($addressBuilderObject, 'getBuilding'));
+        $this->assertSame(
+            'Address_Building|Address_BuildingBuilder|array|null',
+            $this->getReturnTypeAnnotation($addressBuilderObject, 'getBuilding'),
+        );
 
         $buildingBuilderClassName = 'MyApp\Namespace\Dependencies\Address_BuildingBuilder';
         $buildingBuilderObject = new $buildingBuilderClassName();
@@ -254,7 +260,7 @@ class BuilderClassPostProcessorTest extends AbstractPHPModelGeneratorTestCase
 
         $nestedObjectClassName = null;
         foreach ($this->getGeneratedFiles() as $file) {
-            if (str_contains((string) $file, 'ItemOfArray')) {
+            if (str_contains((string) $file, 'AddressListItem')) {
                 $nestedObjectClassName = str_replace('.php', '', basename((string) $file));
 
                 break;

--- a/tests/Schema/ClassNameGeneratorTest/NamingLevels/NamingLevels.json
+++ b/tests/Schema/ClassNameGeneratorTest/NamingLevels/NamingLevels.json
@@ -1,0 +1,75 @@
+{
+  "type": "object",
+  "definitions": {
+    "address": {
+      "type": "object",
+      "properties": {
+        "street": {
+          "type": "string"
+        }
+      }
+    },
+    "labeled": {
+      "title": "PostalAddress",
+      "type": "object",
+      "properties": {
+        "zip": {
+          "type": "string"
+        }
+      }
+    },
+    "contact_info": {
+      "type": "object",
+      "properties": {
+        "email": {
+          "type": "string"
+        }
+      }
+    }
+  },
+  "properties": {
+    "home": {
+      "$ref": "#/definitions/address"
+    },
+    "office": {
+      "$ref": "#/definitions/address"
+    },
+    "postal": {
+      "$ref": "#/definitions/labeled"
+    },
+    "contact": {
+      "$ref": "#/definitions/contact_info"
+    },
+    "anchored": {
+      "$anchor": "AnchoredContent",
+      "type": "object",
+      "properties": {
+        "text": {
+          "type": "string"
+        }
+      }
+    },
+    "location": {
+      "type": "object",
+      "properties": {
+        "city": {
+          "type": "string"
+        }
+      }
+    },
+    "tags": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer"
+          },
+          "name": {
+            "type": "string"
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- Adds `$anchor` (Draft 2019-09+) as a third naming source, parallel to `title` and `$id`
- Inline object properties under a `properties` keyword now use the property key without a content hash — the key is already unique within its containing object
- Array `items` schemas derive their name from the array property name with an `Item` suffix (e.g. a `tags` array → `TagsItem` class), instead of the unreadable `Itemofarraytags{hash}` fallback
- The hash fallback is now only reached by truly anonymous schemas (e.g. inline branches inside `anyOf`/`oneOf`)

Closes #158 (ADF schema generating hash-based class names).

## Priority order after this change

| # | Source | Example |
|---|---|---|
| 1 | `title` | `title: Person` → `Person` |
| 2 | `$id` | `$id: /types/person` → `Person` |
| 3 | `$anchor` *(new)* | `$anchor: PersonData` → `PersonData` |
| 4 | Definition key | `$ref: #/definitions/address` → `Address` |
| 5 | Inline property key *(new, no hash)* | inline `car` object → `Parent_Car` |
| 6 | Array items *(new)* | `tags[].items` → `Parent_TagsItem` |
| 7 | Property name + hash | anonymous composition branch fallback |

## Test plan

- [ ] `tests/Basic/ClassNameGeneratorTest::testNamingLevels` — single test covering all six named levels in one generation pass
- [ ] `tests/PostProcessor/BuilderClassPostProcessorTest::testNestedObjectArray` — updated to match new `AddressListItem` class name
- [ ] `tests/ComposedValue/ComposedAnyOfTest` — regex updated to match `Person` (definition key) instead of `Property` (call-site name)
- [ ] Full suite: 2757 tests, all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)