### PR TITLE
Add JSON Pointer (RFC 6901) stamping on all ValidationExceptions

### DIFF
--- a/docs/source/combinedSchemas/allOf.rst
+++ b/docs/source/combinedSchemas/allOf.rst
@@ -67,6 +67,8 @@ The thrown exception will be a *PHPModelGenerator\\Exception\\ComposedValue\\All
     public function getPropertyName(): string
     // get the value provided to the property
     public function getProvidedValue()
+    // get the JSON pointer to the schema keyword that rejected the value
+    public function getJsonPointer(): JsonPointer
 
 .. hint::
 

--- a/docs/source/combinedSchemas/anyOf.rst
+++ b/docs/source/combinedSchemas/anyOf.rst
@@ -57,6 +57,8 @@ The thrown exception will be a *PHPModelGenerator\\Exception\\ComposedValue\\Any
     public function getPropertyName(): string
     // get the value provided to the property
     public function getProvidedValue()
+    // get the JSON pointer to the schema keyword that rejected the value
+    public function getJsonPointer(): JsonPointer
 
 .. note::
 

--- a/docs/source/combinedSchemas/if.rst
+++ b/docs/source/combinedSchemas/if.rst
@@ -69,6 +69,8 @@ The thrown exception will be a *PHPModelGenerator\\Exception\\ComposedValue\\Con
     public function getPropertyName(): string
     // get the value provided to the property
     public function getProvidedValue()
+    // get the JSON pointer to the schema keyword that rejected the value
+    public function getJsonPointer(): JsonPointer
 
 An object level composition will result in an object which contains all properties contained in the three possible blocks of the condition.
 

--- a/docs/source/combinedSchemas/not.rst
+++ b/docs/source/combinedSchemas/not.rst
@@ -45,6 +45,8 @@ The thrown exception will be a *PHPModelGenerator\\Exception\\ComposedValue\\Not
     public function getPropertyName(): string
     // get the value provided to the property
     public function getProvidedValue()
+    // get the JSON pointer to the schema keyword that rejected the value
+    public function getJsonPointer(): JsonPointer
 
 .. note::
 

--- a/docs/source/combinedSchemas/oneOf.rst
+++ b/docs/source/combinedSchemas/oneOf.rst
@@ -67,6 +67,8 @@ The thrown exception will be a *PHPModelGenerator\\Exception\\ComposedValue\\One
     public function getPropertyName(): string
     // get the value provided to the property
     public function getProvidedValue()
+    // get the JSON pointer to the schema keyword that rejected the value
+    public function getJsonPointer(): JsonPointer
 
 .. note::
 

--- a/docs/source/complexTypes/array.rst
+++ b/docs/source/complexTypes/array.rst
@@ -42,6 +42,8 @@ The thrown exception will be a *PHPModelGenerator\\Exception\\Generic\\InvalidTy
     public function getPropertyName(): string
     // get the value provided to the property
     public function getProvidedValue()
+    // get the JSON pointer to the schema keyword that rejected the value
+    public function getJsonPointer(): JsonPointer
 
 Items
 ^^^^^
@@ -82,6 +84,8 @@ The thrown exception will be a *PHPModelGenerator\\Exception\\Arrays\\InvalidIte
     public function getPropertyName(): string
     // get the value provided to the property
     public function getProvidedValue()
+    // get the JSON pointer to the schema keyword that rejected the value
+    public function getJsonPointer(): JsonPointer
 
 A more complex array may contain a nested object.
 
@@ -204,6 +208,8 @@ The thrown exception will be a *PHPModelGenerator\\Exception\\Arrays\\InvalidTup
     public function getPropertyName(): string
     // get the value provided to the property
     public function getProvidedValue()
+    // get the JSON pointer to the schema keyword that rejected the value
+    public function getJsonPointer(): JsonPointer
 
 .. hint::
 
@@ -259,6 +265,8 @@ The thrown exception will be a *PHPModelGenerator\\Exception\\Arrays\\Additional
     public function getPropertyName(): string
     // get the value provided to the property
     public function getProvidedValue()
+    // get the JSON pointer to the schema keyword that rejected the value
+    public function getJsonPointer(): JsonPointer
 
 If invalid additional items are provided a detailed exception will be thrown containing all violations:
 
@@ -280,6 +288,8 @@ The thrown exception will be a *PHPModelGenerator\\Exception\\Arrays\\InvalidAdd
     public function getPropertyName(): string
     // get the value provided to the property
     public function getProvidedValue()
+    // get the JSON pointer to the schema keyword that rejected the value
+    public function getJsonPointer(): JsonPointer
 
 Contains
 --------
@@ -313,6 +323,8 @@ The thrown exception will be a *PHPModelGenerator\\Exception\\Arrays\\ContainsEx
     public function getPropertyName(): string
     // get the value provided to the property
     public function getProvidedValue()
+    // get the JSON pointer to the schema keyword that rejected the value
+    public function getJsonPointer(): JsonPointer
 
 The ``contains`` keyword also accepts the boolean literals ``true`` and ``false``.
 
@@ -358,6 +370,8 @@ The thrown exception will be a *PHPModelGenerator\\Exception\\Arrays\\MaxItemsEx
     public function getPropertyName(): string
     // get the value provided to the property
     public function getProvidedValue()
+    // get the JSON pointer to the schema keyword that rejected the value
+    public function getJsonPointer(): JsonPointer
 
 Uniqueness
 ----------
@@ -389,3 +403,5 @@ The thrown exception will be an *PHPModelGenerator\\Exception\\Arrays\\UniqueIte
     public function getPropertyName(): string
     // get the value provided to the property
     public function getProvidedValue()
+    // get the JSON pointer to the schema keyword that rejected the value
+    public function getJsonPointer(): JsonPointer

--- a/docs/source/complexTypes/enum.rst
+++ b/docs/source/complexTypes/enum.rst
@@ -70,3 +70,5 @@ The thrown exception will be an *PHPModelGenerator\\Exception\\Generic\\EnumExce
     public function getPropertyName(): string
     // get the value provided to the property
     public function getProvidedValue()
+    // get the JSON pointer to the schema keyword that rejected the value
+    public function getJsonPointer(): JsonPointer

--- a/docs/source/complexTypes/multiType.rst
+++ b/docs/source/complexTypes/multiType.rst
@@ -37,6 +37,8 @@ The thrown exception will be a *PHPModelGenerator\\Exception\\Generic\\InvalidTy
     public function getPropertyName(): string
     // get the value provided to the property
     public function getProvidedValue()
+    // get the JSON pointer to the schema keyword that rejected the value
+    public function getJsonPointer(): JsonPointer
 
 Additional validators
 ---------------------

--- a/docs/source/complexTypes/object.rst
+++ b/docs/source/complexTypes/object.rst
@@ -63,6 +63,8 @@ The thrown exception will be a *PHPModelGenerator\\Exception\\Generic\\InvalidTy
     public function getPropertyName(): string
     // get the value provided to the property
     public function getProvidedValue()
+    // get the JSON pointer to the schema keyword that rejected the value
+    public function getJsonPointer(): JsonPointer
 
 The nested object will be validated in the nested class Car which may throw additional exceptions if invalid data is provided. If the internal validation of a nested object fails a *PHPModelGenerator\\Exception\\Generic\\NestedObjectException* will be thrown which provides the following methods to get further error details:
 
@@ -74,6 +76,8 @@ The nested object will be validated in the nested class Car which may throw addi
     public function getPropertyName(): string
     // get the value provided to the property
     public function getProvidedValue()
+    // get the JSON pointer to the schema keyword that rejected the value
+    public function getJsonPointer(): JsonPointer
 
 If `error collection <../gettingStarted.html#collect-errors-vs-early-return>`__ is enabled the nested exception returned by `getNestedException` will be an **ErrorRegistryException** containing all validation errors of the nested object. Otherwise it will contain the first validation error which occurred during the validation of the nested object.
 
@@ -231,6 +235,8 @@ The thrown exception will be a *PHPModelGenerator\\Exception\\Object\\MaxPropert
     public function getPropertyName(): string
     // get the value provided to the property
     public function getProvidedValue()
+    // get the JSON pointer to the schema keyword that rejected the value
+    public function getJsonPointer(): JsonPointer
 
 Additional Properties
 ---------------------
@@ -278,6 +284,8 @@ The thrown exception will be a *PHPModelGenerator\\Exception\\Object\\Additional
     public function getPropertyName(): string
     // get the value provided to the property
     public function getProvidedValue()
+    // get the JSON pointer to the schema keyword that rejected the value
+    public function getJsonPointer(): JsonPointer
 
 If invalid additional properties are provided a detailed exception will be thrown containing all violations:
 
@@ -299,6 +307,8 @@ The thrown exception will be a *PHPModelGenerator\\Exception\\Object\\InvalidAdd
     public function getPropertyName(): string
     // get the value provided to the property
     public function getProvidedValue()
+    // get the JSON pointer to the schema keyword that rejected the value
+    public function getJsonPointer(): JsonPointer
 
 .. warning::
 
@@ -395,6 +405,8 @@ The thrown exception will be a *PHPModelGenerator\\Exception\\Object\\InvalidPro
     public function getPropertyName(): string
     // get the value provided to the property
     public function getProvidedValue()
+    // get the JSON pointer to the schema keyword that rejected the value
+    public function getJsonPointer(): JsonPointer
 
 Dependencies
 ------------
@@ -444,6 +456,8 @@ The thrown exception will be a *PHPModelGenerator\\Exception\\Dependency\\Invali
     public function getPropertyName(): string
     // get the value provided to the property
     public function getProvidedValue()
+    // get the JSON pointer to the schema keyword that rejected the value
+    public function getJsonPointer(): JsonPointer
 
 As stated above the dependency declaration is not bidirectional. If the presence of a billing_address shall also require the credit_card property to be required the dependency has to be declared separately:
 
@@ -541,6 +555,8 @@ The thrown exception will be a *PHPModelGenerator\\Exception\\Dependency\\Invali
     public function getPropertyName(): string
     // get the value provided to the property
     public function getProvidedValue()
+    // get the JSON pointer to the schema keyword that rejected the value
+    public function getJsonPointer(): JsonPointer
 
 Multiple violations against the schema dependency may be included.
 
@@ -592,6 +608,8 @@ The thrown exception will be a *PHPModelGenerator\\Exception\\Object\\InvalidPat
     public function getPropertyName(): string
     // get the value provided to the property
     public function getProvidedValue()
+    // get the JSON pointer to the schema keyword that rejected the value
+    public function getJsonPointer(): JsonPointer
 
 .. note::
 

--- a/docs/source/generic/combinedException.rst
+++ b/docs/source/generic/combinedException.rst
@@ -88,3 +88,10 @@ The exception which will be thrown (combined array-exception and combined-schema
             * Missing required value for name
             * Invalid type for name. Requires string, got NULL
           - Composition element #2: Valid
+
+.. seealso::
+
+    Each leaf ``ValidationException`` inside a combined exception also exposes a JSON pointer to the
+    schema keyword that rejected the value. See
+    `Collect errors vs. early return <../gettingStarted.html#collect-errors-vs-early-return>`__
+    for details on ``getJsonPointer()``.

--- a/docs/source/generic/required.rst
+++ b/docs/source/generic/required.rst
@@ -78,6 +78,8 @@ The thrown exception will be an *PHPModelGenerator\\Exception\\Object\\RequiredV
     public function getPropertyName(): string
     // get the value provided to the property
     public function getProvidedValue()
+    // get the JSON pointer to the schema keyword that rejected the value
+    public function getJsonPointer(): JsonPointer
 
 Behaviour with different inputs:
 

--- a/docs/source/gettingStarted.rst
+++ b/docs/source/gettingStarted.rst
@@ -231,6 +231,27 @@ The exceptions are implemented in the php-json-schema-model-generator-production
 
 All collected exceptions from an ErrorRegistryException are accessible via the *getErrors* method. The collected errors are the specific exceptions extending the **PHPModelGenerator\\Exception\\ValidationException** which would be thrown directly if error collection is disabled. Each exception provides various specific details about the validation violation.
 
+Every ``ValidationException`` carries a **JSON pointer** (see :rfc:`6901`) to the schema keyword
+that rejected the value:
+
+.. code-block:: php
+
+    public function getJsonPointer(): PHPModelGenerator\Attributes\JsonPointer;
+
+.. code-block:: php
+
+    try {
+        $person = new Person(['name' => 'Albert', 'age' => -1]);
+    } catch (\PHPModelGenerator\Exception\Number\MinimumException $e) {
+        $e->getPropertyName();          // 'age'
+        $e->getProvidedValue();         // -1
+        $e->getJsonPointer()->pointer;  // '/properties/age/minimum'
+    }
+
+The pointer identifies the **schema keyword** that rejected the value, not the data location. For
+object-level constraints such as ``minProperties`` the pointer is relative to the schema root
+(e.g. ``/minProperties``).
+
 .. code-block:: php
 
     (new GeneratorConfiguration())

--- a/docs/source/nonStandardExtensions/filter.rst
+++ b/docs/source/nonStandardExtensions/filter.rst
@@ -183,6 +183,8 @@ If the filter throws an exception during execution the exception will be caught 
     public function getPropertyName(): string
     // get the value provided to the property
     public function getProvidedValue()
+    // get the JSON pointer to the schema keyword that rejected the value
+    public function getJsonPointer(): JsonPointer
 
 Builtin filter
 --------------

--- a/docs/source/types/boolean.rst
+++ b/docs/source/types/boolean.rst
@@ -37,3 +37,5 @@ The thrown exception will be a *PHPModelGenerator\\Exception\\Generic\\InvalidTy
     public function getPropertyName(): string
     // get the value provided to the property
     public function getProvidedValue()
+    // get the JSON pointer to the schema keyword that rejected the value
+    public function getJsonPointer(): JsonPointer

--- a/docs/source/types/const.rst
+++ b/docs/source/types/const.rst
@@ -36,3 +36,5 @@ The thrown exception will be a *PHPModelGenerator\\Exception\\Generic\\InvalidCo
     public function getPropertyName(): string
     // get the value provided to the property
     public function getProvidedValue()
+    // get the JSON pointer to the schema keyword that rejected the value
+    public function getJsonPointer(): JsonPointer

--- a/docs/source/types/null.rst
+++ b/docs/source/types/null.rst
@@ -38,3 +38,5 @@ The thrown exception will be a *PHPModelGenerator\\Exception\\Generic\\InvalidTy
     public function getPropertyName(): string
     // get the value provided to the property
     public function getProvidedValue()
+    // get the JSON pointer to the schema keyword that rejected the value
+    public function getJsonPointer(): JsonPointer

--- a/docs/source/types/number.rst
+++ b/docs/source/types/number.rst
@@ -44,6 +44,8 @@ The thrown exception will be a *PHPModelGenerator\\Exception\\Generic\\InvalidTy
     public function getPropertyName(): string
     // get the value provided to the property
     public function getProvidedValue()
+    // get the JSON pointer to the schema keyword that rejected the value
+    public function getJsonPointer(): JsonPointer
 
 Range validation
 -----------------
@@ -91,6 +93,8 @@ Each exception additionally provides the following methods:
     public function getPropertyName(): string
     // get the value provided to the property
     public function getProvidedValue()
+    // get the JSON pointer to the schema keyword that rejected the value
+    public function getJsonPointer(): JsonPointer
 
 Multiple of validation
 ----------------------
@@ -128,3 +132,5 @@ The thrown exception will be a *PHPModelGenerator\\Exception\\Number\\MultipleOf
     public function getPropertyName(): string
     // get the value provided to the property
     public function getProvidedValue()
+    // get the JSON pointer to the schema keyword that rejected the value
+    public function getJsonPointer(): JsonPointer

--- a/docs/source/types/string.rst
+++ b/docs/source/types/string.rst
@@ -37,6 +37,8 @@ The thrown exception will be a *PHPModelGenerator\\Exception\\Generic\\InvalidTy
     public function getPropertyName(): string
     // get the value provided to the property
     public function getProvidedValue()
+    // get the JSON pointer to the schema keyword that rejected the value
+    public function getJsonPointer(): JsonPointer
 
 Length validation
 -----------------
@@ -74,6 +76,8 @@ The thrown exception will be a *PHPModelGenerator\\Exception\\String\\MinLengthE
     public function getPropertyName(): string
     // get the value provided to the property
     public function getProvidedValue()
+    // get the JSON pointer to the schema keyword that rejected the value
+    public function getJsonPointer(): JsonPointer
 
 Pattern validation
 ------------------
@@ -111,6 +115,8 @@ The thrown exception will be a *PHPModelGenerator\\Exception\\String\\PatternExc
     public function getPropertyName(): string
     // get the value provided to the property
     public function getProvidedValue()
+    // get the JSON pointer to the schema keyword that rejected the value
+    public function getJsonPointer(): JsonPointer
 
 Format
 ------
@@ -144,6 +150,8 @@ The thrown exception will be a *PHPModelGenerator\\Exception\\String\\FormatExce
     public function getPropertyName(): string
     // get the value provided to the property
     public function getProvidedValue()
+    // get the JSON pointer to the schema keyword that rejected the value
+    public function getJsonPointer(): JsonPointer
 
 Builtin formats
 ^^^^^^^^^^^^^^^
@@ -383,3 +391,5 @@ The ``ContentException`` exposes:
     public function getExpectedEncoding(): ?string
     public function getPropertyName(): string
     public function getProvidedValue()
+    // get the JSON pointer to the schema keyword that rejected the value
+    public function getJsonPointer(): JsonPointer

--- a/src/Draft/Modifier/MediaStringModifier.php
+++ b/src/Draft/Modifier/MediaStringModifier.php
@@ -52,6 +52,13 @@ class MediaStringModifier implements ModifierInterface
         $mediaType = $json['contentMediaType'] ?? null;
         $encoding  = $json['contentEncoding'] ?? null;
 
+        // ContentValidatorInterface::validate() is a single opaque check over both dimensions
+        // combined — it has no contract for reporting which one actually failed. Until that
+        // interface gains a way to attribute failure to a specific dimension, encoding takes
+        // pointer priority over media type when both are present, since the encoding (e.g.
+        // base64) is decoded first and is the more "mechanical" of the two transformations.
+        $pointer = $propertySchema->getPointer() . '/' . ($encoding !== null ? 'contentEncoding' : 'contentMediaType');
+
         (new FilterProcessor())->process(
             $property,
             [
@@ -61,12 +68,16 @@ class MediaStringModifier implements ModifierInterface
             ],
             $generatorConfiguration,
             $schema,
+            $pointer,
             self::FILTER_START_PRIORITY,
         );
 
         $contentValidator = $generatorConfiguration->getContentValidator($mediaType, $encoding);
         if ($contentValidator !== null) {
-            $property->addValidator(new ContentValidator($property, $contentValidator, $mediaType, $encoding));
+            $property->addValidator(
+                (new ContentValidator($property, $contentValidator, $mediaType, $encoding))
+                    ->withJsonPointer($pointer),
+            );
         }
     }
 }

--- a/src/Draft/Modifier/ObjectType/ObjectModifier.php
+++ b/src/Draft/Modifier/ObjectType/ObjectModifier.php
@@ -68,6 +68,9 @@ class ObjectModifier implements ModifierInterface
             )
             ->setType(new PropertyType($nestedSchema->getClassName()));
 
-        $property->addValidator(new InstanceOfValidator($property), 3);
+        $property->addValidator(
+            (new InstanceOfValidator($property))->withJsonPointer($propertySchema->getPointer() . '/type'),
+            3,
+        );
     }
 }

--- a/src/Draft/Modifier/TypeCheckModifier.php
+++ b/src/Draft/Modifier/TypeCheckModifier.php
@@ -32,11 +32,11 @@ class TypeCheckModifier implements ModifierInterface
         }
 
         $property->addValidator(
-            new TypeCheckValidator(
+            (new TypeCheckValidator(
                 $this->type,
                 $property,
                 $schemaProcessor->getGeneratorConfiguration()->isImplicitNullAllowed() && !$property->isRequired(),
-            ),
+            ))->withJsonPointer($propertySchema->getPointer() . '/type'),
             2,
         );
     }

--- a/src/Model/Attributes/PhpAttribute.php
+++ b/src/Model/Attributes/PhpAttribute.php
@@ -33,6 +33,11 @@ final class PhpAttribute
         return $this->fqcn;
     }
 
+    public function getArguments(): array
+    {
+        return $this->arguments;
+    }
+
     /**
      * Render the attribute body — the content that appears inside #[...].
      * Uses the simple (unqualified) class name; the FQCN is added via use-import separately.

--- a/src/Model/SchemaDefinition/JsonSchema.php
+++ b/src/Model/SchemaDefinition/JsonSchema.php
@@ -94,6 +94,18 @@ class JsonSchema
     }
 
     /**
+     * Creates a clone of this JsonSchema with a different pointer, without navigating the JSON content.
+     * Use when the target pointer path cannot be traversed via navigate() (e.g. the schema value is `true`).
+     */
+    public function withPointer(string $pointer): JsonSchema
+    {
+        $jsonSchema = clone $this;
+        $jsonSchema->pointer = $pointer;
+
+        return $jsonSchema;
+    }
+
+    /**
      * Creates a clone of the JsonSchema object with a subschema,
      * navigated to the provided $pointer from the current schema.
      */

--- a/src/Model/Validator/AbstractPropertyValidator.php
+++ b/src/Model/Validator/AbstractPropertyValidator.php
@@ -20,6 +20,8 @@ abstract class AbstractPropertyValidator implements PropertyValidatorInterface
     /**
      * AbstractPropertyValidator constructor.
      */
+    protected string $jsonPointer = '';
+
     public function __construct(
         protected PropertyInterface $property,
         protected string $exceptionClass,
@@ -45,12 +47,36 @@ abstract class AbstractPropertyValidator implements PropertyValidatorInterface
         return $this->exceptionClass;
     }
 
+    public function withJsonPointer(string $jsonPointer): static
+    {
+        $clone = clone $this;
+        $clone->jsonPointer = $jsonPointer;
+
+        // If the original is not yet resolved (e.g. ArrayItemValidator waiting on a recursive
+        // $ref), the SchemaDefinition resolution chain holds a reference to the original, not
+        // the clone. Forward resolution so the clone resolves when the original does — otherwise
+        // the property that received the clone never decrements its pending-validator count and
+        // finalizeMultiTypeProperty never fires.
+        if (!$this->isResolved) {
+            $this->onResolve(static function () use ($clone): void {
+                $clone->resolve();
+            });
+        }
+
+        return $clone;
+    }
+
+    public function getJsonPointer(): string
+    {
+        return $this->jsonPointer;
+    }
+
     /**
      * @inheritDoc
      */
     public function getExceptionParams(): array
     {
-        return array_merge([$this->property->getName()], $this->exceptionParams);
+        return array_merge([$this->property->getName(), $this->jsonPointer], $this->exceptionParams);
     }
 
     /**

--- a/src/Model/Validator/Factory/Any/EnumValidatorFactory.php
+++ b/src/Model/Validator/Factory/Any/EnumValidatorFactory.php
@@ -91,6 +91,9 @@ class EnumValidatorFactory extends AbstractValidatorFactory
             $allowedValues[] = null;
         }
 
-        $property->addValidator(new EnumValidator($property, $allowedValues), 3);
+        $property->addValidator(
+            (new EnumValidator($property, $allowedValues))->withJsonPointer($propertySchema->getPointer() . '/enum'),
+            3,
+        );
     }
 }

--- a/src/Model/Validator/Factory/Any/FilterValidatorFactory.php
+++ b/src/Model/Validator/Factory/Any/FilterValidatorFactory.php
@@ -36,6 +36,7 @@ class FilterValidatorFactory extends AbstractValidatorFactory
             $json[$this->key],
             $schemaProcessor->getGeneratorConfiguration(),
             $schema,
+            $propertySchema->getPointer() . '/' . $this->key,
         );
     }
 }

--- a/src/Model/Validator/Factory/Arrays/ItemsValidatorFactory.php
+++ b/src/Model/Validator/Factory/Arrays/ItemsValidatorFactory.php
@@ -35,16 +35,17 @@ class ItemsValidatorFactory extends AbstractValidatorFactory
         }
 
         $itemsSchema = $json[$this->key];
+        $itemsPointer = $propertySchema->getPointer() . '/' . $this->key;
 
         if (is_bool($itemsSchema)) {
             if ($itemsSchema === false) {
                 $property->addValidator(
-                    new PropertyValidator(
+                    (new PropertyValidator(
                         $property,
                         'count($value) > 0',
                         MaxItemsException::class,
                         [0],
-                    ),
+                    ))->withJsonPointer($itemsPointer),
                 );
             }
 
@@ -56,18 +57,18 @@ class ItemsValidatorFactory extends AbstractValidatorFactory
             is_array($itemsSchema) &&
             array_keys($itemsSchema) === range(0, count($itemsSchema) - 1)
         ) {
-            $this->addTupleValidator($schemaProcessor, $schema, $property, $propertySchema);
+            $this->addTupleValidator($schemaProcessor, $schema, $property, $propertySchema, $itemsPointer);
 
             return;
         }
 
         $property->addValidator(
-            new ArrayItemValidator(
+            (new ArrayItemValidator(
                 $schemaProcessor,
                 $schema,
                 $propertySchema->navigate($this->key),
                 $property,
-            ),
+            ))->withJsonPointer($itemsPointer),
         );
     }
 
@@ -79,6 +80,7 @@ class ItemsValidatorFactory extends AbstractValidatorFactory
         Schema $schema,
         PropertyInterface $property,
         JsonSchema $propertySchema,
+        string $itemsPointer,
     ): void {
         $json = $propertySchema->getJson();
 
@@ -87,12 +89,12 @@ class ItemsValidatorFactory extends AbstractValidatorFactory
         }
 
         $property->addValidator(
-            new ArrayTupleValidator(
+            (new ArrayTupleValidator(
                 $schemaProcessor,
                 $schema,
                 $propertySchema->navigate($this->key),
                 $property->getName(),
-            ),
+            ))->withJsonPointer($itemsPointer),
         );
     }
 
@@ -106,15 +108,16 @@ class ItemsValidatorFactory extends AbstractValidatorFactory
         JsonSchema $propertySchema,
     ): void {
         $json = $propertySchema->getJson();
+        $additionalItemsPointer = $propertySchema->getPointer() . '/additionalItems';
 
         if (!is_bool($json['additionalItems'])) {
             $property->addValidator(
-                new AdditionalItemsValidator(
+                (new AdditionalItemsValidator(
                     $schemaProcessor,
                     $schema,
                     $propertySchema,
                     $property->getName(),
-                ),
+                ))->withJsonPointer($additionalItemsPointer),
             );
 
             return;
@@ -123,12 +126,12 @@ class ItemsValidatorFactory extends AbstractValidatorFactory
         $expectedAmount = count($json[$this->key]);
 
         $property->addValidator(
-            new PropertyValidator(
+            (new PropertyValidator(
                 $property,
                 '($amount = count($value)) > ' . $expectedAmount,
                 AdditionalTupleItemsException::class,
                 [$expectedAmount, '&$amount'],
-            ),
+            ))->withJsonPointer($additionalItemsPointer),
         );
     }
 }

--- a/src/Model/Validator/Factory/Composition/AllOfValidatorFactory.php
+++ b/src/Model/Validator/Factory/Composition/AllOfValidatorFactory.php
@@ -85,7 +85,7 @@ class AllOfValidatorFactory
         $availableAmount = count($compositionProperties);
 
         $property->addValidator(
-            new ComposedPropertyValidator(
+            (new ComposedPropertyValidator(
                 $schemaProcessor->getGeneratorConfiguration(),
                 $property,
                 $compositionProperties,
@@ -102,7 +102,7 @@ class AllOfValidatorFactory
                     'mergedProperty' => &$mergedProperty,
                     'onlyForDefinedValues' => false,
                 ],
-            ),
+            ))->withJsonPointer($propertySchema->getPointer() . '/' . $this->key),
             100,
         );
     }

--- a/src/Model/Validator/Factory/Composition/AnyOfValidatorFactory.php
+++ b/src/Model/Validator/Factory/Composition/AnyOfValidatorFactory.php
@@ -90,7 +90,7 @@ class AnyOfValidatorFactory
         $availableAmount = count($compositionProperties);
 
         $property->addValidator(
-            new ComposedPropertyValidator(
+            (new ComposedPropertyValidator(
                 $schemaProcessor->getGeneratorConfiguration(),
                 $property,
                 $compositionProperties,
@@ -107,7 +107,7 @@ class AnyOfValidatorFactory
                     'mergedProperty' => &$mergedProperty,
                     'onlyForDefinedValues' => $onlyForDefinedValues,
                 ],
-            ),
+            ))->withJsonPointer($propertySchema->getPointer() . '/' . $this->key),
             100,
         );
     }

--- a/src/Model/Validator/Factory/Composition/IfValidatorFactory.php
+++ b/src/Model/Validator/Factory/Composition/IfValidatorFactory.php
@@ -138,7 +138,7 @@ class IfValidatorFactory
         $this->applyIfThenElseTypeSemantics($property, $properties);
 
         $property->addValidator(
-            new ConditionalPropertyValidator(
+            (new ConditionalPropertyValidator(
                 $schemaProcessor->getGeneratorConfiguration(),
                 $property,
                 array_values(array_filter($properties)),
@@ -152,7 +152,7 @@ class IfValidatorFactory
                     'viewHelper' => new RenderHelper($schemaProcessor->getGeneratorConfiguration()),
                     'onlyForDefinedValues' => $onlyForDefinedValues,
                 ],
-            ),
+            ))->withJsonPointer($propertySchema->getPointer() . '/if'),
             100,
         );
     }

--- a/src/Model/Validator/Factory/Composition/NotValidatorFactory.php
+++ b/src/Model/Validator/Factory/Composition/NotValidatorFactory.php
@@ -79,7 +79,7 @@ class NotValidatorFactory extends AbstractCompositionValidatorFactory
         $availableAmount = count($compositionProperties);
 
         $property->addValidator(
-            new ComposedPropertyValidator(
+            (new ComposedPropertyValidator(
                 $schemaProcessor->getGeneratorConfiguration(),
                 $property,
                 $compositionProperties,
@@ -96,7 +96,7 @@ class NotValidatorFactory extends AbstractCompositionValidatorFactory
                     'mergedProperty' => null,
                     'onlyForDefinedValues' => false,
                 ],
-            ),
+            ))->withJsonPointer($propertySchema->getPointer() . '/not'),
             100,
         );
     }
@@ -153,7 +153,7 @@ class NotValidatorFactory extends AbstractCompositionValidatorFactory
         $compositionProperties = [$branchProperty];
 
         $property->addValidator(
-            new ComposedPropertyValidator(
+            (new ComposedPropertyValidator(
                 $schemaProcessor->getGeneratorConfiguration(),
                 $property,
                 $compositionProperties,
@@ -170,7 +170,7 @@ class NotValidatorFactory extends AbstractCompositionValidatorFactory
                     'mergedProperty' => null,
                     'onlyForDefinedValues' => false,
                 ],
-            ),
+            ))->withJsonPointer($propertySchema->getPointer() . '/not'),
             100,
         );
     }

--- a/src/Model/Validator/Factory/Composition/OneOfValidatorFactory.php
+++ b/src/Model/Validator/Factory/Composition/OneOfValidatorFactory.php
@@ -72,7 +72,7 @@ class OneOfValidatorFactory
         $availableAmount = count($compositionProperties);
 
         $property->addValidator(
-            new ComposedPropertyValidator(
+            (new ComposedPropertyValidator(
                 $schemaProcessor->getGeneratorConfiguration(),
                 $property,
                 $compositionProperties,
@@ -89,7 +89,7 @@ class OneOfValidatorFactory
                     'mergedProperty' => null,
                     'onlyForDefinedValues' => $onlyForDefinedValues,
                 ],
-            ),
+            ))->withJsonPointer($propertySchema->getPointer() . '/' . $this->key),
             100,
         );
     }

--- a/src/Model/Validator/Factory/Object/AdditionalPropertiesValidatorFactory.php
+++ b/src/Model/Validator/Factory/Object/AdditionalPropertiesValidatorFactory.php
@@ -38,23 +38,25 @@ class AdditionalPropertiesValidatorFactory extends AbstractValidatorFactory
             return;
         }
 
+        $additionalPropertiesPointer = $propertySchema->getPointer() . '/' . $this->key;
+
         if (!is_bool($json[$this->key])) {
             $schema->addBaseValidator(
-                new AdditionalPropertiesValidator(
+                (new AdditionalPropertiesValidator(
                     $schemaProcessor,
                     $schema,
                     $propertySchema,
-                )
+                ))->withJsonPointer($additionalPropertiesPointer),
             );
 
             return;
         }
 
         $schema->addBaseValidator(
-            new NoAdditionalPropertiesValidator(
+            (new NoAdditionalPropertiesValidator(
                 new Property($schema->getClassName(), null, $propertySchema),
                 $json,
-            )
+            ))->withJsonPointer($additionalPropertiesPointer),
         );
     }
 }

--- a/src/Model/Validator/Factory/Object/PatternPropertiesValidatorFactory.php
+++ b/src/Model/Validator/Factory/Object/PatternPropertiesValidatorFactory.php
@@ -45,22 +45,26 @@ class PatternPropertiesValidatorFactory extends AbstractValidatorFactory
 
             if ($patternSchema === false) {
                 $schema->addBaseValidator(
-                    new ForbiddenPatternPropertiesValidator(
+                    (new ForbiddenPatternPropertiesValidator(
                         $pattern,
                         $schema->getClassName(),
                         $propertySchema,
-                    )
+                    ))->withJsonPointer(
+                        $propertySchema->getPointer() . '/' . $this->key . '/' . JsonSchema::encodePointer($pattern),
+                    ),
                 );
                 continue;
             }
 
             $schema->addBaseValidator(
-                new PatternPropertiesValidator(
+                (new PatternPropertiesValidator(
                     $schemaProcessor,
                     $schema,
                     $pattern,
                     $propertySchema->navigate("$this->key/" . JsonSchema::encodePointer($pattern)),
-                )
+                ))->withJsonPointer(
+                    $propertySchema->getPointer() . '/' . $this->key . '/' . JsonSchema::encodePointer($pattern),
+                ),
             );
         }
     }

--- a/src/Model/Validator/Factory/Object/PropertiesValidatorFactory.php
+++ b/src/Model/Validator/Factory/Object/PropertiesValidatorFactory.php
@@ -65,11 +65,15 @@ class PropertiesValidatorFactory extends AbstractValidatorFactory
                 }
 
                 $schema->addBaseValidator(
-                    new PropertyValidator(
+                    (new PropertyValidator(
                         new Property($propertyName, null, $propertySchema->withJson([])),
                         "array_key_exists('" . addslashes($propertyName) . "', \$modelData)",
                         DeniedPropertyException::class,
-                    )
+                    ))->withJsonPointer(
+                        $propertySchema->getPointer()
+                            . '/properties/'
+                            . JsonSchema::encodePointer((string) $propertyName),
+                    ),
                 );
                 continue;
             }
@@ -78,7 +82,15 @@ class PropertiesValidatorFactory extends AbstractValidatorFactory
             $dependencies = $json['dependencies'][$propertyName] ?? null;
 
             if ($propertyStructure === true) {
-                $nestedPropertySchema = $propertySchema->withJson([]);
+                // navigate() cannot traverse into a `true` schema value; use withPointer() to
+                // advance the pointer without descending into JSON content, then replace the json.
+                $nestedPropertySchema = $propertySchema
+                    ->withPointer(
+                        $propertySchema->getPointer()
+                            . '/' . $this->key . '/'
+                            . JsonSchema::encodePointer($propertyName)
+                    )
+                    ->withJson([]);
             } else {
                 $nestedPropertySchema = $propertySchema
                     ->navigate("$this->key/" . JsonSchema::encodePointer($propertyName))
@@ -130,8 +142,13 @@ class PropertiesValidatorFactory extends AbstractValidatorFactory
             }
         }
 
+        $dependencyPointer = $dependencyJsonSchema->getPointer();
+
         if ($propertyDependency) {
-            $property->addValidator(new PropertyDependencyValidator($property, $dependencyJsonSchema->getJson()));
+            $property->addValidator(
+                (new PropertyDependencyValidator($property, $dependencyJsonSchema->getJson()))
+                    ->withJsonPointer($dependencyPointer),
+            );
 
             return;
         }
@@ -148,7 +165,10 @@ class PropertiesValidatorFactory extends AbstractValidatorFactory
             $schema->getSchemaDictionary(),
         );
 
-        $property->addValidator(new SchemaDependencyValidator($schemaProcessor, $property, $dependencySchema));
+        $property->addValidator(
+            (new SchemaDependencyValidator($schemaProcessor, $property, $dependencySchema))
+                ->withJsonPointer($dependencyPointer),
+        );
         $schema->addNamespaceTransferDecorator(new SchemaNamespaceTransferDecorator($dependencySchema));
 
         $this->transferDependentPropertiesToBaseSchema($dependencySchema, $schema);

--- a/src/Model/Validator/Factory/Object/PropertyNamesValidatorFactory.php
+++ b/src/Model/Validator/Factory/Object/PropertyNamesValidatorFactory.php
@@ -30,11 +30,11 @@ class PropertyNamesValidatorFactory extends AbstractValidatorFactory
         }
 
         $schema->addBaseValidator(
-            new PropertyNamesValidator(
+            (new PropertyNamesValidator(
                 $schemaProcessor,
                 $schema,
                 $propertySchema->navigate($this->key),
-            )
+            ))->withJsonPointer($propertySchema->getPointer() . '/' . $this->key),
         );
     }
 }

--- a/src/Model/Validator/Factory/SimpleBaseValidatorFactory.php
+++ b/src/Model/Validator/Factory/SimpleBaseValidatorFactory.php
@@ -7,6 +7,7 @@ namespace PHPModelGenerator\Model\Validator\Factory;
 use PHPModelGenerator\Model\Property\PropertyInterface;
 use PHPModelGenerator\Model\Schema;
 use PHPModelGenerator\Model\SchemaDefinition\JsonSchema;
+use PHPModelGenerator\Model\Validator\AbstractPropertyValidator;
 use PHPModelGenerator\SchemaProcessor\SchemaProcessor;
 
 abstract class SimpleBaseValidatorFactory extends SimplePropertyValidatorFactory
@@ -21,8 +22,14 @@ abstract class SimpleBaseValidatorFactory extends SimplePropertyValidatorFactory
             return;
         }
 
-        $schema->addBaseValidator(
-            $this->getValidator($property, $propertySchema->getJson()[$this->key]),
-        );
+        $validator = $this->getValidator($property, $propertySchema->getJson()[$this->key]);
+
+        if ($validator instanceof AbstractPropertyValidator) {
+            $validator = $validator->withJsonPointer(
+                $propertySchema->getPointer() . '/' . JsonSchema::encodePointer($this->key),
+            );
+        }
+
+        $schema->addBaseValidator($validator);
     }
 }

--- a/src/Model/Validator/Factory/SimplePropertyValidatorFactory.php
+++ b/src/Model/Validator/Factory/SimplePropertyValidatorFactory.php
@@ -8,6 +8,7 @@ use PHPModelGenerator\Exception\SchemaException;
 use PHPModelGenerator\Model\Property\PropertyInterface;
 use PHPModelGenerator\Model\Schema;
 use PHPModelGenerator\Model\SchemaDefinition\JsonSchema;
+use PHPModelGenerator\Model\Validator\AbstractPropertyValidator;
 use PHPModelGenerator\Model\Validator\PropertyValidatorInterface;
 use PHPModelGenerator\SchemaProcessor\SchemaProcessor;
 
@@ -23,9 +24,15 @@ abstract class SimplePropertyValidatorFactory extends AbstractValidatorFactory
             return;
         }
 
-        $property->addValidator(
-            $this->getValidator($property, $propertySchema->getJson()[$this->key]),
-        );
+        $validator = $this->getValidator($property, $propertySchema->getJson()[$this->key]);
+
+        if ($validator instanceof AbstractPropertyValidator) {
+            $validator = $validator->withJsonPointer(
+                $propertySchema->getPointer() . '/' . JsonSchema::encodePointer($this->key),
+            );
+        }
+
+        $property->addValidator($validator);
     }
 
     protected function hasValidValue(PropertyInterface $property, JsonSchema $propertySchema): bool

--- a/src/Model/Validator/Factory/String/FormatValidatorFactory.php
+++ b/src/Model/Validator/Factory/String/FormatValidatorFactory.php
@@ -44,11 +44,11 @@ class FormatValidatorFactory extends AbstractValidatorFactory
         }
 
         $property->addValidator(
-            new FormatValidator(
+            (new FormatValidator(
                 $property,
                 $formatValidator,
                 [$format],
-            ),
+            ))->withJsonPointer($propertySchema->getPointer() . '/format'),
         );
     }
 }

--- a/src/Model/Validator/Factory/String/PatternPropertyValidatorFactory.php
+++ b/src/Model/Validator/Factory/String/PatternPropertyValidatorFactory.php
@@ -47,12 +47,12 @@ class PatternPropertyValidatorFactory extends AbstractValidatorFactory
         $encodedPattern = base64_encode("/$escapedPattern/");
 
         $property->addValidator(
-            new PropertyValidator(
+            (new PropertyValidator(
                 $property,
                 "is_string(\$value) && !preg_match(base64_decode('$encodedPattern'), \$value)",
                 PatternException::class,
                 [$pattern],
-            ),
+            ))->withJsonPointer($propertySchema->getPointer() . '/pattern'),
         );
     }
 }

--- a/src/Model/Validator/FilterValidator.php
+++ b/src/Model/Validator/FilterValidator.php
@@ -79,6 +79,19 @@ class FilterValidator extends PropertyTemplateValidator
     }
 
     /**
+     * Also propagate the pointer to the embedded filterValueValidator, since
+     * InvalidFilterValueException is thrown by that nested validator, not by $this directly.
+     */
+    public function withJsonPointer(string $jsonPointer): static
+    {
+        $clone = parent::withJsonPointer($jsonPointer);
+        $clone->templateValues['filterValueValidator'] = $clone->templateValues['filterValueValidator']
+            ->withJsonPointer($jsonPointer);
+
+        return $clone;
+    }
+
+    /**
      * Track if a transformation failed. If a transformation fails don't execute subsequent filter as they'd fail with
      * an invalid type
      */

--- a/src/Model/Validator/ForbiddenPatternPropertiesValidator.php
+++ b/src/Model/Validator/ForbiddenPatternPropertiesValidator.php
@@ -18,6 +18,8 @@ use PHPModelGenerator\Model\SchemaDefinition\JsonSchema;
  */
 class ForbiddenPatternPropertiesValidator extends AbstractPropertyValidator
 {
+    private readonly string $patternPointer;
+
     /**
      * @param string $pattern The unescaped regex pattern from the schema
      */
@@ -28,6 +30,10 @@ class ForbiddenPatternPropertiesValidator extends AbstractPropertyValidator
             InvalidPatternPropertiesException::class,
             [$pattern, '&$invalidProperties'],
         );
+
+        $this->patternPointer = $propertySchema->getPointer()
+            . '/patternProperties/'
+            . JsonSchema::encodePointer($this->pattern);
     }
 
     public function getPattern(): string
@@ -46,20 +52,23 @@ class ForbiddenPatternPropertiesValidator extends AbstractPropertyValidator
     public function getCheck(): string
     {
         $escapedPattern = addcslashes($this->pattern, '/');
+        $escapedPointer = addslashes($this->patternPointer);
 
         return <<<PHP
-(function () use (\$properties, &\$invalidProperties) {
-    foreach (\$properties as \$propertyKey => \$propertyValue) {
-        \$propertyKey = (string) \$propertyKey;
-        if (!preg_match('/$escapedPattern/', \$propertyKey)) {
-            continue;
-        }
-        \$invalidProperties[\$propertyKey] = [
-            new \PHPModelGenerator\Exception\Generic\DeniedPropertyException(\$propertyValue, \$propertyKey),
-        ];
-    }
-    return !empty(\$invalidProperties);
-})()
-PHP;
+            (function () use (\$properties, &\$invalidProperties) {
+                foreach (\$properties as \$propertyKey => \$propertyValue) {
+                    \$propertyKey = (string) \$propertyKey;
+                    if (!preg_match('/$escapedPattern/', \$propertyKey)) {
+                        continue;
+                    }
+                    \$invalidProperties[\$propertyKey] = [
+                        new \PHPModelGenerator\Exception\Generic\DeniedPropertyException(
+                            \$propertyValue, \$propertyKey, '$escapedPointer'
+                        ),
+                    ];
+                }
+                return !empty(\$invalidProperties);
+            })()
+            PHP;
     }
 }

--- a/src/PropertyProcessor/Filter/FilterProcessor.php
+++ b/src/PropertyProcessor/Filter/FilterProcessor.php
@@ -67,6 +67,7 @@ class FilterProcessor
         string|array $filterList,
         GeneratorConfiguration $generatorConfiguration,
         Schema $schema,
+        string $jsonPointer,
         int $startPriority = 10,
     ): void {
         $filterList = self::normalizeFilterList($filterList);
@@ -137,7 +138,13 @@ class FilterProcessor
             // filter — FilterValidator correctly receives null (no previous transforming filter).
             $actualFilterPriority = $filterPriority++;
             $property->addValidator(
-                new FilterValidator($generatorConfiguration, $filter, $property, $filterOptions, $transformingFilter),
+                (new FilterValidator(
+                    $generatorConfiguration,
+                    $filter,
+                    $property,
+                    $filterOptions,
+                    $transformingFilter,
+                ))->withJsonPointer($jsonPointer),
                 $actualFilterPriority,
             );
 
@@ -738,8 +745,8 @@ class FilterProcessor
      * Remove all validators of the given class from the property and re-add the same validation
      * logic wrapped in a new check expression, at priority 3.
      *
-     * The property name is stripped from exceptionParams before re-adding because
-     * AbstractPropertyValidator::getExceptionParams() prepends it again automatically.
+     * The property name and json pointer are stripped from exceptionParams before re-adding because
+     * AbstractPropertyValidator::getExceptionParams() prepends both automatically.
      */
     private function replaceValidatorWithGuardedCheck(
         PropertyInterface $property,
@@ -752,15 +759,16 @@ class FilterProcessor
         );
 
         $exceptionParams = $validator->getExceptionParams();
-        array_shift($exceptionParams);
+        array_shift($exceptionParams); // strip auto-prepended propertyName
+        $jsonPointer = (string) array_shift($exceptionParams); // strip auto-prepended jsonPointer
 
         $property->addValidator(
-            new PropertyValidator(
+            (new PropertyValidator(
                 $property,
                 $guardedCheck,
                 $validator->getExceptionClass(),
                 $exceptionParams,
-            ),
+            ))->withJsonPointer($jsonPointer),
             3,
         );
     }

--- a/src/PropertyProcessor/PropertyFactory.php
+++ b/src/PropertyProcessor/PropertyFactory.php
@@ -248,7 +248,15 @@ class PropertyFactory
         }
 
         if ($required && !str_starts_with($propertyName, 'item of array ')) {
-            $property->addValidator(new RequiredPropertyValidator($property), 1);
+            // Compute the parent object schema pointer by stripping '<name>/properties' (last two
+            // path segments) from the property pointer, then appending the 'required' keyword.
+            $propertyPointer = $propertySchema->getPointer();
+            $segments = $propertyPointer !== '' ? explode('/', ltrim($propertyPointer, '/')) : [];
+            $parentPointer = count($segments) > 2 ? '/' . implode('/', array_slice($segments, 0, -2)) : '';
+            $property->addValidator(
+                (new RequiredPropertyValidator($property))->withJsonPointer($parentPointer . '/required'),
+                1,
+            );
         }
 
         $configuration = $schemaProcessor->getGeneratorConfiguration();
@@ -555,7 +563,8 @@ class PropertyFactory
             && !$property->isRequired();
 
         $property->addValidator(
-            new MultiTypeCheckValidator($collectedTypes, $property, $allowImplicitNull),
+            (new MultiTypeCheckValidator($collectedTypes, $property, $allowImplicitNull))
+                ->withJsonPointer($propertySchema->getPointer() . '/type'),
             2,
         );
 

--- a/src/SchemaProcessor/PostProcessor/AdditionalPropertiesAccessorPostProcessor.php
+++ b/src/SchemaProcessor/PostProcessor/AdditionalPropertiesAccessorPostProcessor.php
@@ -6,6 +6,7 @@ namespace PHPModelGenerator\SchemaProcessor\PostProcessor;
 
 use PHPModelGenerator\Accessor\AdditionalPropertiesAccessor;
 use PHPModelGenerator\Accessor\ImmutableAdditionalPropertiesAccessor;
+use PHPModelGenerator\Attributes\JsonPointer;
 use PHPModelGenerator\Exception\FileSystemException;
 use PHPModelGenerator\Exception\Object\MinPropertiesException;
 use PHPModelGenerator\Exception\Object\RegularPropertyAsAdditionalPropertyException;
@@ -149,12 +150,22 @@ class AdditionalPropertiesAccessorPostProcessor extends PostProcessor
         GeneratorConfiguration $generatorConfiguration,
         ?PropertyInterface $validationProperty,
     ): void {
+        $nonInternalProperties = array_filter(
+            $schema->getProperties(),
+            static fn(PropertyInterface $property): bool => !$property->isInternal(),
+        );
+
         $objectProperties = array_map(
             static fn(PropertyInterface $property): string => $property->getName(),
-            array_filter(
-                $schema->getProperties(),
-                static fn(PropertyInterface $property): bool => !$property->isInternal(),
-            )
+            $nonInternalProperties,
+        );
+
+        $objectPropertyPointers = array_combine(
+            array_map(static fn(PropertyInterface $property): string => $property->getName(), $nonInternalProperties),
+            array_map(
+                static fn(PropertyInterface $property): string => self::resolvePrimaryJsonPointer($property),
+                $nonInternalProperties,
+            ),
         );
 
         $hasObjectProperties = $objectProperties !== [];
@@ -172,10 +183,37 @@ class AdditionalPropertiesAccessorPostProcessor extends PostProcessor
                     'validationProperty' => $validationProperty,
                     'hasObjectProperties' => $hasObjectProperties,
                     'objectProperties' => RenderHelper::varExportArray($objectProperties),
+                    'objectPropertyPointers' => RenderHelper::varExportArray($objectPropertyPointers),
                     'schemaHookResolver' => new SchemaHookResolver($schema),
                 ],
             )
         );
+    }
+
+    /**
+     * Resolve the pointer to report when a property name collides with a regular property.
+     *
+     * A property merged from multiple composition branches (e.g. declared in both the root
+     * properties block and an allOf branch) carries one #[JsonPointer] attribute per defining
+     * location, synthesized by PropertyAttributeSynthesizer. Reading that attribute data ties
+     * this pointer to the same single source of truth used for the generated #[JsonPointer]
+     * attributes, instead of independently recomputing it from
+     * $property->getJsonSchema()->getPointer() — a second computation that would silently
+     * diverge from the attribute data if PropertyMerger's choice of JsonSchema ever changes.
+     *
+     * RegularPropertyAsAdditionalPropertyException carries a single pointer, so when a property
+     * has multiple declaration sites only the first (root-preferred) one is reported — knowing
+     * any one true location is sufficient to explain the name collision.
+     */
+    private static function resolvePrimaryJsonPointer(PropertyInterface $property): string
+    {
+        foreach ($property->getAttributes() as $attribute) {
+            if ($attribute->getFqcn() === JsonPointer::class) {
+                return (string) $attribute->getArguments()[0];
+            }
+        }
+
+        return $property->getJsonSchema()->getPointer();
     }
 
     /**
@@ -188,7 +226,7 @@ class AdditionalPropertiesAccessorPostProcessor extends PostProcessor
         $minPropertyValidator = null;
         $json = $schema->getJsonSchema()->getJson();
         if (isset($json['minProperties'])) {
-            $minPropertyValidator = new PropertyValidator(
+            $minPropertyValidator = (new PropertyValidator(
                 new Property($schema->getClassName(), null, $schema->getJsonSchema()),
                 sprintf(
                     '%s < %d',
@@ -197,7 +235,7 @@ class AdditionalPropertiesAccessorPostProcessor extends PostProcessor
                 ),
                 MinPropertiesException::class,
                 [$json['minProperties']],
-            );
+            ))->withJsonPointer($schema->getJsonSchema()->getPointer() . '/minProperties');
         }
 
         $schema->addMethod(

--- a/src/SchemaProcessor/PostProcessor/EnumPostProcessor.php
+++ b/src/SchemaProcessor/PostProcessor/EnumPostProcessor.php
@@ -177,6 +177,9 @@ class EnumPostProcessor extends PostProcessor
             ['filter' => (new EnumFilter())->getToken(), 'fqcn' => $fqcn],
             $generatorConfiguration,
             $schema,
+            // This synthetic filter converts an already-validated scalar into the generated
+            // enum-backed class; conceptually it's part of the enum keyword's contract.
+            $property->getJsonSchema()->getPointer() . '/enum',
         );
 
         $schema->addUsedClass($fqcn);

--- a/src/SchemaProcessor/PostProcessor/Internal/ExtendObjectPropertiesMatchingPatternPropertiesPostProcessor.php
+++ b/src/SchemaProcessor/PostProcessor/Internal/ExtendObjectPropertiesMatchingPatternPropertiesPostProcessor.php
@@ -436,6 +436,10 @@ class ExtendObjectPropertiesMatchingPatternPropertiesPostProcessor extends PostP
                         ['filter'],
                     $generatorConfiguration,
                     $schema,
+                    // The property itself never declared a 'filter' keyword — it was
+                    // dynamically discovered as matching the pattern — so point to the
+                    // patternProperties branch that actually declared the filter.
+                    $patternPropertiesValidator->getJsonPointer() . '/filter',
                 );
             }
         }

--- a/src/SchemaProcessor/PostProcessor/Templates/AdditionalProperties/SetAdditionalProperty.phptpl
+++ b/src/SchemaProcessor/PostProcessor/Templates/AdditionalProperties/SetAdditionalProperty.phptpl
@@ -8,7 +8,7 @@ private function _setAdditionalProperty(
 ): void {
     {% if hasObjectProperties %}
         if (in_array($key, {{ objectProperties }})) {
-            throw new RegularPropertyAsAdditionalPropertyException($value, $key, self::class);
+            throw new RegularPropertyAsAdditionalPropertyException($value, $key, {{ objectPropertyPointers }}[$key] ?? '', self::class);
         }
     {% endif %}
 

--- a/src/Utils/TypeCheck.php
+++ b/src/Utils/TypeCheck.php
@@ -115,7 +115,8 @@ class TypeCheck
             || $typeCheckValidator instanceof MultiTypeCheckValidator
         ) {
             $property->addValidator(
-                new PassThroughTypeCheckValidator($passThroughTypeNames, $property, $typeCheckValidator),
+                (new PassThroughTypeCheckValidator($passThroughTypeNames, $property, $typeCheckValidator))
+                    ->withJsonPointer($typeCheckValidator->getJsonPointer()),
                 2,
             );
         }

--- a/tests/Basic/AdditionalPropertiesTest.php
+++ b/tests/Basic/AdditionalPropertiesTest.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 namespace PHPModelGenerator\Tests\Basic;
 
+use PHPModelGenerator\Exception\ErrorRegistryException;
 use PHPModelGenerator\Exception\Object\AdditionalPropertiesException;
+use PHPModelGenerator\Exception\Object\InvalidAdditionalPropertiesException;
 use PHPModelGenerator\Interfaces\JSONModelInterface;
 use PHPModelGenerator\Model\GeneratorConfiguration;
 use PHPModelGenerator\ModelGenerator;
@@ -76,31 +78,41 @@ class AdditionalPropertiesTest extends AbstractPHPModelGeneratorTestCase
     #[DataProvider('additionalPropertiesDataProvider')]
     public function testAdditionalPropertiesThrowAnExceptionWhenSetToFalse(array $propertyValue): void
     {
-        $this->expectException(AdditionalPropertiesException::class);
-        $this->expectExceptionMessageMatches(
-            '/Provided JSON for .* contains not allowed additional properties \[additional\]/',
-        );
-
         $className = $this->generateClassFromFileTemplate('AdditionalProperties.json', ['false']);
 
-        new $className($propertyValue);
+        try {
+            new $className($propertyValue);
+            $this->fail('Expected AdditionalPropertiesException');
+        } catch (AdditionalPropertiesException $exception) {
+            $this->assertMatchesRegularExpression(
+                '/Provided JSON for .* contains not allowed additional properties \[additional\]/',
+                $exception->getMessage(),
+            );
+            $this->assertSame('/additionalProperties', $exception->getJsonPointer()->pointer);
+        }
     }
 
     #[DataProvider('additionalPropertiesDataProvider')]
     public function testAdditionalPropertiesThrowAnExceptionWhenNotDefinedAndDeniedByGeneratorConfiguration(
         array $propertyValue,
     ): void {
-        $this->expectException(AdditionalPropertiesException::class);
-        $this->expectExceptionMessageMatches(
-            '/Provided JSON for .* contains not allowed additional properties \[additional\]/',
-        );
-
         $className = $this->generateClassFromFile(
             'AdditionalPropertiesNotDefined.json',
             (new GeneratorConfiguration())->setDenyAdditionalProperties(true)->setCollectErrors(false),
         );
 
-        new $className($propertyValue);
+        try {
+            new $className($propertyValue);
+            $this->fail('Expected AdditionalPropertiesException');
+        } catch (AdditionalPropertiesException $exception) {
+            $this->assertMatchesRegularExpression(
+                '/Provided JSON for .* contains not allowed additional properties \[additional\]/',
+                $exception->getMessage(),
+            );
+            // denyAdditionalProperties() synthesizes the check without a literal "additionalProperties"
+            // keyword in the schema; the pointer still points at the synthetic root location.
+            $this->assertSame('/additionalProperties', $exception->getJsonPointer()->pointer);
+        }
     }
 
     #[DataProvider('validTypedAdditionalPropertiesDataProvider')]
@@ -137,10 +149,22 @@ class AdditionalPropertiesTest extends AbstractPHPModelGeneratorTestCase
         array $propertyValue,
         string $errorMessage,
     ): void {
-        $this->expectValidationError($generatorConfiguration, $errorMessage);
         $className = $this->generateClassFromFile('AdditionalPropertiesTyped.json', $generatorConfiguration);
 
-        new $className($propertyValue);
+        try {
+            new $className($propertyValue);
+            $this->fail('Expected exception for invalid typed additional property');
+        } catch (ErrorRegistryException | InvalidAdditionalPropertiesException $exception) {
+            $this->assertStringContainsString($errorMessage, $exception->getMessage());
+
+            // collectErrors(true) wraps the additional properties exception in an ErrorRegistryException.
+            $innerException = $exception instanceof ErrorRegistryException
+                ? $exception->getErrors()[0]
+                : $exception;
+
+            $this->assertInstanceOf(InvalidAdditionalPropertiesException::class, $innerException);
+            $this->assertSame('/additionalProperties', $innerException->getJsonPointer()->pointer);
+        }
     }
 
     public static function invalidTypedAdditionalPropertiesDataProvider(): array
@@ -248,10 +272,22 @@ class AdditionalPropertiesTest extends AbstractPHPModelGeneratorTestCase
         array $propertyValue,
         string $errorMessage,
     ): void {
-        $this->expectValidationError($generatorConfiguration, $errorMessage);
         $className = $this->generateClassFromFile('AdditionalPropertiesObject.json', $generatorConfiguration);
 
-        new $className($propertyValue);
+        try {
+            new $className($propertyValue);
+            $this->fail('Expected exception for invalid additional property object');
+        } catch (ErrorRegistryException | InvalidAdditionalPropertiesException $exception) {
+            $this->assertStringContainsString($errorMessage, $exception->getMessage());
+
+            // collectErrors(true) wraps the additional properties exception in an ErrorRegistryException.
+            $innerException = $exception instanceof ErrorRegistryException
+                ? $exception->getErrors()[0]
+                : $exception;
+
+            $this->assertInstanceOf(InvalidAdditionalPropertiesException::class, $innerException);
+            $this->assertSame('/additionalProperties', $innerException->getJsonPointer()->pointer);
+        }
     }
 
     public static function invalidAdditionalPropertiesObjectsDataProvider(): array

--- a/tests/Basic/BasicSchemaGenerationTest.php
+++ b/tests/Basic/BasicSchemaGenerationTest.php
@@ -117,7 +117,6 @@ class BasicSchemaGenerationTest extends AbstractPHPModelGeneratorTestCase
         $object->setProperty('Hello');
 
         $this->assertSame('Hello', $object->getProperty());
-
     }
 
     public function testReadOnlyPropertyDoesntGenerateSetter(): void
@@ -278,7 +277,8 @@ class BasicSchemaGenerationTest extends AbstractPHPModelGeneratorTestCase
     public static function invalidStringPropertyValueProvider(): array
     {
         return self::combineDataProvider(
-            self::validationMethodDataProvider(), [
+            self::validationMethodDataProvider(),
+            [
                 'Too long string' => [
                     'HelloMyOldFriend',
                     [

--- a/tests/Basic/ContentMediaStringTest.php
+++ b/tests/Basic/ContentMediaStringTest.php
@@ -263,9 +263,13 @@ class ContentMediaStringTest extends AbstractPHPModelGeneratorTestCase
 
         $object = new $className(['requiredContent' => 'req']);
 
-        $this->expectException(InvalidFilterValueException::class);
-        $this->expectExceptionMessageMatches('/mediaType mismatch/');
-        $object->setContent(new MediaString('data', 'text/plain'));
+        try {
+            $object->setContent(new MediaString('data', 'text/plain'));
+            $this->fail('Expected InvalidFilterValueException');
+        } catch (InvalidFilterValueException $exception) {
+            $this->assertMatchesRegularExpression('/mediaType mismatch/', $exception->getMessage());
+            $this->assertSame('/properties/content/contentMediaType', $exception->getJsonPointer()->pointer);
+        }
     }
 
     public function testPassingMediaStringWithMismatchedEncodingThrows(): void
@@ -277,9 +281,13 @@ class ContentMediaStringTest extends AbstractPHPModelGeneratorTestCase
 
         $object = new $className([]);
 
-        $this->expectException(InvalidFilterValueException::class);
-        $this->expectExceptionMessageMatches('/encoding mismatch/');
-        $object->setContent(new MediaString('data', 'application/json', 'utf-8'));
+        try {
+            $object->setContent(new MediaString('data', 'application/json', 'utf-8'));
+            $this->fail('Expected InvalidFilterValueException');
+        } catch (InvalidFilterValueException $exception) {
+            $this->assertMatchesRegularExpression('/encoding mismatch/', $exception->getMessage());
+            $this->assertSame('/properties/content/contentEncoding', $exception->getJsonPointer()->pointer);
+        }
     }
 
     /**
@@ -342,6 +350,7 @@ class ContentMediaStringTest extends AbstractPHPModelGeneratorTestCase
             $this->assertSame('base64', $exception->getExpectedEncoding());
             $this->assertInstanceOf(RuntimeException::class, $exception->getPrevious());
             $this->assertStringContainsString('not-valid', $exception->getPrevious()->getMessage());
+            $this->assertSame('/properties/content/contentEncoding', $exception->getJsonPointer()->pointer);
         }
 
         // --- null on nullable property → content validator does not run ---
@@ -379,13 +388,21 @@ class ContentMediaStringTest extends AbstractPHPModelGeneratorTestCase
     public function testAddContentValidatorRejectsInvalidArrayElements(): void
     {
         $this->expectException(InvalidArgumentException::class);
-        (new GeneratorConfiguration())->addContentValidator(['application/json', ''], 'base64', new AlwaysValidContentValidator());
+        (new GeneratorConfiguration())->addContentValidator(
+            ['application/json', ''],
+            'base64',
+            new AlwaysValidContentValidator(),
+        );
     }
 
     public function testAddContentValidatorRejectsNonStringInArray(): void
     {
         $this->expectException(InvalidArgumentException::class);
-        (new GeneratorConfiguration())->addContentValidator('application/json', ['base64', null], new AlwaysValidContentValidator());
+        (new GeneratorConfiguration())->addContentValidator(
+            'application/json',
+            ['base64', null],
+            new AlwaysValidContentValidator(),
+        );
     }
 
     /**
@@ -515,6 +532,7 @@ class ContentMediaStringTest extends AbstractPHPModelGeneratorTestCase
         } catch (ContentException $exception) {
             $this->assertSame('image/png', $exception->getExpectedMediaType());
             $this->assertNull($exception->getExpectedEncoding());
+            $this->assertSame('/properties/content/contentMediaType', $exception->getJsonPointer()->pointer);
         }
 
         // Full wildcard also fires for this property
@@ -553,6 +571,7 @@ class ContentMediaStringTest extends AbstractPHPModelGeneratorTestCase
         } catch (ContentException $exception) {
             $this->assertNull($exception->getExpectedMediaType());
             $this->assertSame('base64', $exception->getExpectedEncoding());
+            $this->assertSame('/properties/content/contentEncoding', $exception->getJsonPointer()->pointer);
         }
     }
 }

--- a/tests/Basic/ErrorCollectionTest.php
+++ b/tests/Basic/ErrorCollectionTest.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types = 1);
+declare(strict_types=1);
 
 namespace PHPModelGenerator\Tests\Basic;
 
@@ -42,9 +42,13 @@ class ErrorCollectionTest extends AbstractPHPModelGeneratorTestCase
     public function testInvalidValuesForMultipleChecksForSinglePropertyThrowsAnException(
         mixed $value,
         array $messages,
+        array $expectedPointers,
     ): void {
         try {
-            $className = $this->generateClassFromFile('MultipleChecksForSingleProperty.json', new GeneratorConfiguration());
+            $className = $this->generateClassFromFile(
+                'MultipleChecksForSingleProperty.json',
+                new GeneratorConfiguration(),
+            );
 
             new $className(['property' => $value]);
         } catch (ErrorRegistryException $e) {
@@ -57,6 +61,7 @@ class ErrorCollectionTest extends AbstractPHPModelGeneratorTestCase
                 $this->assertStringContainsString($message, $error->getMessage());
                 $this->assertSame('property', $error->getPropertyName());
                 $this->assertSame($value, $error->getProvidedValue());
+                $this->assertSame($expectedPointers[$expectedExceptionClass], $error->getJsonPointer()->pointer);
             }
 
             return;
@@ -68,27 +73,58 @@ class ErrorCollectionTest extends AbstractPHPModelGeneratorTestCase
     public static function invalidValuesForSinglePropertyDataProvider(): array
     {
         return [
+            // PatternException → /pattern suffix; minLength → /minLength suffix; type check → /type suffix
             'pattern invalid' => [
                 '  ',
-                [PatternException::class => 'Value for property doesn\'t match pattern ^[^\s]+$']
+                [PatternException::class => 'Value for property doesn\'t match pattern ^[^\s]+$'],
+                [PatternException::class => '/properties/property/pattern'],
             ],
             'length invalid' => [
                 'a',
-                [MinLengthException::class => 'Value for property must not be shorter than 2']
+                [MinLengthException::class => 'Value for property must not be shorter than 2'],
+                [MinLengthException::class => '/properties/property/minLength'],
             ],
             'pattern and length invalid' => [
                 ' ',
                 [
                     PatternException::class => 'Value for property doesn\'t match pattern ^[^\s]+$',
-                    MinLengthException::class => 'Value for property must not be shorter than 2'
-                ]
+                    MinLengthException::class => 'Value for property must not be shorter than 2',
+                ],
+                [
+                    PatternException::class => '/properties/property/pattern',
+                    MinLengthException::class => '/properties/property/minLength',
+                ],
             ],
-            'null' => [null, [InvalidTypeException::class => 'Invalid type for property']],
-            'int' => [1, [InvalidTypeException::class => 'Invalid type for property']],
-            'float' => [0.92, [InvalidTypeException::class => 'Invalid type for property']],
-            'bool' => [true, [InvalidTypeException::class => 'Invalid type for property']],
-            'array' => [[], [InvalidTypeException::class => 'Invalid type for property']],
-            'object' => [new stdClass(), [InvalidTypeException::class => 'Invalid type for property']],
+            'null' => [
+                null,
+                [InvalidTypeException::class => 'Invalid type for property'],
+                [InvalidTypeException::class => '/properties/property/type'],
+            ],
+            'int' => [
+                1,
+                [InvalidTypeException::class => 'Invalid type for property'],
+                [InvalidTypeException::class => '/properties/property/type'],
+            ],
+            'float' => [
+                0.92,
+                [InvalidTypeException::class => 'Invalid type for property'],
+                [InvalidTypeException::class => '/properties/property/type'],
+            ],
+            'bool' => [
+                true,
+                [InvalidTypeException::class => 'Invalid type for property'],
+                [InvalidTypeException::class => '/properties/property/type'],
+            ],
+            'array' => [
+                [],
+                [InvalidTypeException::class => 'Invalid type for property'],
+                [InvalidTypeException::class => '/properties/property/type'],
+            ],
+            'object' => [
+                new stdClass(),
+                [InvalidTypeException::class => 'Invalid type for property'],
+                [InvalidTypeException::class => '/properties/property/type'],
+            ],
         ];
     }
 

--- a/tests/Basic/FormatTest.php
+++ b/tests/Basic/FormatTest.php
@@ -6,6 +6,7 @@ namespace PHPModelGenerator\Tests\Basic;
 
 use PHPModelGenerator\Exception\ErrorRegistryException;
 use PHPModelGenerator\Exception\SchemaException;
+use PHPModelGenerator\Exception\String\FormatException;
 use PHPModelGenerator\Format\FormatValidatorFromRegEx;
 use PHPModelGenerator\Model\GeneratorConfiguration;
 use PHPModelGenerator\Tests\AbstractPHPModelGeneratorTestCase;
@@ -203,26 +204,39 @@ class FormatTest extends AbstractPHPModelGeneratorTestCase
     }
 
     #[DataProvider('invalidEmailProvider')]
-    public function testInvalidEmail(string $value): void
+    public function testInvalidEmail(GeneratorConfiguration $configuration, string $value): void
     {
-        $this->expectException(ErrorRegistryException::class);
-        $this->expectExceptionMessageMatches('/must match the format email/');
-
         $className = $this->generateClassFromFile(
             'Email.json',
-            (new GeneratorConfiguration())->setImmutable(false),
+            $configuration->setImmutable(false),
         );
 
-        new $className(['value' => $value]);
+        try {
+            new $className(['value' => $value]);
+            $this->fail('Expected exception for invalid email format');
+        } catch (ErrorRegistryException | FormatException $exception) {
+            $this->assertMatchesRegularExpression('/must match the format email/', $exception->getMessage());
+
+            // collectErrors(true) wraps the format exception in an ErrorRegistryException.
+            $innerException = $exception instanceof ErrorRegistryException
+                ? $exception->getErrors()[0]
+                : $exception;
+
+            $this->assertInstanceOf(FormatException::class, $innerException);
+            $this->assertSame('/properties/value/format', $innerException->getJsonPointer()->pointer);
+        }
     }
 
     public static function invalidEmailProvider(): array
     {
-        return [
-            'no at sign'   => ['userexample.com'],
-            'no domain'    => ['user@'],
-            'empty string' => [''],
-        ];
+        return self::combineDataProvider(
+            self::validationMethodDataProvider(),
+            [
+                'no at sign'   => ['userexample.com'],
+                'no domain'    => ['user@'],
+                'empty string' => [''],
+            ],
+        );
     }
 
     // --- hostname ---

--- a/tests/Basic/ObjectSizeTest.php
+++ b/tests/Basic/ObjectSizeTest.php
@@ -36,13 +36,17 @@ class ObjectSizeTest extends AbstractPHPModelGeneratorTestCase
     public function testObjectWithInvalidPropertyAmountThrowsAnException(
         array $propertyValue,
         string $exceptionMessage,
+        string $expectedPointer,
     ): void {
-        $this->expectException(ValidationException::class);
-        $this->expectExceptionMessageMatches("/$exceptionMessage/");
-
         $className = $this->generateClassFromFile('ObjectSize.json');
 
-        new $className($propertyValue);
+        try {
+            new $className($propertyValue);
+            $this->fail('Expected exception for invalid property amount');
+        } catch (ValidationException $exception) {
+            $this->assertMatchesRegularExpression("/$exceptionMessage/", $exception->getMessage());
+            $this->assertSame($expectedPointer, $exception->getJsonPointer()->pointer);
+        }
     }
 
     public static function invalidObjectPropertyAmountDataProvider(): array
@@ -50,16 +54,19 @@ class ObjectSizeTest extends AbstractPHPModelGeneratorTestCase
         return [
             'empty object' => [
                 [],
-                'Provided object for ObjectSizeTest_(.*) must not contain less than 2 properties'
+                'Provided object for ObjectSizeTest_(.*) must not contain less than 2 properties',
+                '/minProperties',
             ],
             'too few properties' => [
                 ['b' => 2],
-                'Provided object for ObjectSizeTest_(.*) must not contain less than 2 properties'
+                'Provided object for ObjectSizeTest_(.*) must not contain less than 2 properties',
+                '/minProperties',
             ],
             'too many properties' => [
                 ['a' => 1, 'b' => 2, 'c' => 3, 'd' => 4],
-                'Provided object for ObjectSizeTest_(.*) must not contain more than 3 properties'
-            ]
+                'Provided object for ObjectSizeTest_(.*) must not contain more than 3 properties',
+                '/maxProperties',
+            ],
         ];
     }
 }

--- a/tests/Basic/PatternPropertiesTest.php
+++ b/tests/Basic/PatternPropertiesTest.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace PHPModelGenerator\Tests\Basic;
 
+use PHPModelGenerator\Exception\ErrorRegistryException;
+use PHPModelGenerator\Exception\Object\InvalidPatternPropertiesException;
 use PHPModelGenerator\Exception\SchemaException;
 use PHPModelGenerator\Model\GeneratorConfiguration;
 use PHPModelGenerator\ModelGenerator;
@@ -32,15 +34,25 @@ class PatternPropertiesTest extends AbstractPHPModelGeneratorTestCase
         GeneratorConfiguration $configuration,
         $propertyValue,
     ): void {
-        $this->expectValidationError(
-            $configuration,
-            'Invalid type for pattern property. Requires string, got ' .
-                (is_object($propertyValue) ? $propertyValue::class : gettype($propertyValue)),
-        );
+        $expectedMessage = 'Invalid type for pattern property. Requires string, got ' .
+            (is_object($propertyValue) ? $propertyValue::class : gettype($propertyValue));
 
         $className = $this->generateClassFromFile('TypedPatternProperty.json', $configuration);
 
-        new $className(['S_invalid' => $propertyValue]);
+        try {
+            new $className(['S_invalid' => $propertyValue]);
+            $this->fail('Expected exception for invalid typed pattern property');
+        } catch (ErrorRegistryException | InvalidPatternPropertiesException $exception) {
+            $this->assertStringContainsString($expectedMessage, $exception->getMessage());
+
+            // collectErrors(true) wraps the pattern properties exception in an ErrorRegistryException.
+            $innerException = $exception instanceof ErrorRegistryException
+                ? $exception->getErrors()[0]
+                : $exception;
+
+            $this->assertInstanceOf(InvalidPatternPropertiesException::class, $innerException);
+            $this->assertSame('/patternProperties/^S_', $innerException->getJsonPointer()->pointer);
+        }
     }
 
     public static function invalidTypedPatternPropertyDataProvider(): array
@@ -74,6 +86,42 @@ class PatternPropertiesTest extends AbstractPHPModelGeneratorTestCase
             'only non numeric chars' => ['abc'],
             'mixed string' => ['1234a'],
         ];
+    }
+
+    public function testForbiddenPatternPropertyIsAcceptedWhenNoMatchingKeyIsProvided(): void
+    {
+        $className = $this->generateClassFromFile('ForbiddenPatternProperty.json');
+        $object = new $className(['other' => 'value']);
+
+        $this->assertSame(['other' => 'value'], $object->meta()->rawInput());
+    }
+
+    #[DataProvider('validationMethodDataProvider')]
+    public function testForbiddenPatternPropertyThrowsAnException(GeneratorConfiguration $configuration): void
+    {
+        $className = $this->generateClassFromFile('ForbiddenPatternProperty.json', $configuration);
+
+        try {
+            new $className(['S~/invalid' => 'value']);
+            $this->fail('Expected exception for forbidden pattern property');
+        } catch (ErrorRegistryException | InvalidPatternPropertiesException $exception) {
+            $this->assertStringContainsString(
+                "invalid property 'S~/invalid' matching pattern '^S~/'",
+                $exception->getMessage(),
+            );
+
+            // collectErrors(true) wraps the pattern properties exception in an ErrorRegistryException.
+            $innerException = $exception instanceof ErrorRegistryException
+                ? $exception->getErrors()[0]
+                : $exception;
+
+            $this->assertInstanceOf(InvalidPatternPropertiesException::class, $innerException);
+            // Pattern '^S~/' contains '~' and '/' which encode to '~0' and '~1' respectively.
+            $this->assertSame('/patternProperties/^S~0~1', $innerException->getJsonPointer()->pointer);
+
+            $deniedPropertyException = $innerException->getNestedExceptions()['S~/invalid'][0];
+            $this->assertSame('/patternProperties/^S~0~1', $deniedPropertyException->getJsonPointer()->pointer);
+        }
     }
 
     public function testMultipleTransformingFiltersForPatternPropertiesAndObjectPropertyThrowsAnException(): void
@@ -174,7 +222,8 @@ class PatternPropertiesTest extends AbstractPHPModelGeneratorTestCase
     {
         $this->expectException(SchemaException::class);
         $this->expectExceptionMessageMatches(
-            "/Property 'alpha' has type int\|string but the matching patternProperties pattern '\\^a' requires type bool/",
+            "/Property 'alpha' has type int\|string but the matching patternProperties pattern"
+                . " '\\^a' requires type bool/",
         );
 
         $this->generateClassFromFile('CompositionPropertyConflictsWithPattern.json');

--- a/tests/Basic/PropertyDependencyTest.php
+++ b/tests/Basic/PropertyDependencyTest.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace PHPModelGenerator\Tests\Basic;
 
+use PHPModelGenerator\Exception\Dependency\InvalidPropertyDependencyException;
+use PHPModelGenerator\Exception\ErrorRegistryException;
 use PHPModelGenerator\Model\GeneratorConfiguration;
 use PHPModelGenerator\Tests\AbstractPHPModelGeneratorTestCase;
 use PHPUnit\Framework\Attributes\DataProvider;
@@ -52,7 +54,9 @@ class PropertyDependencyTest extends AbstractPHPModelGeneratorTestCase
             'Only dependant property provided 1' => [['billing_address' => '555 Debitors Lane']],
             'Only dependant property provided 2' => [['name' => 'John']],
             'Only dependant property provided 3' => [['billing_address' => '555 Debitors Lane', 'name' => 'John']],
-            'All properties provided' => [['credit_card' => 12345, 'billing_address' => '555 Debitors Lane', 'name' => 'John']],
+            'All properties provided' => [
+                ['credit_card' => 12345, 'billing_address' => '555 Debitors Lane', 'name' => 'John'],
+            ],
         ];
     }
 
@@ -75,18 +79,30 @@ class PropertyDependencyTest extends AbstractPHPModelGeneratorTestCase
     }
 
     #[DataProvider('validationMethodDataProvider')]
-    public function testInvalidPropertyDependencyThrowsAnException(GeneratorConfiguration $configuration): void {
-        $this->expectValidationError(
-            $configuration,
-            <<<ERROR
-            Missing required attributes which are dependants of credit_card:
-              - billing_address
-            ERROR,
-        );
-
+    public function testInvalidPropertyDependencyThrowsAnException(GeneratorConfiguration $configuration): void
+    {
         $className = $this->generateClassFromFile('PropertyDependency.json', $configuration);
 
-        new $className(['credit_card' => 12345]);
+        try {
+            new $className(['credit_card' => 12345]);
+            $this->fail('Expected exception for missing property dependency');
+        } catch (ErrorRegistryException | InvalidPropertyDependencyException $exception) {
+            $this->assertSame(
+                <<<ERROR
+                Missing required attributes which are dependants of credit_card:
+                  - billing_address
+                ERROR,
+                $exception->getMessage(),
+            );
+
+            // collectErrors(true) wraps the dependency exception in an ErrorRegistryException.
+            $innerException = $exception instanceof ErrorRegistryException
+                ? $exception->getErrors()[0]
+                : $exception;
+
+            $this->assertInstanceOf(InvalidPropertyDependencyException::class, $innerException);
+            $this->assertSame('/dependencies/credit_card', $innerException->getJsonPointer()->pointer);
+        }
     }
 
     #[DataProvider('invalidMultiplePropertyDependenciesDataProvider')]

--- a/tests/Basic/PropertyNamesTest.php
+++ b/tests/Basic/PropertyNamesTest.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace PHPModelGenerator\Tests\Basic;
 
+use PHPModelGenerator\Exception\ErrorRegistryException;
+use PHPModelGenerator\Exception\Object\InvalidPropertyNamesException;
 use PHPModelGenerator\Exception\SchemaException;
 use PHPModelGenerator\Model\GeneratorConfiguration;
 use PHPModelGenerator\Tests\AbstractPHPModelGeneratorTestCase;
@@ -101,9 +103,20 @@ class PropertyNamesTest extends AbstractPHPModelGeneratorTestCase
             false,
         );
 
-        $this->expectValidationError($generatorConfiguration, $exceptionMessage);
+        try {
+            new $className($properties);
+            $this->fail('Expected exception for invalid property names');
+        } catch (ErrorRegistryException | InvalidPropertyNamesException $exception) {
+            $this->assertStringContainsString($exceptionMessage, $exception->getMessage());
 
-        new $className($properties);
+            // collectErrors(true) wraps the property names exception in an ErrorRegistryException.
+            $innerException = $exception instanceof ErrorRegistryException
+                ? $exception->getErrors()[0]
+                : $exception;
+
+            $this->assertInstanceOf(InvalidPropertyNamesException::class, $innerException);
+            $this->assertSame('/propertyNames', $innerException->getJsonPointer()->pointer);
+        }
     }
 
     public static function invalidPropertyNamesDataProvider(): array

--- a/tests/Basic/SchemaDependencyTest.php
+++ b/tests/Basic/SchemaDependencyTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace PHPModelGenerator\Tests\Basic;
 
+use PHPModelGenerator\Exception\Dependency\InvalidSchemaDependencyException;
 use PHPModelGenerator\Exception\ErrorRegistryException;
 use PHPModelGenerator\Model\GeneratorConfiguration;
 use PHPModelGenerator\Tests\AbstractPHPModelGeneratorTestCase;
@@ -34,10 +35,14 @@ class SchemaDependencyTest extends AbstractPHPModelGeneratorTestCase
             'Only dependant property provided with different type' => [['billing_address' => true]],
             'Only dependant property provided 1' => [['billing_address' => '555 Debitors Lane']],
             'Only dependant property provided 2' => [['date_of_birth' => '01-01-1990']],
-            'Only dependant property provided 3' => [['billing_address' => '555 Debitors Lane', 'date_of_birth' => '01-01-1990']],
+            'Only dependant property provided 3' => [
+                ['billing_address' => '555 Debitors Lane', 'date_of_birth' => '01-01-1990'],
+            ],
             'Dependant property nulled 1' => [['billing_address' => null]],
             'Dependant property nulled 2' => [['date_of_birth' => null]],
-            'All properties provided' => [['credit_card' => 12345, 'billing_address' => '555 Debitors Lane', 'date_of_birth' => '01-01-1990']],
+            'All properties provided' => [
+                ['credit_card' => 12345, 'billing_address' => '555 Debitors Lane', 'date_of_birth' => '01-01-1990'],
+            ],
             'Only required properties provided' => [['credit_card' => 12345, 'date_of_birth' => '01-01-1990']],
         ];
     }
@@ -48,11 +53,24 @@ class SchemaDependencyTest extends AbstractPHPModelGeneratorTestCase
         array $propertyValue,
         string $message,
     ): void {
-        $this->expectValidationError($configuration, $message);
-
         $className = $this->generateClassFromFile('SchemaDependency.json', $configuration);
 
-        new $className($propertyValue);
+        try {
+            new $className($propertyValue);
+            $this->fail('Expected exception for invalid schema dependency');
+        } catch (ErrorRegistryException | InvalidSchemaDependencyException $exception) {
+            // collectErrors(true) appends additional collected errors after the expected message,
+            // matching the substring-style assertion the original expectExceptionMessage() used.
+            $this->assertStringContainsString($message, $exception->getMessage());
+
+            // collectErrors(true) wraps the dependency exception in an ErrorRegistryException.
+            $innerException = $exception instanceof ErrorRegistryException
+                ? $exception->getErrors()[0]
+                : $exception;
+
+            $this->assertInstanceOf(InvalidSchemaDependencyException::class, $innerException);
+            $this->assertSame('/dependencies/credit_card', $innerException->getJsonPointer()->pointer);
+        }
     }
 
     public static function invalidSchemaDependencyDataProvider(): array
@@ -195,6 +213,7 @@ class SchemaDependencyTest extends AbstractPHPModelGeneratorTestCase
         new $className($propertyValue);
     }
 
+    // phpcs:disable Generic.Files.LineLength.TooLong
     public static function invalidSchemaDependencyCompositionDataProvider(): array
     {
         return [
@@ -237,6 +256,7 @@ class SchemaDependencyTest extends AbstractPHPModelGeneratorTestCase
             ],
         ];
     }
+    // phpcs:enable Generic.Files.LineLength.TooLong
 
     #[DataProvider('validSchemaDependencyNestedObjectDataProvider')]
     public function testSchemaDependencyNestedObject(array $propertyValue): void

--- a/tests/ComposedValue/ComposedAllOfTest.php
+++ b/tests/ComposedValue/ComposedAllOfTest.php
@@ -173,12 +173,18 @@ class ComposedAllOfTest extends AbstractPHPModelGeneratorTestCase
         int $propertyValue,
         string $exceptionMessage,
     ): void {
-        $this->expectException(ValidationException::class);
-        $this->expectExceptionMessage($exceptionMessage);
+        $className = $this->generateClassFromFile(
+            'ComposedPropertyDefinition.json',
+            (new GeneratorConfiguration())->setCollectErrors(false),
+        );
 
-        $className = $this->generateClassFromFile('ComposedPropertyDefinition.json');
-
-        new $className(['property' => $propertyValue]);
+        try {
+            new $className(['property' => $propertyValue]);
+            $this->fail('Expected AllOfException');
+        } catch (AllOfException $exception) {
+            $this->assertStringContainsString($exceptionMessage, $exception->getMessage());
+            $this->assertSame('/properties/property/allOf', $exception->getJsonPointer()->pointer);
+        }
     }
 
     public static function invalidComposedPropertyDataProvider(): array

--- a/tests/ComposedValue/ComposedAnyOfTest.php
+++ b/tests/ComposedValue/ComposedAnyOfTest.php
@@ -319,25 +319,36 @@ class ComposedAnyOfTest extends AbstractPHPModelGeneratorTestCase
     public function testExtendedPropertyDefinitionWithInvalidValuesThrowsAnException(
         mixed $propertyValue,
         string $exceptionMessage,
+        string $expectedPointer,
     ): void {
-        $this->expectException(ValidationException::class);
-        $this->expectExceptionMessage($exceptionMessage);
+        $className = $this->generateClassFromFile(
+            'ExtendedPropertyDefinition.json',
+            (new GeneratorConfiguration())->setCollectErrors(false),
+        );
 
-        $className = $this->generateClassFromFile('ExtendedPropertyDefinition.json');
-
-        new $className(['property' => $propertyValue]);
+        try {
+            new $className(['property' => $propertyValue]);
+            $this->fail('Expected exception for invalid value');
+        } catch (ValidationException $exception) {
+            $this->assertStringContainsString($exceptionMessage, $exception->getMessage());
+            $this->assertSame($expectedPointer, $exception->getJsonPointer()->pointer);
+        }
     }
 
     public static function invalidExtendedPropertyDataProvider(): array
     {
         return [
-            'int 13' => [13, 'Invalid value for property declined by composition constraint'],
-            'float 9.9' => [9.9, 'Value for property must not be smaller than 10'],
-            'int 8' => [8, 'Value for property must not be smaller than 10'],
-            'bool' => [true, 'Invalid type for property'],
-            'array' => [[], 'Invalid type for property'],
-            'object' => [new stdClass(), 'Invalid type for property'],
-            'string' => ['', 'Invalid type for property'],
+            'int 13' => [
+                13,
+                'Invalid value for property declined by composition constraint',
+                '/properties/property/anyOf',
+            ],
+            'float 9.9' => [9.9, 'Value for property must not be smaller than 10', '/properties/property/minimum'],
+            'int 8' => [8, 'Value for property must not be smaller than 10', '/properties/property/minimum'],
+            'bool' => [true, 'Invalid type for property', '/properties/property/type'],
+            'array' => [[], 'Invalid type for property', '/properties/property/type'],
+            'object' => [new stdClass(), 'Invalid type for property', '/properties/property/type'],
+            'string' => ['', 'Invalid type for property', '/properties/property/type'],
         ];
     }
 
@@ -547,8 +558,9 @@ class ComposedAnyOfTest extends AbstractPHPModelGeneratorTestCase
     }
 
     #[DataProvider('invalidComposedObjectDataProvider')]
-    public function testNotMatchingPropertyForComposedAnyOfObjectWithRequiredPropertiesThrowsAnException(array $input): void
-    {
+    public function testNotMatchingPropertyForComposedAnyOfObjectWithRequiredPropertiesThrowsAnException(
+        array $input,
+    ): void {
         $this->expectException(ValidationException::class);
 
         $className = $this->generateClassFromFile('ObjectLevelCompositionRequired.json');

--- a/tests/ComposedValue/ComposedIfTest.php
+++ b/tests/ComposedValue/ComposedIfTest.php
@@ -64,11 +64,15 @@ class ComposedIfTest extends AbstractPHPModelGeneratorTestCase
     #[DataProvider('invalidConditionalPropertyDefinitionDataProvider')]
     public function testInvalidConditionalPropertyDefinition(int $value, string $expectedExceptionMessage): void
     {
-        $this->expectException(ConditionalException::class);
-        $this->expectExceptionMessage($expectedExceptionMessage);
-
         $className = $this->generateClassFromFile('ConditionalPropertyDefinition.json');
-        new $className(['property' => $value]);
+
+        try {
+            new $className(['property' => $value]);
+            $this->fail('Expected ConditionalException');
+        } catch (ConditionalException $exception) {
+            $this->assertSame($expectedExceptionMessage, $exception->getMessage());
+            $this->assertSame('/properties/property/if', $exception->getJsonPointer()->pointer);
+        }
     }
 
     public static function invalidConditionalPropertyDefinitionDataProvider(): array

--- a/tests/ComposedValue/ComposedNotTest.php
+++ b/tests/ComposedValue/ComposedNotTest.php
@@ -102,11 +102,25 @@ class ComposedNotTest extends AbstractPHPModelGeneratorTestCase
         GeneratorConfiguration $configuration,
         string $propertyValue,
     ): void {
-        $this->expectValidationError($configuration, 'Invalid value for property declined by composition constraint');
-
         $className = $this->generateClassFromFile('NotOfType.json', $configuration);
 
-        new $className(['property' => $propertyValue]);
+        try {
+            new $className(['property' => $propertyValue]);
+            $this->fail('Expected exception for value matching the not branch');
+        } catch (ErrorRegistryException | NotException $exception) {
+            $this->assertStringContainsString(
+                'Invalid value for property declined by composition constraint',
+                $exception->getMessage(),
+            );
+
+            // collectErrors(true) wraps the not exception in an ErrorRegistryException.
+            $innerException = $exception instanceof ErrorRegistryException
+                ? $exception->getErrors()[0]
+                : $exception;
+
+            $this->assertInstanceOf(NotException::class, $innerException);
+            $this->assertSame('/properties/property/not', $innerException->getJsonPointer()->pointer);
+        }
     }
 
     public static function invalidPropertyTypeDataProvider(): array

--- a/tests/ComposedValue/ComposedOneOfTest.php
+++ b/tests/ComposedValue/ComposedOneOfTest.php
@@ -142,8 +142,14 @@ class ComposedOneOfTest extends AbstractPHPModelGeneratorTestCase
         $className = $this->generateClassFromFile($schema);
 
         $object = new $className([]);
-        $this->assertMatchesRegularExpression($annotationPattern, $this->getPropertyTypeAnnotation($object, 'property'));
-        $this->assertMatchesRegularExpression($annotationPattern, $this->getReturnTypeAnnotation($object, 'getProperty'));
+        $this->assertMatchesRegularExpression(
+            $annotationPattern,
+            $this->getPropertyTypeAnnotation($object, 'property'),
+        );
+        $this->assertMatchesRegularExpression(
+            $annotationPattern,
+            $this->getReturnTypeAnnotation($object, 'getProperty'),
+        );
     }
 
     public static function annotationDataProvider(): array
@@ -239,28 +245,51 @@ class ComposedOneOfTest extends AbstractPHPModelGeneratorTestCase
     public function testExtendedPropertyDefinitionWithInvalidValuesThrowsAnException(
         mixed $propertyValue,
         string $exceptionMessage,
+        string $expectedPointer,
     ): void {
-        $this->expectException(ValidationException::class);
-        $this->expectExceptionMessage($exceptionMessage);
+        $className = $this->generateClassFromFile(
+            'ExtendedPropertyDefinition.json',
+            (new GeneratorConfiguration())->setCollectErrors(false),
+        );
 
-        $className = $this->generateClassFromFile('ExtendedPropertyDefinition.json');
-
-        new $className(['property' => $propertyValue]);
+        try {
+            new $className(['property' => $propertyValue]);
+            $this->fail('Expected exception for invalid value');
+        } catch (ValidationException $exception) {
+            $this->assertStringContainsString($exceptionMessage, $exception->getMessage());
+            $this->assertSame($expectedPointer, $exception->getJsonPointer()->pointer);
+        }
     }
 
     public static function invalidExtendedPropertyDataProvider(): array
     {
         return [
-            'int 10' => [10, 'Invalid value for property declined by composition constraint'],
-            'int 13' => [13, 'Invalid value for property declined by composition constraint'],
-            'int 20' => [20, 'Invalid value for property declined by composition constraint'],
-            'float 10.' => [10., 'Invalid value for property declined by composition constraint'],
-            'float 9.9' => [9.9, 'Value for property must not be smaller than 10'],
-            'int 8' => [8, 'Value for property must not be smaller than 10'],
-            'bool' => [true, 'Invalid type for property'],
-            'array' => [[], 'Invalid type for property'],
-            'object' => [new stdClass(), 'Invalid type for property'],
-            'string' => ['', 'Invalid type for property'],
+            'int 10' => [
+                10,
+                'Invalid value for property declined by composition constraint',
+                '/properties/property/oneOf',
+            ],
+            'int 13' => [
+                13,
+                'Invalid value for property declined by composition constraint',
+                '/properties/property/oneOf',
+            ],
+            'int 20' => [
+                20,
+                'Invalid value for property declined by composition constraint',
+                '/properties/property/oneOf',
+            ],
+            'float 10.' => [
+                10.,
+                'Invalid value for property declined by composition constraint',
+                '/properties/property/oneOf',
+            ],
+            'float 9.9' => [9.9, 'Value for property must not be smaller than 10', '/properties/property/minimum'],
+            'int 8' => [8, 'Value for property must not be smaller than 10', '/properties/property/minimum'],
+            'bool' => [true, 'Invalid type for property', '/properties/property/type'],
+            'array' => [[], 'Invalid type for property', '/properties/property/type'],
+            'object' => [new stdClass(), 'Invalid type for property', '/properties/property/type'],
+            'string' => ['', 'Invalid type for property', '/properties/property/type'],
         ];
     }
 
@@ -403,8 +432,11 @@ class ComposedOneOfTest extends AbstractPHPModelGeneratorTestCase
      */
     #[DataProvider('invalidComposedObjectDataProvider')]
     #[DataProvider('validComposedObjectWithRequiredPropertiesDataProvider')]
-    public function testNotMatchingPropertyForComposedOneOfObjectThrowsAnException(array $input, mixed $_stringValue = null, mixed $_intValue = null): void
-    {
+    public function testNotMatchingPropertyForComposedOneOfObjectThrowsAnException(
+        array $input,
+        mixed $_stringValue = null,
+        mixed $_intValue = null,
+    ): void {
         $this->expectException(ValidationException::class);
 
         $className = $this->generateClassFromFile('ObjectLevelComposition.json');
@@ -444,8 +476,11 @@ class ComposedOneOfTest extends AbstractPHPModelGeneratorTestCase
     }
 
     #[DataProvider('invalidComposedObjectDataProvider')]
-    public function testNotMatchingPropertyForComposedOneOfObjectWithRequiredPropertiesThrowsAnException(array $input, mixed $_stringValue = null, mixed $_intValue = null): void
-    {
+    public function testNotMatchingPropertyForComposedOneOfObjectWithRequiredPropertiesThrowsAnException(
+        array $input,
+        mixed $_stringValue = null,
+        mixed $_intValue = null,
+    ): void {
         $this->expectException(ValidationException::class);
 
         $className = $this->generateClassFromFile('ObjectLevelCompositionRequired.json');

--- a/tests/Filter/FilterCompositionRuntimeTest.php
+++ b/tests/Filter/FilterCompositionRuntimeTest.php
@@ -135,6 +135,9 @@ class FilterCompositionRuntimeTest extends AbstractFilterTestCase
             $this->fail('Expected MinimumException for input -5');
         } catch (MinimumException $minimumException) {
             $this->assertStringContainsString('must not be smaller than 0', $minimumException->getMessage());
+            // AbstractRangeValidatorFactory (SimplePropertyValidatorFactory) stamps the keyword pointer;
+            // replaceValidatorWithGuardedCheck strips and re-injects it, so it survives filter rewriting.
+            $this->assertSame('/properties/value/minimum', $minimumException->getJsonPointer()->pointer);
         }
     }
 
@@ -181,6 +184,7 @@ class FilterCompositionRuntimeTest extends AbstractFilterTestCase
             $this->fail('Expected MinimumException for int input -5');
         } catch (MinimumException $minimumException) {
             $this->assertStringContainsString('must not be smaller than 0', $minimumException->getMessage());
+            $this->assertSame('/properties/value/minimum', $minimumException->getJsonPointer()->pointer);
         }
 
         // Already-transformed int 42: skip guard bypasses format check, minimum passes.

--- a/tests/Filter/TransformingFilterTest.php
+++ b/tests/Filter/TransformingFilterTest.php
@@ -6,6 +6,8 @@ namespace PHPModelGenerator\Tests\Filter;
 
 use DateTime;
 use PHPModelGenerator\Exception\ErrorRegistryException;
+use PHPModelGenerator\Exception\Filter\InvalidFilterValueException;
+use PHPModelGenerator\Exception\Generic\InvalidTypeException;
 use PHPModelGenerator\Exception\InvalidFilterException;
 use PHPModelGenerator\Exception\SchemaException;
 use PHPModelGenerator\Model\GeneratorConfiguration;
@@ -115,20 +117,54 @@ class TransformingFilterTest extends AbstractFilterTestCase
 
     public function testFilterExceptionsAreCaught(): void
     {
-        $this->expectException(ErrorRegistryException::class);
-        $this->expectExceptionMessage(
-            <<<ERROR
-            Invalid value for property created denied by filter dateTime: Invalid Date Time value "Hello"
-            Invalid type for name. Requires string, got integer
-            ERROR,
-        );
-
         $className = $this->generateClassFromFile(
             'TransformingFilter.json',
             (new GeneratorConfiguration())->setCollectErrors(true),
         );
 
-        new $className(['created' => 'Hello', 'name' => 12]);
+        try {
+            new $className(['created' => 'Hello', 'name' => 12]);
+            $this->fail('Expected exception for invalid filter value and invalid type');
+        } catch (ErrorRegistryException $exception) {
+            $this->assertSame(
+                <<<ERROR
+                Invalid value for property created denied by filter dateTime: Invalid Date Time value "Hello"
+                Invalid type for name. Requires string, got integer
+                ERROR,
+                $exception->getMessage(),
+            );
+
+            $filterException = $exception->getErrors()[0];
+            $this->assertInstanceOf(InvalidFilterValueException::class, $filterException);
+            $this->assertSame('/properties/created/filter', $filterException->getJsonPointer()->pointer);
+        }
+    }
+
+    #[DataProvider('validationMethodDataProvider')]
+    public function testValueRejectedByPassThroughTypeCheckCarriesTypePointer(
+        GeneratorConfiguration $configuration,
+    ): void {
+        $className = $this->generateClassFromFile('TransformingFilter.json', $configuration);
+
+        try {
+            // 12 is neither the original string type nor the transformed DateTime type, so the
+            // PassThroughTypeCheckValidator added on top of the dateTime filter must reject it.
+            new $className(['created' => 12]);
+            $this->fail('Expected exception for invalid type on a transforming-filtered property');
+        } catch (ErrorRegistryException | InvalidTypeException $exception) {
+            $this->assertStringContainsString(
+                'Invalid type for created. Requires [DateTime, string], got integer',
+                $exception->getMessage(),
+            );
+
+            // collectErrors(true) wraps the type exception in an ErrorRegistryException.
+            $innerException = $exception instanceof ErrorRegistryException
+                ? $exception->getErrors()[0]
+                : $exception;
+
+            $this->assertInstanceOf(InvalidTypeException::class, $innerException);
+            $this->assertSame('/properties/created/type', $innerException->getJsonPointer()->pointer);
+        }
     }
 
     #[DataProvider('additionalFilterOptionsDataProvider')]

--- a/tests/Objects/AbstractNumericPropertyTestCase.php
+++ b/tests/Objects/AbstractNumericPropertyTestCase.php
@@ -49,28 +49,43 @@ abstract class AbstractNumericPropertyTestCase extends AbstractPHPModelGenerator
     }
 
     #[DataProvider('invalidRangeDataProvider')]
-    public function testInvalidValueForRangeValidatorThrowsAnException($propertyValue, string $exceptionMessage): void
-    {
-        $this->expectException(ValidationException::class);
-        $this->expectExceptionMessage($exceptionMessage);
-
+    public function testInvalidValueForRangeValidatorThrowsAnException(
+        $propertyValue,
+        string $exceptionMessage,
+        string $expectedPointerKeyword,
+    ): void {
         $className = $this->generateClassFromFile($this->getRangeFile(false));
 
-        new $className(['property' => $propertyValue]);
+        try {
+            new $className(['property' => $propertyValue]);
+            $this->fail('Expected ValidationException for out-of-range value');
+        } catch (ValidationException $exception) {
+            $this->assertSame($exceptionMessage, $exception->getMessage());
+            $this->assertSame(
+                "/properties/property/$expectedPointerKeyword",
+                $exception->getJsonPointer()->pointer,
+            );
+        }
     }
 
-    /**
-     * @param $propertyValue
-     */
     #[DataProvider('invalidExclusiveRangeDataProvider')]
-    public function testInvalidValueForExclusiveRangeValidatorThrowsAnException($propertyValue, string $exceptionMessage): void
-    {
-        $this->expectException(ValidationException::class);
-        $this->expectExceptionMessage($exceptionMessage);
-
+    public function testInvalidValueForExclusiveRangeValidatorThrowsAnException(
+        $propertyValue,
+        string $exceptionMessage,
+        string $expectedPointerKeyword,
+    ): void {
         $className = $this->generateClassFromFile($this->getRangeFile(true));
 
-        new $className(['property' => $propertyValue]);
+        try {
+            new $className(['property' => $propertyValue]);
+            $this->fail('Expected ValidationException for out-of-range value');
+        } catch (ValidationException $exception) {
+            $this->assertSame($exceptionMessage, $exception->getMessage());
+            $this->assertSame(
+                "/properties/property/$expectedPointerKeyword",
+                $exception->getJsonPointer()->pointer,
+            );
+        }
     }
 
     /**
@@ -93,11 +108,14 @@ abstract class AbstractNumericPropertyTestCase extends AbstractPHPModelGenerator
     #[DataProvider('invalidMultipleOfDataProvider')]
     public function testInvalidValueForMultipleOfValidatorThrowsAnException($multipleOf, $propertyValue): void
     {
-        $this->expectException(ValidationException::class);
-        $this->expectExceptionMessage("Value for property must be a multiple of $multipleOf");
-
         $className = $this->generateClassFromFileTemplate($this->getMultipleOfFile(), [$multipleOf]);
 
-        new $className(['property' => $propertyValue]);
+        try {
+            new $className(['property' => $propertyValue]);
+            $this->fail('Expected ValidationException for non-multiple value');
+        } catch (ValidationException $exception) {
+            $this->assertSame("Value for property must be a multiple of $multipleOf", $exception->getMessage());
+            $this->assertSame('/properties/property/multipleOf', $exception->getJsonPointer()->pointer);
+        }
     }
 }

--- a/tests/Objects/ArrayPropertyTest.php
+++ b/tests/Objects/ArrayPropertyTest.php
@@ -5,8 +5,11 @@ declare(strict_types=1);
 namespace PHPModelGenerator\Tests\Objects;
 
 use PHPModelGenerator\Exception\Arrays\InvalidItemException;
+use PHPModelGenerator\Exception\Arrays\MaxItemsException;
 use PHPModelGenerator\Exception\Arrays\MinItemsException;
+use PHPModelGenerator\Exception\ErrorRegistryException;
 use PHPModelGenerator\Exception\FileSystemException;
+use PHPModelGenerator\Exception\ValidationException;
 use PHPModelGenerator\Exception\RenderException;
 use PHPModelGenerator\Exception\SchemaException;
 use PHPModelGenerator\Model\GeneratorConfiguration;
@@ -330,11 +333,26 @@ class ArrayPropertyTest extends AbstractPHPModelGeneratorTestCase
         array $propertyValue,
         string $exceptionMessage,
     ): void {
-        $this->expectValidationError($configuration, $exceptionMessage);
-
         $className = $this->generateClassFromFile('ArrayPropertyItemAmount.json', $configuration);
 
-        new $className(['property' => $propertyValue]);
+        try {
+            new $className(['property' => $propertyValue]);
+            $this->fail('Expected exception for invalid array item amount');
+        } catch (ErrorRegistryException | ValidationException $exception) {
+            $this->assertStringContainsString($exceptionMessage, $exception->getMessage());
+
+            // collectErrors(true) wraps the item-amount exception in an ErrorRegistryException.
+            $innerException = $exception instanceof ErrorRegistryException
+                ? $exception->getErrors()[0]
+                : $exception;
+
+            if ($innerException instanceof MinItemsException) {
+                $this->assertSame('/properties/property/minItems', $innerException->getJsonPointer()->pointer);
+            } else {
+                $this->assertInstanceOf(MaxItemsException::class, $innerException);
+                $this->assertSame('/properties/property/maxItems', $innerException->getJsonPointer()->pointer);
+            }
+        }
     }
 
     public static function invalidItemAmountDataProvider(): array
@@ -721,11 +739,22 @@ class ArrayPropertyTest extends AbstractPHPModelGeneratorTestCase
         array $propertyValue,
         string $message,
     ): void {
-        $this->expectValidationError($configuration, $message);
-
         $className = $this->generateClassFromFile($file, $configuration);
 
-        new $className(['property' => $propertyValue]);
+        try {
+            new $className(['property' => $propertyValue]);
+            $this->fail('Expected exception for invalid object array item');
+        } catch (ErrorRegistryException | InvalidItemException $exception) {
+            $this->assertStringContainsString($message, $exception->getMessage());
+
+            // collectErrors(true) wraps the array item exception in an ErrorRegistryException.
+            $innerException = $exception instanceof ErrorRegistryException
+                ? $exception->getErrors()[0]
+                : $exception;
+
+            $this->assertInstanceOf(InvalidItemException::class, $innerException);
+            $this->assertSame('/properties/property/items', $innerException->getJsonPointer()->pointer);
+        }
     }
 
     public static function invalidObjectArrayDataProvider(): array

--- a/tests/Objects/EnumPropertyTest.php
+++ b/tests/Objects/EnumPropertyTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace PHPModelGenerator\Tests\Objects;
 
 use PHPModelGenerator\Exception\FileSystemException;
+use PHPModelGenerator\Exception\Generic\EnumException;
 use PHPModelGenerator\Exception\ValidationException;
 use PHPModelGenerator\Exception\RenderException;
 use PHPModelGenerator\Exception\SchemaException;
@@ -87,12 +88,15 @@ class EnumPropertyTest extends AbstractPHPModelGeneratorTestCase
     #[DataProvider('invalidEnumEntriesDataProvider')]
     public function testInvalidItemThrowsAnException(string $propertyValue): void
     {
-        $this->expectException(ValidationException::class);
-        $this->expectExceptionMessage('Invalid value for property declined by enum constraint');
-
         $className = $this->generateEnumClass('string', static::ENUM_STRING);
 
-        new $className(['property' => $propertyValue]);
+        try {
+            new $className(['property' => $propertyValue]);
+            $this->fail('Expected EnumException');
+        } catch (EnumException $exception) {
+            $this->assertSame('Invalid value for property declined by enum constraint', $exception->getMessage());
+            $this->assertSame('/properties/property/enum', $exception->getJsonPointer()->pointer);
+        }
     }
 
     public static function invalidEnumEntriesDataProvider(): array

--- a/tests/Objects/IntegerPropertyTest.php
+++ b/tests/Objects/IntegerPropertyTest.php
@@ -140,8 +140,8 @@ class IntegerPropertyTest extends AbstractNumericPropertyTestCase
     public static function invalidRangeDataProvider(): iterable
     {
         return [
-            'Too large number' => [2, 'Value for property must not be larger than 1'],
-            'Too small number' => [-2, 'Value for property must not be smaller than -1'],
+            'Too large number' => [2, 'Value for property must not be larger than 1', 'maximum'],
+            'Too small number' => [-2, 'Value for property must not be smaller than -1', 'minimum'],
         ];
     }
 
@@ -158,10 +158,10 @@ class IntegerPropertyTest extends AbstractNumericPropertyTestCase
     public static function invalidExclusiveRangeDataProvider(): iterable
     {
         return [
-            'Too large number 1' => [2, 'Value for property must be smaller than 1'],
-            'Too large number 2' => [1, 'Value for property must be smaller than 1'],
-            'Too small number 1' => [-1, 'Value for property must be larger than -1'],
-            'Too small number 2' => [-2, 'Value for property must be larger than -1'],
+            'Too large number 1' => [2, 'Value for property must be smaller than 1', 'exclusiveMaximum'],
+            'Too large number 2' => [1, 'Value for property must be smaller than 1', 'exclusiveMaximum'],
+            'Too small number 1' => [-1, 'Value for property must be larger than -1', 'exclusiveMinimum'],
+            'Too small number 2' => [-2, 'Value for property must be larger than -1', 'exclusiveMinimum'],
         ];
     }
 }

--- a/tests/Objects/NumberPropertyTest.php
+++ b/tests/Objects/NumberPropertyTest.php
@@ -72,7 +72,7 @@ class NumberPropertyTest extends AbstractNumericPropertyTestCase
             'Null' => [null],
         ];
     }
-    
+
     /**
      * @throws FileSystemException
      * @throws RenderException
@@ -178,10 +178,10 @@ class NumberPropertyTest extends AbstractNumericPropertyTestCase
     public static function invalidRangeDataProvider(): iterable
     {
         return [
-            'Too large number int' => [2, 'Value for property must not be larger than 1.6'],
-            'Too large number float' => [1.7, 'Value for property must not be larger than 1.6'],
-            'Too small number int' => [-2, 'Value for property must not be smaller than -1.6'],
-            'Too small number float' => [-1.7, 'Value for property must not be smaller than -1.6'],
+            'Too large number int' => [2, 'Value for property must not be larger than 1.6', 'maximum'],
+            'Too large number float' => [1.7, 'Value for property must not be larger than 1.6', 'maximum'],
+            'Too small number int' => [-2, 'Value for property must not be smaller than -1.6', 'minimum'],
+            'Too small number float' => [-1.7, 'Value for property must not be smaller than -1.6', 'minimum'],
         ];
     }
     #[\Override]
@@ -202,12 +202,12 @@ class NumberPropertyTest extends AbstractNumericPropertyTestCase
     public static function invalidExclusiveRangeDataProvider(): iterable
     {
         return [
-            'Too large number int' => [2, 'Value for property must be smaller than 1.6'],
-            'Too large number float 1' => [1.6, 'Value for property must be smaller than 1.6'],
-            'Too large number float 2' => [1.9, 'Value for property must be smaller than 1.6'],
-            'Too small number int' => [-2, 'Value for property must be larger than -1.6'],
-            'Too small number float 1' => [-1.6, 'Value for property must be larger than -1.6'],
-            'Too small number float 2' => [-1.9, 'Value for property must be larger than -1.6'],
+            'Too large number int' => [2, 'Value for property must be smaller than 1.6', 'exclusiveMaximum'],
+            'Too large number float 1' => [1.6, 'Value for property must be smaller than 1.6', 'exclusiveMaximum'],
+            'Too large number float 2' => [1.9, 'Value for property must be smaller than 1.6', 'exclusiveMaximum'],
+            'Too small number int' => [-2, 'Value for property must be larger than -1.6', 'exclusiveMinimum'],
+            'Too small number float 1' => [-1.6, 'Value for property must be larger than -1.6', 'exclusiveMinimum'],
+            'Too small number float 2' => [-1.9, 'Value for property must be larger than -1.6', 'exclusiveMinimum'],
         ];
     }
 }

--- a/tests/Objects/ObjectPropertyTest.php
+++ b/tests/Objects/ObjectPropertyTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace PHPModelGenerator\Tests\Objects;
 
 use PHPModelGenerator\Exception\FileSystemException;
+use PHPModelGenerator\Exception\Object\InvalidInstanceOfException;
 use PHPModelGenerator\Exception\ValidationException;
 use PHPModelGenerator\Exception\RenderException;
 use PHPModelGenerator\Exception\SchemaException;
@@ -88,14 +89,18 @@ class ObjectPropertyTest extends AbstractPHPModelGeneratorTestCase
      */
     public function testInvalidPropertyObjectClassThrowsAnException(): void
     {
-        $this->expectException(ValidationException::class);
-        $this->expectExceptionMessageMatches(
-            '/Invalid class for property. Requires ObjectPropertyTest_.*, got stdClass/',
-        );
-
         $className = $this->generateClassFromFile('ObjectProperty.json');
 
-        new $className(['property' => new stdClass()]);
+        try {
+            new $className(['property' => new stdClass()]);
+            $this->fail('Expected InvalidInstanceOfException');
+        } catch (InvalidInstanceOfException $exception) {
+            $this->assertMatchesRegularExpression(
+                '/Invalid class for property. Requires ObjectPropertyTest_.*, got stdClass/',
+                $exception->getMessage(),
+            );
+            $this->assertSame('/properties/property/type', $exception->getJsonPointer()->pointer);
+        }
     }
 
     /**
@@ -104,7 +109,7 @@ class ObjectPropertyTest extends AbstractPHPModelGeneratorTestCase
      * @throws SchemaException
      */
     #[DataProvider('validInputProviderObjectLevelValidation')]
-    public function testObjectLevelValidationApplyForNestedObjectsWithValidInput(?array $input, string $typeCheck):void
+    public function testObjectLevelValidationApplyForNestedObjectsWithValidInput(?array $input, string $typeCheck): void
     {
         $className = $this->generateClassFromFile('ObjectLevelValidation.json');
 
@@ -124,9 +129,15 @@ class ObjectPropertyTest extends AbstractPHPModelGeneratorTestCase
         return [
             'Null' => [null, 'null'],
             'Required property, one custom property' => [['name' => 'Hannes', 'country' => 'Germany'], 'object'],
-            'Required property, two custom property' => [['name' => 'Hannes', 'country' => 'Germany', 'alive' => true], 'object'],
+            'Required property, two custom property' => [
+                ['name' => 'Hannes', 'country' => 'Germany', 'alive' => true],
+                'object',
+            ],
             'Required property, one defined property' => [['name' => 'Hannes', 'age' => 42], 'object'],
-            'Required property, one defined property, one custom property' => [['name' => 'Hannes', 'age' => 42, 'alive' => true], 'object'],
+            'Required property, one defined property, one custom property' => [
+                ['name' => 'Hannes', 'age' => 42, 'alive' => true],
+                'object',
+            ],
         ];
     }
 

--- a/tests/Objects/RequiredPropertyTest.php
+++ b/tests/Objects/RequiredPropertyTest.php
@@ -4,9 +4,11 @@ declare(strict_types=1);
 
 namespace PHPModelGenerator\Tests\Objects;
 
+use PHPModelGenerator\Exception\ComposedValue\AllOfException;
 use PHPModelGenerator\Exception\ErrorRegistryException;
 use PHPModelGenerator\Exception\FileSystemException;
-use PHPModelGenerator\Exception\ValidationException;
+use PHPModelGenerator\Exception\Object\NestedObjectException;
+use PHPModelGenerator\Exception\Object\RequiredValueException;
 use PHPModelGenerator\Exception\RenderException;
 use PHPModelGenerator\Exception\SchemaException;
 use PHPModelGenerator\Model\GeneratorConfiguration;
@@ -150,5 +152,115 @@ class RequiredPropertyTest extends AbstractPHPModelGeneratorTestCase
                 'RequiredReferencePropertyInComposition' => ['RequiredReferencePropertyInComposition.json'],
             ],
         );
+    }
+
+    public function testRequiredValueExceptionCarriesPointer(): void
+    {
+        $className = $this->generateClassFromFile(
+            'RequiredStringProperty.json',
+            (new GeneratorConfiguration())->setCollectErrors(false),
+        );
+
+        try {
+            new $className([]);
+            $this->fail('Expected RequiredValueException');
+        } catch (RequiredValueException $exception) {
+            // The required keyword is on the parent object schema, not the property schema.
+            $this->assertSame('/required', $exception->getJsonPointer()->pointer);
+        }
+    }
+
+    public function testRequiredInAllOfBranchCarriesPointer(): void
+    {
+        // Property and required are both declared in the same allOf branch.
+        // The inner RequiredValueException must point to that branch's required keyword.
+        $className = $this->generateClassFromFile(
+            'RequiredPropertyInAllOfBranch.json',
+            (new GeneratorConfiguration())->setCollectErrors(true),
+        );
+
+        try {
+            new $className([]);
+            $this->fail('Expected ErrorRegistryException');
+        } catch (ErrorRegistryException $registryException) {
+            /** @var AllOfException $allOfException */
+            $allOfException = $registryException->getErrors()[0];
+            $this->assertInstanceOf(AllOfException::class, $allOfException);
+
+            /** @var RequiredValueException $requiredError */
+            $requiredError = $allOfException->getCompositionErrorCollection()[0]->getErrors()[0];
+            $this->assertInstanceOf(RequiredValueException::class, $requiredError);
+            $this->assertSame('/allOf/0/required', $requiredError->getJsonPointer()->pointer);
+        }
+    }
+
+    public function testRequiredCrossAllOfBranchesCarriesPointer(): void
+    {
+        // Property is defined in allOf branch 0 (optional there). Required is in allOf branch 1.
+        // The inner RequiredValueException must point to branch 1's required keyword.
+        $className = $this->generateClassFromFile(
+            'RequiredPropertyCrossAllOfBranches.json',
+            (new GeneratorConfiguration())->setCollectErrors(true),
+        );
+
+        try {
+            new $className([]);
+            $this->fail('Expected ErrorRegistryException');
+        } catch (ErrorRegistryException $registryException) {
+            /** @var AllOfException $allOfException */
+            $allOfException = $registryException->getErrors()[0];
+            $this->assertInstanceOf(AllOfException::class, $allOfException);
+
+            // Branch 0 succeeds (name is optional there); branch 1 fails (name is required).
+            $this->assertEmpty($allOfException->getCompositionErrorCollection()[0]->getErrors());
+
+            /** @var RequiredValueException $requiredError */
+            $requiredError = $allOfException->getCompositionErrorCollection()[1]->getErrors()[0];
+            $this->assertInstanceOf(RequiredValueException::class, $requiredError);
+            $this->assertSame('/allOf/1/required', $requiredError->getJsonPointer()->pointer);
+        }
+    }
+
+    public function testNestedObjectRequiredCarriesPointer(): void
+    {
+        // Required is declared on the nested object schema, not the root.
+        // The ObjectInstantiationDecorator wraps the inner RequiredValueException in a
+        // NestedObjectException; unwrap it to assert the inner exception's pointer.
+        $className = $this->generateClassFromFile(
+            'RequiredNestedObjectProperty.json',
+            (new GeneratorConfiguration())->setCollectErrors(false),
+        );
+
+        try {
+            // Provide address so the nested object is instantiated, but omit 'street'.
+            new $className(['address' => []]);
+            $this->fail('Expected NestedObjectException');
+        } catch (NestedObjectException $exception) {
+            $inner = $exception->getNestedException();
+            $this->assertInstanceOf(RequiredValueException::class, $inner);
+            /** @var RequiredValueException $inner */
+            $this->assertSame('/properties/address/required', $inner->getJsonPointer()->pointer);
+        }
+    }
+
+    public function testTrueSchemaPropertyRequiredInNestedObjectCarriesPointer(): void
+    {
+        // A "property": true schema inside a nested object, combined with required,
+        // must still compute the correct required pointer for the nested object.
+        // The NestedObjectException must wrap a RequiredValueException with the nested pointer.
+        $className = $this->generateClassFromFile(
+            'RequiredTruePropertyInNestedObject.json',
+            (new GeneratorConfiguration())->setCollectErrors(false),
+        );
+
+        try {
+            new $className(['address' => []]);
+            $this->fail('Expected NestedObjectException');
+        } catch (NestedObjectException $exception) {
+            $inner = $exception->getNestedException();
+            $this->assertInstanceOf(RequiredValueException::class, $inner);
+            /** @var RequiredValueException $inner */
+            $this->assertSame('/properties/address/required', $inner->getJsonPointer()->pointer);
+        }
     }
 }

--- a/tests/Objects/StringPropertyTest.php
+++ b/tests/Objects/StringPropertyTest.php
@@ -8,6 +8,7 @@ use PHPModelGenerator\Exception\ErrorRegistryException;
 use PHPModelGenerator\Exception\FileSystemException;
 use PHPModelGenerator\Exception\RenderException;
 use PHPModelGenerator\Exception\SchemaException;
+use PHPModelGenerator\Exception\ValidationException;
 use PHPModelGenerator\Format\FormatValidatorFromRegEx;
 use PHPModelGenerator\Model\GeneratorConfiguration;
 use PHPModelGenerator\Tests\AbstractPHPModelGeneratorTestCase;
@@ -137,12 +138,23 @@ class StringPropertyTest extends AbstractPHPModelGeneratorTestCase
         GeneratorConfiguration $configuration,
         string $propertyValue,
         string $exceptionMessage,
+        string $expectedPointer,
     ): void {
-        $this->expectValidationError($configuration, $exceptionMessage);
-
         $className = $this->generateClassFromFile('StringPropertyLengthValidation.json', $configuration);
 
-        new $className(['property' => $propertyValue]);
+        try {
+            new $className(['property' => $propertyValue]);
+            $this->fail('Expected exception for invalid string length');
+        } catch (ErrorRegistryException | ValidationException $exception) {
+            $this->assertSame($exceptionMessage, $exception->getMessage());
+
+            $innerException = $exception instanceof ErrorRegistryException
+                ? $exception->getErrors()[0]
+                : $exception;
+
+            $this->assertInstanceOf(ValidationException::class, $innerException);
+            $this->assertSame($expectedPointer, $innerException->getJsonPointer()->pointer);
+        }
     }
 
     public static function invalidStringLengthDataProvider(): array
@@ -150,9 +162,21 @@ class StringPropertyTest extends AbstractPHPModelGeneratorTestCase
         return self::combineDataProvider(
             self::validationMethodDataProvider(),
             [
-                'Empty string' => ['', 'Value for property must not be shorter than 2'],
-                'Too short string' => ['1', 'Value for property must not be shorter than 2'],
-                'Too long string' => ['Some Text', 'Value for property must not be longer than 8']
+                'Empty string' => [
+                    '',
+                    'Value for property must not be shorter than 2',
+                    '/properties/property/minLength',
+                ],
+                'Too short string' => [
+                    '1',
+                    'Value for property must not be shorter than 2',
+                    '/properties/property/minLength',
+                ],
+                'Too long string' => [
+                    'Some Text',
+                    'Value for property must not be longer than 8',
+                    '/properties/property/maxLength',
+                ],
             ],
         );
     }

--- a/tests/PostProcessor/AdditionalPropertiesAccessorPostProcessorTest.php
+++ b/tests/PostProcessor/AdditionalPropertiesAccessorPostProcessorTest.php
@@ -231,10 +231,8 @@ class AdditionalPropertiesAccessorPostProcessorTest extends AbstractPHPModelGene
         string $expectedExceptionMessage,
         string $action,
         array $items,
+        string $expectedPointer,
     ): void {
-        $this->expectException($expectedException);
-        $this->expectExceptionMessage($expectedExceptionMessage);
-
         $this->addPostProcessor(true);
 
         $className = $this->generateClassFromFile(
@@ -245,10 +243,17 @@ class AdditionalPropertiesAccessorPostProcessorTest extends AbstractPHPModelGene
         $object = new $className(['property1' => '  Hello  ', 'property2' => 'World']);
         $accessor = $object->additionalProperties();
 
-        foreach ($items as $property => $value) {
-            $action === 'remove'
-                ? $accessor->remove($value)
-                : $accessor->set($property, $value);
+        try {
+            foreach ($items as $property => $value) {
+                $action === 'remove'
+                    ? $accessor->remove($value)
+                    : $accessor->set($property, $value);
+            }
+            $this->fail("Expected $expectedException");
+        } catch (\Throwable $exception) {
+            $this->assertInstanceOf($expectedException, $exception);
+            $this->assertStringContainsString($expectedExceptionMessage, $exception->getMessage());
+            $this->assertSame($expectedPointer, $exception->getJsonPointer()->pointer);
         }
     }
 
@@ -260,32 +265,61 @@ class AdditionalPropertiesAccessorPostProcessorTest extends AbstractPHPModelGene
                 "Couldn't add regular property name as additional property to object ",
                 'add',
                 ['name' => 'Hannes'],
+                '/properties/name',
             ],
             'min properties violation' => [
                 MinPropertiesException::class,
                 'must not contain less than 2 properties',
                 'remove',
-                ['property1']
+                ['property1'],
+                '/minProperties',
             ],
             'max properties violation' => [
                 MaxPropertiesException::class,
                 'must not contain more than 4 properties',
                 'add',
-                ['property3' => 'Bye', 'property4' => 'Ciao', 'property5' => 'fails']
+                ['property3' => 'Bye', 'property4' => 'Ciao', 'property5' => 'fails'],
+                '/maxProperties',
             ],
             'Invalid property name' => [
                 InvalidPropertyNamesException::class,
                 "contains properties with invalid names",
                 'add',
-                ['property name with spaces' => 'should fail']
+                ['property name with spaces' => 'should fail'],
+                '/propertyNames',
             ],
             'Invalid property value' => [
                 InvalidAdditionalPropertiesException::class,
                 "Value for additional property must not be longer than 15",
                 'add',
-                ['property2' => 'My much too long property value will fail the validation']
+                ['property2' => 'My much too long property value will fail the validation'],
+                '/additionalProperties',
             ],
         ];
+    }
+
+    public function testRegularPropertyMergedFromMultipleBranchesReportsFirstDeclaredPointer(): void
+    {
+        // 'name' is declared in two allOf branches (no root-level declaration) and merged into
+        // a single property carrying one #[JsonPointer] attribute per declaration site. The
+        // collision exception must report one of those real locations, not an arbitrary value
+        // derived from whichever JsonSchema instance the merged property happens to carry.
+        $this->addPostProcessor(true);
+
+        $className = $this->generateClassFromFile(
+            'AdditionalPropertiesMultiBranchProperty.json',
+            (new GeneratorConfiguration())->setImmutable(false)->setCollectErrors(false),
+        );
+
+        $object = new $className(['name' => 'Hannes']);
+        $accessor = $object->additionalProperties();
+
+        try {
+            $accessor->set('name', 'Other');
+            $this->fail('Expected RegularPropertyAsAdditionalPropertyException');
+        } catch (RegularPropertyAsAdditionalPropertyException $exception) {
+            $this->assertSame('/allOf/0/properties/name', $exception->getJsonPointer()->pointer);
+        }
     }
 
     public function testMinPropertiesIsEnforcedWhenRemovingAPatternPropertyKey(): void

--- a/tests/Schema/AdditionalPropertiesAccessorPostProcessorTest/AdditionalPropertiesMultiBranchProperty.json
+++ b/tests/Schema/AdditionalPropertiesAccessorPostProcessorTest/AdditionalPropertiesMultiBranchProperty.json
@@ -1,0 +1,22 @@
+{
+  "type": "object",
+  "allOf": [
+    {
+      "properties": {
+        "name": {
+          "type": "string"
+        }
+      }
+    },
+    {
+      "properties": {
+        "name": {
+          "minLength": 1
+        }
+      }
+    }
+  ],
+  "additionalProperties": {
+    "type": "string"
+  }
+}

--- a/tests/Schema/PatternPropertiesTest/ForbiddenPatternProperty.json
+++ b/tests/Schema/PatternPropertiesTest/ForbiddenPatternProperty.json
@@ -1,0 +1,7 @@
+{
+  "$id": "ForbiddenPatternProperty",
+  "type": "object",
+  "patternProperties": {
+    "^S~/": false
+  }
+}

--- a/tests/Schema/RequiredPropertyTest/RequiredNestedObjectProperty.json
+++ b/tests/Schema/RequiredPropertyTest/RequiredNestedObjectProperty.json
@@ -1,0 +1,19 @@
+{
+  "type": "object",
+  "properties": {
+    "address": {
+      "type": "object",
+      "properties": {
+        "street": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "street"
+      ]
+    }
+  },
+  "required": [
+    "address"
+  ]
+}

--- a/tests/Schema/RequiredPropertyTest/RequiredPropertyCrossAllOfBranches.json
+++ b/tests/Schema/RequiredPropertyTest/RequiredPropertyCrossAllOfBranches.json
@@ -1,0 +1,16 @@
+{
+  "allOf": [
+    {
+      "properties": {
+        "name": {
+          "type": "string"
+        }
+      }
+    },
+    {
+      "required": [
+        "name"
+      ]
+    }
+  ]
+}

--- a/tests/Schema/RequiredPropertyTest/RequiredPropertyInAllOfBranch.json
+++ b/tests/Schema/RequiredPropertyTest/RequiredPropertyInAllOfBranch.json
@@ -1,0 +1,14 @@
+{
+  "allOf": [
+    {
+      "properties": {
+        "name": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "name"
+      ]
+    }
+  ]
+}

--- a/tests/Schema/RequiredPropertyTest/RequiredTruePropertyInNestedObject.json
+++ b/tests/Schema/RequiredPropertyTest/RequiredTruePropertyInNestedObject.json
@@ -1,0 +1,17 @@
+{
+  "type": "object",
+  "properties": {
+    "address": {
+      "type": "object",
+      "properties": {
+        "street": true
+      },
+      "required": [
+        "street"
+      ]
+    }
+  },
+  "required": [
+    "address"
+  ]
+}


### PR DESCRIPTION
## Summary

- Every \`ValidationException\` now carries \`getJsonPointer()\` (via the production library) identifying the schema keyword that rejected the value — e.g. \`/properties/age/minimum\`, \`/required\`, \`/patternProperties/^S~0~1\`
- All validator factories thread the pointer from \`JsonSchema::getPointer()\` through \`->withJsonPointer()\` on each constructed validator
- \`AbstractPropertyValidator::withJsonPointer()\` forwards resolution to its clone, fixing a regression where recursive \`\$ref\` schemas silently lost validators (the SchemaDefinition resolution chain held the original; the clone was never resolved)
- \`FilterValidator\` overrides \`withJsonPointer()\` to propagate the pointer to its embedded \`filterValueValidator\`
- \`AdditionalPropertiesAccessorPostProcessor\` resolves the primary pointer from the synthesised \`#[JsonPointer]\` attribute on each property, using the new \`PhpAttribute::getArguments()\` getter
- Documentation updated with concise pointer docs and a usage example
- All standalone pointer-assertion tests merged into their sibling validation tests; data providers extended with expected pointer columns

## Depends on

- wol-soft/php-json-schema-model-generator-production#18 (exception constructor signature change)

## Test plan

- [x] All 2756 tests pass
- [x] No phpcs violations in changed files

🤖 Generated with [Claude Code](https://claude.ai/claude-code)