### PR TITLE
Remove ext-json as a requirement from documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Simple example from a PHP application: you define and document an API with swagg
 ## Requirements ##
 
 - Requires at least PHP 8.4
-- Requires the PHP extensions ext-json and ext-mbstring
+- Requires the PHP extension ext-mbstring
 
 ## Installation ##
 


### PR DESCRIPTION
The ext-json extension has been bundled with PHP since version 7.0.
Since this project requires PHP 8.4, explicitly requiring ext-json is unnecessary.

Co-Authored-By: Claude Haiku 4.5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session