### PR TITLE
Add line/column location reporting to SchemaException

### DIFF
--- a/docs/source/gettingStarted.rst
+++ b/docs/source/gettingStarted.rst
@@ -32,6 +32,19 @@ RecursiveDirectoryProvider  Fetches all *.json files from the given source direc
 OpenAPIv3Provider           Fetches all objects defined in the #/components/schemas section of an Open API v3 spec file
 =========================== ===========
 
+The built-in providers pass the raw, undecoded text of each schema file into the ``JsonSchema``
+objects they yield. This is what allows a `SchemaException <#schema-errors>`__ raised while
+processing that schema to report the exact line and column of the problem. If you implement a
+custom ``SchemaProviderInterface``, you can opt into the same behaviour by passing your schema's
+raw source text as the optional fourth constructor argument when you create a ``JsonSchema``:
+
+.. code-block:: php
+
+    new JsonSchema($file, $decodedJson, rawSource: $rawFileContents);
+
+Omitting the raw source is safe — location reporting is simply skipped and ``SchemaException``
+messages fall back to naming only the file.
+
 The second parameter must point to an existing and empty directory (you may use the *generateModelDirectory* helper method to create your destination directory). This directory will contain the generated PHP classes after the generator is finished.
 
 As an optional parameter you can set up a *GeneratorConfiguration* object to configure your Generator and/or use the method *generateModelDirectory* to generate your model directory (will generate the directory if it doesn't exist; if it exists, all contained files and folders will be removed for a clean generation process):
@@ -49,6 +62,42 @@ As an optional parameter you can set up a *GeneratorConfiguration* object to con
         ->generateModels(new RecursiveDirectoryProvider(__DIR__ . '/schema'), __DIR__ . '/result');
 
 The generator will check the given source directory recursive and convert all found \*.json files to models. All JSON-Schema files inside the source directory must provide a schema of an object.
+
+Schema errors
+^^^^^^^^^^^^^
+
+If a schema file can't be parsed as JSON, or is valid JSON but contradicts itself (e.g. an
+``allOf`` composition requiring incompatible types for the same property), the generator throws a
+**PHPModelGenerator\\Exception\\SchemaException** while processing that file. This is a
+generation-time error about the schema itself, distinct from the runtime
+``ValidationException``/``ErrorRegistryException`` thrown by generated model classes when they're
+given bad *data* (see `Collect errors vs. early return <#collect-errors-vs-early-return>`__).
+
+Whenever the location of the problem can be determined, ``getMessage()`` includes the line and
+column, and the same information is available as structured accessors:
+
+.. code-block:: php
+
+    public function getSchemaFile(): ?string;   // the JSON schema file the problem was found in
+    public function getSourceLine(): ?int;      // 1-indexed line, or null if unresolved
+    public function getSourceColumn(): ?int;    // 1-indexed column, or null if unresolved
+
+.. code-block:: php
+
+    try {
+        (new Generator())->generateModels(new RecursiveDirectoryProvider(__DIR__ . '/schema'), __DIR__ . '/result');
+    } catch (\PHPModelGenerator\Exception\SchemaException $e) {
+        $e->getMessage();     // e.g. 'Invalid JSON-Schema file schema/Person.json at line 4, column 12'
+        $e->getSchemaFile();  // 'schema/Person.json'
+        $e->getSourceLine();  // 4
+        $e->getSourceColumn(); // 12
+    }
+
+The accessors return ``null`` when a location can't be determined — for example when the schema
+file couldn't be read at all, or when a custom ``SchemaProviderInterface`` doesn't supply the raw
+source text needed to locate the problem (see the note on custom providers above). A missing
+location never prevents the exception from being thrown; it only means the message names the file
+without a line and column.
 
 Default interface of configured classes
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/src/Draft/Modifier/DefaultValueModifier.php
+++ b/src/Draft/Modifier/DefaultValueModifier.php
@@ -71,6 +71,7 @@ class DefaultValueModifier implements ModifierInterface
                 $property->getName(),
                 $propertySchema->getFile(),
             ),
+            $propertySchema,
         );
     }
 

--- a/src/Exception/SchemaException.php
+++ b/src/Exception/SchemaException.php
@@ -4,11 +4,90 @@ declare(strict_types=1);
 
 namespace PHPModelGenerator\Exception;
 
-/**
- * Class SchemaException
- *
- * @package PHPModelGenerator\Exception
- */
+use PHPModelGenerator\Model\SchemaDefinition\JsonSchema;
+use PHPModelGenerator\Utils\Json\JsonPointerLocator;
+use PHPModelGenerator\Utils\Json\JsonSourcePosition;
+use PHPModelGenerator\Utils\Json\JsonSyntaxErrorLocator;
+use Throwable;
+
 class SchemaException extends PHPModelGeneratorException
 {
+    private ?string $schemaFile = null;
+    private ?int $sourceLine = null;
+    private ?int $sourceColumn = null;
+
+    /**
+     * When $jsonSchema is provided, getSchemaFile() is populated from it regardless of raw source availability.
+     * getSourceLine()/getSourceColumn() (and the "at line X, column Y" suffix on the message) additionally require
+     * $jsonSchema to carry raw source text and its pointer to resolve against that text; when either is missing,
+     * those two accessors stay null and the message is left unchanged - resolution never throws.
+     */
+    public function __construct(
+        string $message,
+        ?JsonSchema $jsonSchema = null,
+        int $code = 0,
+        ?Throwable $previous = null,
+    ) {
+        $position = null;
+
+        if ($jsonSchema !== null) {
+            $this->schemaFile = $jsonSchema->getFile();
+            $rawSource = $jsonSchema->getRawSource();
+
+            if ($rawSource !== null) {
+                $position = JsonPointerLocator::locate($rawSource, $jsonSchema->getPointer());
+            }
+        }
+
+        parent::__construct(self::appendLocation($message, $position), $code, $previous);
+
+        $this->sourceLine = $position?->line;
+        $this->sourceColumn = $position?->column;
+    }
+
+    /**
+     * Named constructor for the "the schema file isn't valid JSON at all" case, where json_last_error() gives no
+     * position of its own - $rawSource is scanned with JsonSyntaxErrorLocator to find one.
+     */
+    public static function invalidJson(string $file, string $rawSource): self
+    {
+        $position = JsonSyntaxErrorLocator::locate($rawSource);
+
+        $exception = new self(self::appendLocation("Invalid JSON-Schema file $file", $position));
+        $exception->schemaFile = $file;
+        $exception->sourceLine = $position?->line;
+        $exception->sourceColumn = $position?->column;
+
+        return $exception;
+    }
+
+    /**
+     * Falls back to the wrapped previous exception's location when this exception carries none of its own - a
+     * generic wrapper (e.g. "Unresolved Reference ..." around a caught exception) must not hide the more specific
+     * location a nested SchemaException already resolved.
+     */
+    public function getSchemaFile(): ?string
+    {
+        return $this->schemaFile ?? $this->previousSchemaException()?->getSchemaFile();
+    }
+
+    public function getSourceLine(): ?int
+    {
+        return $this->sourceLine ?? $this->previousSchemaException()?->getSourceLine();
+    }
+
+    public function getSourceColumn(): ?int
+    {
+        return $this->sourceColumn ?? $this->previousSchemaException()?->getSourceColumn();
+    }
+
+    private function previousSchemaException(): ?self
+    {
+        return $this->getPrevious() instanceof self ? $this->getPrevious() : null;
+    }
+
+    private static function appendLocation(string $message, ?JsonSourcePosition $position): string
+    {
+        return $position === null ? $message : "$message at line {$position->line}, column {$position->column}";
+    }
 }

--- a/src/Model/Schema.php
+++ b/src/Model/Schema.php
@@ -24,11 +24,6 @@ use PHPModelGenerator\PropertyProcessor\Decorator\SchemaNamespaceTransferDecorat
 use PHPModelGenerator\SchemaProcessor\Hook\SchemaHookInterface;
 use PHPModelGenerator\Utils\PropertyMerger;
 
-/**
- * Class Schema
- *
- * @package PHPModelGenerator\Model
- */
 class Schema
 {
     use JsonSchemaTrait;
@@ -217,6 +212,7 @@ class Schema
                             $attribute,
                             $this->jsonSchema->getFile(),
                         ),
+                        $property->getJsonSchema(),
                     );
                 }
 

--- a/src/Model/SchemaDefinition/JsonSchema.php
+++ b/src/Model/SchemaDefinition/JsonSchema.php
@@ -8,11 +8,6 @@ use PHPModelGenerator\Exception\GeneratorException;
 use PHPModelGenerator\Exception\SchemaException;
 use PHPModelGenerator\Utils\ArrayHash;
 
-/**
- * Class JsonSchema
- *
- * @package PHPModelGenerator\Model\SchemaDefinition
- */
 class JsonSchema
 {
     private const array SCHEMA_SIGNATURE_RELEVANT_FIELDS = [
@@ -43,9 +38,16 @@ class JsonSchema
      * @param string $file the source file for the schema
      * @param array $json Decoded json schema
      * @param string $pointer The JSON pointer inside the $file leading to the schema provided in $json
+     * @param string|null $rawSource The raw, undecoded text of $file, if the provider retained it. Populating this
+     *                               enables SchemaException to report the line/column a validation error occurred
+     *                               at; providers that don't have the raw text on hand may omit it.
      */
-    public function __construct(private string $file, array $json, private string $pointer = '')
-    {
+    public function __construct(
+        private string $file,
+        array $json,
+        private string $pointer = '',
+        private ?string $rawSource = null,
+    ) {
         // wrap in an allOf to pass the processing to multiple handlers - ugly hack to be removed after rework
         if (
             isset($json['$ref']) &&
@@ -124,7 +126,7 @@ class JsonSchema
             $decodedPathSegment = self::decodePointer($pathSegment);
 
             if (!array_key_exists($decodedPathSegment, $jsonSchema->json)) {
-                throw new SchemaException("Unresolved path segment $pathSegment in file $this->file");
+                throw new SchemaException("Unresolved path segment $pathSegment in file $this->file", $jsonSchema);
             }
 
             $jsonSchema->json = $jsonSchema->json[$decodedPathSegment];
@@ -136,6 +138,11 @@ class JsonSchema
     public function getFile(): string
     {
         return $this->file;
+    }
+
+    public function getRawSource(): ?string
+    {
+        return $this->rawSource;
     }
 
     public function getPointer(): string

--- a/src/Model/Validator/Factory/Any/EnumValidatorFactory.php
+++ b/src/Model/Validator/Factory/Any/EnumValidatorFactory.php
@@ -41,6 +41,7 @@ class EnumValidatorFactory extends AbstractValidatorFactory
                     $property->getName(),
                     $propertySchema->getFile(),
                 ),
+                $propertySchema,
             );
         }
 
@@ -55,6 +56,7 @@ class EnumValidatorFactory extends AbstractValidatorFactory
                         $property->getName(),
                         $propertySchema->getFile(),
                     ),
+                    $propertySchema,
                 );
             }
         }

--- a/src/Model/Validator/Factory/Composition/AbstractCompositionValidatorFactory.php
+++ b/src/Model/Validator/Factory/Composition/AbstractCompositionValidatorFactory.php
@@ -104,12 +104,15 @@ abstract class AbstractCompositionValidatorFactory extends AbstractValidatorFact
                 is_array($branch)
                 && CompositionCompatibilityChecker::branchContainsFilter($branch)
             ) {
-                throw new SchemaException(sprintf(
-                    'A filter keyword inside a not composition branch is not supported'
-                        . ' for property %s in file %s.',
-                    $property->getName(),
-                    $property->getJsonSchema()->getFile(),
-                ), $property->getJsonSchema());
+                throw new SchemaException(
+                    sprintf(
+                        'A filter keyword inside a not composition branch is not supported'
+                            . ' for property %s in file %s.',
+                        $property->getName(),
+                        $property->getJsonSchema()->getFile(),
+                    ),
+                    $property->getJsonSchema(),
+                );
             }
             return;
         }
@@ -119,14 +122,17 @@ abstract class AbstractCompositionValidatorFactory extends AbstractValidatorFact
                 is_array($compositionElement)
                 && CompositionCompatibilityChecker::branchContainsFilter($compositionElement)
             ) {
-                throw new SchemaException(sprintf(
-                    'A filter keyword inside a %s composition branch is not supported'
-                        . ' for property %s in file %s (branch #%d).',
-                    $this->key,
-                    $property->getName(),
-                    $property->getJsonSchema()->getFile(),
-                    $index,
-                ), $property->getJsonSchema());
+                throw new SchemaException(
+                    sprintf(
+                        'A filter keyword inside a %s composition branch is not supported'
+                            . ' for property %s in file %s (branch #%d).',
+                        $this->key,
+                        $property->getName(),
+                        $property->getJsonSchema()->getFile(),
+                        $index,
+                    ),
+                    $property->getJsonSchema(),
+                );
             }
         }
     }
@@ -485,13 +491,16 @@ abstract class AbstractCompositionValidatorFactory extends AbstractValidatorFact
         )) === count($constrainingBranches);
 
         if (empty($nonNullNames) && !$allBranchesAllowNull) {
-            throw new SchemaException(sprintf(
-                "Property '%s' is defined with conflicting types in allOf composition branches"
-                    . ' (file %s). allOf requires all constraints to hold simultaneously,'
-                    . ' making this schema unsatisfiable.',
-                $property->getName(),
-                $property->getJsonSchema()->getFile(),
-            ), $property->getJsonSchema());
+            throw new SchemaException(
+                sprintf(
+                    "Property '%s' is defined with conflicting types in allOf composition branches"
+                        . ' (file %s). allOf requires all constraints to hold simultaneously,'
+                        . ' making this schema unsatisfiable.',
+                    $property->getName(),
+                    $property->getJsonSchema()->getFile(),
+                ),
+                $property->getJsonSchema(),
+            );
         }
 
         if (empty($nonNullNames)) {

--- a/src/Model/Validator/Factory/Composition/AbstractCompositionValidatorFactory.php
+++ b/src/Model/Validator/Factory/Composition/AbstractCompositionValidatorFactory.php
@@ -109,7 +109,7 @@ abstract class AbstractCompositionValidatorFactory extends AbstractValidatorFact
                         . ' for property %s in file %s.',
                     $property->getName(),
                     $property->getJsonSchema()->getFile(),
-                ));
+                ), $property->getJsonSchema());
             }
             return;
         }
@@ -126,7 +126,7 @@ abstract class AbstractCompositionValidatorFactory extends AbstractValidatorFact
                     $property->getName(),
                     $property->getJsonSchema()->getFile(),
                     $index,
-                ));
+                ), $property->getJsonSchema());
             }
         }
     }
@@ -491,7 +491,7 @@ abstract class AbstractCompositionValidatorFactory extends AbstractValidatorFact
                     . ' making this schema unsatisfiable.',
                 $property->getName(),
                 $property->getJsonSchema()->getFile(),
-            ));
+            ), $property->getJsonSchema());
         }
 
         if (empty($nonNullNames)) {

--- a/src/Model/Validator/Factory/Composition/IfValidatorFactory.php
+++ b/src/Model/Validator/Factory/Composition/IfValidatorFactory.php
@@ -76,13 +76,16 @@ class IfValidatorFactory
                 && is_array($json[$keyword])
                 && CompositionCompatibilityChecker::branchContainsFilter($json[$keyword])
             ) {
-                throw new SchemaException(sprintf(
-                    'A filter keyword inside an if/then/else composition branch is not supported'
-                        . ' for property %s in file %s (%s sub-schema).',
-                    $property->getName(),
-                    $property->getJsonSchema()->getFile(),
-                    $keyword,
-                ), $property->getJsonSchema());
+                throw new SchemaException(
+                    sprintf(
+                        'A filter keyword inside an if/then/else composition branch is not supported'
+                            . ' for property %s in file %s (%s sub-schema).',
+                        $property->getName(),
+                        $property->getJsonSchema()->getFile(),
+                        $keyword,
+                    ),
+                    $property->getJsonSchema(),
+                );
             }
         }
 
@@ -441,13 +444,16 @@ class IfValidatorFactory
             && empty(TypeIntersection::compute($parentNames, $elseTypes));
 
         if ($thenConflicts || $elseConflicts) {
-            throw new SchemaException(sprintf(
-                "Property '%s' has an if/then/else composition branch with a type incompatible"
-                    . " with the property's declared type (file %s)."
-                    . ' No value can satisfy both constraints.',
-                $property->getName(),
-                $property->getJsonSchema()->getFile(),
-            ), $property->getJsonSchema());
+            throw new SchemaException(
+                sprintf(
+                    "Property '%s' has an if/then/else composition branch with a type incompatible"
+                        . " with the property's declared type (file %s)."
+                        . ' No value can satisfy both constraints.',
+                    $property->getName(),
+                    $property->getJsonSchema()->getFile(),
+                ),
+                $property->getJsonSchema(),
+            );
         }
     }
 

--- a/src/Model/Validator/Factory/Composition/IfValidatorFactory.php
+++ b/src/Model/Validator/Factory/Composition/IfValidatorFactory.php
@@ -49,6 +49,7 @@ class IfValidatorFactory
                     $property->getName(),
                     $property->getJsonSchema()->getFile(),
                 ),
+                $property->getJsonSchema(),
             );
         }
 
@@ -81,7 +82,7 @@ class IfValidatorFactory
                     $property->getName(),
                     $property->getJsonSchema()->getFile(),
                     $keyword,
-                ));
+                ), $property->getJsonSchema());
             }
         }
 
@@ -298,6 +299,7 @@ class IfValidatorFactory
                         $property->getName(),
                         $property->getJsonSchema()->getFile(),
                     ),
+                    $property->getJsonSchema(),
                 );
             }
 
@@ -312,6 +314,7 @@ class IfValidatorFactory
                         $property->getName(),
                         $property->getJsonSchema()->getFile(),
                     ),
+                    $property->getJsonSchema(),
                 );
             }
 
@@ -444,7 +447,7 @@ class IfValidatorFactory
                     . ' No value can satisfy both constraints.',
                 $property->getName(),
                 $property->getJsonSchema()->getFile(),
-            ));
+            ), $property->getJsonSchema());
         }
     }
 

--- a/src/Model/Validator/Factory/Object/PatternPropertiesValidatorFactory.php
+++ b/src/Model/Validator/Factory/Object/PatternPropertiesValidatorFactory.php
@@ -36,6 +36,7 @@ class PatternPropertiesValidatorFactory extends AbstractValidatorFactory
             if (@preg_match("/$escapedPattern/", '') === false) {
                 throw new SchemaException(
                     "Invalid pattern '$pattern' for pattern property in file {$propertySchema->getFile()}",
+                    $propertySchema,
                 );
             }
 

--- a/src/Model/Validator/Factory/Object/PropertiesValidatorFactory.php
+++ b/src/Model/Validator/Factory/Object/PropertiesValidatorFactory.php
@@ -51,6 +51,7 @@ class PropertiesValidatorFactory extends AbstractValidatorFactory
                             $propertyName,
                             $propertySchema->getFile(),
                         ),
+                        $propertySchema,
                     );
                 }
 
@@ -61,6 +62,7 @@ class PropertiesValidatorFactory extends AbstractValidatorFactory
                             $propertyName,
                             $propertySchema->getFile(),
                         ),
+                        $propertySchema,
                     );
                 }
 

--- a/src/Model/Validator/Factory/SimplePropertyValidatorFactory.php
+++ b/src/Model/Validator/Factory/SimplePropertyValidatorFactory.php
@@ -52,6 +52,7 @@ abstract class SimplePropertyValidatorFactory extends AbstractValidatorFactory
                     $property->getName(),
                     $propertySchema->getFile(),
                 ),
+                $propertySchema,
             );
         }
 

--- a/src/Model/Validator/Factory/String/FormatValidatorFactory.php
+++ b/src/Model/Validator/Factory/String/FormatValidatorFactory.php
@@ -40,6 +40,7 @@ class FormatValidatorFactory extends AbstractValidatorFactory
                     $property->getName(),
                     $propertySchema->getFile(),
                 ),
+                $propertySchema,
             );
         }
 

--- a/src/Model/Validator/Factory/String/PatternPropertyValidatorFactory.php
+++ b/src/Model/Validator/Factory/String/PatternPropertyValidatorFactory.php
@@ -41,6 +41,7 @@ class PatternPropertyValidatorFactory extends AbstractValidatorFactory
                     $property->getName(),
                     $propertySchema->getFile(),
                 ),
+                $propertySchema,
             );
         }
 

--- a/src/Model/Validator/FilterValidator.php
+++ b/src/Model/Validator/FilterValidator.php
@@ -346,14 +346,17 @@ class FilterValidator extends PropertyTemplateValidator
             return; // Overlap exists; the filter can fire for at least some valid values.
         }
 
-        throw new SchemaException(sprintf(
-            'Filter %s on property %s in file %s can never be executed:'
-                . ' allOf type constraints (%s) exclude all input types accepted by the filter (%s)',
-            $this->filter->getToken(),
-            $property->getName(),
-            $property->getJsonSchema()->getFile(),
-            implode('|', $effectiveTypes),
-            implode('|', $acceptedTypes),
-        ), $property->getJsonSchema());
+        throw new SchemaException(
+            sprintf(
+                'Filter %s on property %s in file %s can never be executed:'
+                    . ' allOf type constraints (%s) exclude all input types accepted by the filter (%s)',
+                $this->filter->getToken(),
+                $property->getName(),
+                $property->getJsonSchema()->getFile(),
+                implode('|', $effectiveTypes),
+                implode('|', $acceptedTypes),
+            ),
+            $property->getJsonSchema(),
+        );
     }
 }

--- a/src/Model/Validator/FilterValidator.php
+++ b/src/Model/Validator/FilterValidator.php
@@ -17,11 +17,6 @@ use PHPModelGenerator\Utils\TypeCheck;
 use PHPModelGenerator\Utils\TypeConverter;
 use ReflectionException;
 
-/**
- * Class FilterValidator
- *
- * @package PHPModelGenerator\Model\Validator
- */
 class FilterValidator extends PropertyTemplateValidator
 {
     /**
@@ -199,7 +194,8 @@ class FilterValidator extends PropertyTemplateValidator
                     implode('|', array_merge($typeNames, $isNullable ? ['null'] : [])),
                     $property->getName(),
                     $property->getJsonSchema()->getFile(),
-                )
+                ),
+                $property->getJsonSchema(),
             );
         }
     }
@@ -235,7 +231,8 @@ class FilterValidator extends PropertyTemplateValidator
                         $transformingFilter->getToken(),
                         $property->getName(),
                         $property->getJsonSchema()->getFile(),
-                    )
+                    ),
+                    $property->getJsonSchema(),
                 );
             }
 
@@ -268,7 +265,8 @@ class FilterValidator extends PropertyTemplateValidator
                     $typeDisplay,
                     $property->getName(),
                     $property->getJsonSchema()->getFile(),
-                )
+                ),
+                $property->getJsonSchema(),
             );
         }
     }
@@ -356,6 +354,6 @@ class FilterValidator extends PropertyTemplateValidator
             $property->getJsonSchema()->getFile(),
             implode('|', $effectiveTypes),
             implode('|', $acceptedTypes),
-        ));
+        ), $property->getJsonSchema());
     }
 }

--- a/src/Model/Validator/PropertyNamesValidator.php
+++ b/src/Model/Validator/PropertyNamesValidator.php
@@ -14,11 +14,6 @@ use PHPModelGenerator\PropertyProcessor\PropertyFactory;
 use PHPModelGenerator\SchemaProcessor\SchemaProcessor;
 use PHPModelGenerator\Utils\RenderHelper;
 
-/**
- * Class PropertyNamesValidator
- *
- * @package PHPModelGenerator\Model\Validator
- */
 class PropertyNamesValidator extends PropertyTemplateValidator
 {
     /**
@@ -37,18 +32,24 @@ class PropertyNamesValidator extends PropertyTemplateValidator
             array_key_exists('const', $propertiesNames->getJson()) &&
             gettype($propertiesNames->getJson()['const']) !== 'string'
         ) {
-            throw new SchemaException("Invalid const property name in file {$propertiesNames->getFile()}");
+            throw new SchemaException(
+                "Invalid const property name in file {$propertiesNames->getFile()}",
+                $propertiesNames,
+            );
         }
 
         if (
             array_key_exists('type', $propertiesNames->getJson()) &&
             $propertiesNames->getJson()['type'] !== 'string'
         ) {
-            throw new SchemaException(sprintf(
-                "Invalid type '%s' for propertyNames schema in file %s",
-                $propertiesNames->getJson()['type'],
-                $propertiesNames->getFile(),
-            ));
+            throw new SchemaException(
+                sprintf(
+                    "Invalid type '%s' for propertyNames schema in file %s",
+                    $propertiesNames->getJson()['type'],
+                    $propertiesNames->getFile(),
+                ),
+                $propertiesNames,
+            );
         }
 
         // Property names are always strings; ensure the schema declares the type so that

--- a/src/PropertyProcessor/Filter/CompositionCompatibilityChecker.php
+++ b/src/PropertyProcessor/Filter/CompositionCompatibilityChecker.php
@@ -86,15 +86,18 @@ class CompositionCompatibilityChecker
                     // TODO: proper handling is deferred to a follow-up topic.
                     // Root-level composition branches cannot yet be split around the
                     // filter's transform boundary.
-                    throw new SchemaException(sprintf(
-                        'Composition %s in file %s constrains filtered subproperty %s'
-                            . ' (branch #%d) with output-type-space constraints;'
-                            . ' this combination is not yet supported.',
-                        $keyword,
-                        $this->property->getJsonSchema()->getFile(),
-                        $propertyName,
-                        $index,
-                    ), $this->property->getJsonSchema());
+                    throw new SchemaException(
+                        sprintf(
+                            'Composition %s in file %s constrains filtered subproperty %s'
+                                . ' (branch #%d) with output-type-space constraints;'
+                                . ' this combination is not yet supported.',
+                            $keyword,
+                            $this->property->getJsonSchema()->getFile(),
+                            $propertyName,
+                            $index,
+                        ),
+                        $this->property->getJsonSchema(),
+                    );
                 }
             }
         }
@@ -118,13 +121,16 @@ class CompositionCompatibilityChecker
 
             if ($space === TypeSpace::Output || $space === TypeSpace::Mixed) {
                 // TODO: see above.
-                throw new SchemaException(sprintf(
-                    'Composition %s in file %s constrains filtered subproperty %s'
-                        . ' with output-type-space constraints; this combination is not yet supported.',
-                    $keyword,
-                    $this->property->getJsonSchema()->getFile(),
-                    $propertyName,
-                ), $this->property->getJsonSchema());
+                throw new SchemaException(
+                    sprintf(
+                        'Composition %s in file %s constrains filtered subproperty %s'
+                            . ' with output-type-space constraints; this combination is not yet supported.',
+                        $keyword,
+                        $this->property->getJsonSchema()->getFile(),
+                        $propertyName,
+                    ),
+                    $this->property->getJsonSchema(),
+                );
             }
         }
     }
@@ -142,15 +148,18 @@ class CompositionCompatibilityChecker
 
         foreach ($branches as $index => $branch) {
             if ($this->classifier->classify($branch) === TypeSpace::Mixed) {
-                throw new SchemaException(sprintf(
-                    'Composition allOf under property %s in file %s cannot be resolved:'
-                        . ' branch #%d spans both input and output type-spaces;'
-                        . ' allOf branches must not contain constraints from both type-spaces'
-                        . ' when combined with a transforming filter.',
-                    $this->property->getName(),
-                    $this->property->getJsonSchema()->getFile(),
-                    $index,
-                ), $this->property->getJsonSchema());
+                throw new SchemaException(
+                    sprintf(
+                        'Composition allOf under property %s in file %s cannot be resolved:'
+                            . ' branch #%d spans both input and output type-spaces;'
+                            . ' allOf branches must not contain constraints from both type-spaces'
+                            . ' when combined with a transforming filter.',
+                        $this->property->getName(),
+                        $this->property->getJsonSchema()->getFile(),
+                        $index,
+                    ),
+                    $this->property->getJsonSchema(),
+                );
             }
         }
     }
@@ -173,16 +182,19 @@ class CompositionCompatibilityChecker
             $space = $this->classifier->classify($branch);
 
             if ($space === TypeSpace::Mixed) {
-                throw new SchemaException(sprintf(
-                    'Composition %s under property %s in file %s cannot be resolved:'
-                        . ' branch #%d spans both input and output type-spaces;'
-                        . ' branches must not contain constraints from both type-spaces'
-                        . ' when combined with a transforming filter.',
-                    $keyword,
-                    $this->property->getName(),
-                    $this->property->getJsonSchema()->getFile(),
-                    $index,
-                ), $this->property->getJsonSchema());
+                throw new SchemaException(
+                    sprintf(
+                        'Composition %s under property %s in file %s cannot be resolved:'
+                            . ' branch #%d spans both input and output type-spaces;'
+                            . ' branches must not contain constraints from both type-spaces'
+                            . ' when combined with a transforming filter.',
+                        $keyword,
+                        $this->property->getName(),
+                        $this->property->getJsonSchema()->getFile(),
+                        $index,
+                    ),
+                    $this->property->getJsonSchema(),
+                );
             }
 
             if ($space === TypeSpace::Input && $firstInputIndex === null) {
@@ -195,17 +207,20 @@ class CompositionCompatibilityChecker
         }
 
         if ($firstInputIndex !== null && $firstOutputIndex !== null) {
-            throw new SchemaException(sprintf(
-                'Composition %s under property %s in file %s cannot be resolved:'
-                    . ' branch #%d constrains input type-space but branch #%d constrains output type-space;'
-                    . ' %s branches must share a single type-space when combined with a transforming filter.',
-                $keyword,
-                $this->property->getName(),
-                $this->property->getJsonSchema()->getFile(),
-                $firstInputIndex,
-                $firstOutputIndex,
-                $keyword,
-            ), $this->property->getJsonSchema());
+            throw new SchemaException(
+                sprintf(
+                    'Composition %s under property %s in file %s cannot be resolved:'
+                        . ' branch #%d constrains input type-space but branch #%d constrains output type-space;'
+                        . ' %s branches must share a single type-space when combined with a transforming filter.',
+                    $keyword,
+                    $this->property->getName(),
+                    $this->property->getJsonSchema()->getFile(),
+                    $firstInputIndex,
+                    $firstOutputIndex,
+                    $keyword,
+                ),
+                $this->property->getJsonSchema(),
+            );
         }
     }
 
@@ -219,12 +234,15 @@ class CompositionCompatibilityChecker
         }
 
         if ($this->classifier->classify($innerSchema) === TypeSpace::Mixed) {
-            throw new SchemaException(sprintf(
-                'Composition not under property %s in file %s cannot be resolved:'
-                    . ' the inner schema spans both input and output type-spaces.',
-                $this->property->getName(),
-                $this->property->getJsonSchema()->getFile(),
-            ), $this->property->getJsonSchema());
+            throw new SchemaException(
+                sprintf(
+                    'Composition not under property %s in file %s cannot be resolved:'
+                        . ' the inner schema spans both input and output type-spaces.',
+                    $this->property->getName(),
+                    $this->property->getJsonSchema()->getFile(),
+                ),
+                $this->property->getJsonSchema(),
+            );
         }
     }
 
@@ -253,14 +271,17 @@ class CompositionCompatibilityChecker
         $hasMixed  = in_array(TypeSpace::Mixed, $subSchemaSpaces, true);
 
         if ($hasMixed || ($hasInput && $hasOutput)) {
-            throw new SchemaException(sprintf(
-                'Composition if/then/else under property %s in file %s cannot be resolved:'
-                    . ' sub-schemas span different type-spaces;'
-                    . ' if/then/else sub-schemas must share a single type-space'
-                    . ' when combined with a transforming filter.',
-                $this->property->getName(),
-                $this->property->getJsonSchema()->getFile(),
-            ), $this->property->getJsonSchema());
+            throw new SchemaException(
+                sprintf(
+                    'Composition if/then/else under property %s in file %s cannot be resolved:'
+                        . ' sub-schemas span different type-spaces;'
+                        . ' if/then/else sub-schemas must share a single type-space'
+                        . ' when combined with a transforming filter.',
+                    $this->property->getName(),
+                    $this->property->getJsonSchema()->getFile(),
+                ),
+                $this->property->getJsonSchema(),
+            );
         }
     }
 

--- a/src/PropertyProcessor/Filter/CompositionCompatibilityChecker.php
+++ b/src/PropertyProcessor/Filter/CompositionCompatibilityChecker.php
@@ -94,7 +94,7 @@ class CompositionCompatibilityChecker
                         $this->property->getJsonSchema()->getFile(),
                         $propertyName,
                         $index,
-                    ));
+                    ), $this->property->getJsonSchema());
                 }
             }
         }
@@ -124,7 +124,7 @@ class CompositionCompatibilityChecker
                     $keyword,
                     $this->property->getJsonSchema()->getFile(),
                     $propertyName,
-                ));
+                ), $this->property->getJsonSchema());
             }
         }
     }
@@ -150,7 +150,7 @@ class CompositionCompatibilityChecker
                     $this->property->getName(),
                     $this->property->getJsonSchema()->getFile(),
                     $index,
-                ));
+                ), $this->property->getJsonSchema());
             }
         }
     }
@@ -182,7 +182,7 @@ class CompositionCompatibilityChecker
                     $this->property->getName(),
                     $this->property->getJsonSchema()->getFile(),
                     $index,
-                ));
+                ), $this->property->getJsonSchema());
             }
 
             if ($space === TypeSpace::Input && $firstInputIndex === null) {
@@ -205,7 +205,7 @@ class CompositionCompatibilityChecker
                 $firstInputIndex,
                 $firstOutputIndex,
                 $keyword,
-            ));
+            ), $this->property->getJsonSchema());
         }
     }
 
@@ -224,7 +224,7 @@ class CompositionCompatibilityChecker
                     . ' the inner schema spans both input and output type-spaces.',
                 $this->property->getName(),
                 $this->property->getJsonSchema()->getFile(),
-            ));
+            ), $this->property->getJsonSchema());
         }
     }
 
@@ -260,7 +260,7 @@ class CompositionCompatibilityChecker
                     . ' when combined with a transforming filter.',
                 $this->property->getName(),
                 $this->property->getJsonSchema()->getFile(),
-            ));
+            ), $this->property->getJsonSchema());
         }
     }
 

--- a/src/PropertyProcessor/Filter/FilterProcessor.php
+++ b/src/PropertyProcessor/Filter/FilterProcessor.php
@@ -35,11 +35,6 @@ use PHPModelGenerator\Utils\RenderHelper;
 use PHPModelGenerator\Utils\TypeCheck;
 use ReflectionException;
 
-/**
- * Class FilterProcessor
- *
- * @package PHPModelGenerator\PropertyProcessor\Filter
- */
 class FilterProcessor
 {
     /**
@@ -91,7 +86,8 @@ class FilterProcessor
                         $filterToken,
                         $property->getName(),
                         $property->getJsonSchema()->getFile(),
-                    )
+                    ),
+                    $property->getJsonSchema(),
                 );
             }
 
@@ -106,7 +102,8 @@ class FilterProcessor
                             $property->getName(),
                             $property->getJsonSchema()->getFile(),
                             $exception->getMessage(),
-                        )
+                        ),
+                        $property->getJsonSchema(),
                     );
                 }
             }
@@ -120,7 +117,8 @@ class FilterProcessor
                             'Applying a transforming filter to the array property %s is not supported in file %s',
                             $property->getName(),
                             $property->getJsonSchema()->getFile(),
-                        )
+                        ),
+                        $property->getJsonSchema(),
                     );
                 }
                 if ($transformingFilter) {
@@ -129,7 +127,8 @@ class FilterProcessor
                             'Applying multiple transforming filters for property %s is not supported in file %s',
                             $property->getName(),
                             $property->getJsonSchema()->getFile(),
-                        )
+                        ),
+                        $property->getJsonSchema(),
                     );
                 }
             }

--- a/src/PropertyProcessor/PropertyFactory.php
+++ b/src/PropertyProcessor/PropertyFactory.php
@@ -34,11 +34,6 @@ use PHPModelGenerator\PropertyProcessor\Decorator\TypeHint\TypeHintDecorator;
 use PHPModelGenerator\SchemaProcessor\SchemaProcessor;
 use PHPModelGenerator\Utils\TypeConverter;
 
-/**
- * Class PropertyFactory
- *
- * @package PHPModelGenerator\PropertyProcessor
- */
 class PropertyFactory
 {
     /** @var Draft[] Keyed by draft class name */
@@ -231,6 +226,7 @@ class PropertyFactory
                     $propertyName,
                     $propertySchema->getFile(),
                 ),
+                $propertySchema,
             );
         }
 
@@ -369,12 +365,16 @@ class PropertyFactory
         } catch (Exception $exception) {
             throw new SchemaException(
                 "Unresolved Reference $reference in file {$propertySchema->getFile()}",
+                null,
                 0,
                 $exception,
             );
         }
 
-        throw new SchemaException("Unresolved Reference $reference in file {$propertySchema->getFile()}");
+        throw new SchemaException(
+            "Unresolved Reference $reference in file {$propertySchema->getFile()}",
+            $propertySchema,
+        );
     }
 
     /**
@@ -400,7 +400,8 @@ class PropertyFactory
                     'A referenced schema on base level must provide an object definition for property %s in file %s',
                     $propertyName,
                     $propertySchema->getFile(),
-                )
+                ),
+                $propertySchema,
             );
         }
 
@@ -674,7 +675,8 @@ class PropertyFactory
                 'Invalid property type %s in file %s',
                 $type,
                 $schema->getJsonSchema()->getFile(),
-            )
+            ),
+            $schema->getJsonSchema(),
         );
     }
 

--- a/src/SchemaProcessor/PostProcessor/EnumPostProcessor.php
+++ b/src/SchemaProcessor/PostProcessor/EnumPostProcessor.php
@@ -258,7 +258,7 @@ class EnumPostProcessor extends PostProcessor
                     "Can't apply enum filter to an already transformed value on property %s in file %s",
                     $property->getName(),
                     $property->getJsonSchema()->getFile(),
-                ));
+                ), $property->getJsonSchema());
             }
         }
     }
@@ -281,7 +281,8 @@ class EnumPostProcessor extends PostProcessor
                     $message,
                     $property->getName(),
                     $property->getJsonSchema()->getFile(),
-                )
+                ),
+                $property->getJsonSchema(),
             );
         };
 

--- a/src/SchemaProcessor/PostProcessor/EnumPostProcessor.php
+++ b/src/SchemaProcessor/PostProcessor/EnumPostProcessor.php
@@ -254,11 +254,14 @@ class EnumPostProcessor extends PostProcessor
                 $validator instanceof FilterValidator
                 && $validator->getFilter() instanceof TransformingFilterInterface
             ) {
-                throw new SchemaException(sprintf(
-                    "Can't apply enum filter to an already transformed value on property %s in file %s",
-                    $property->getName(),
-                    $property->getJsonSchema()->getFile(),
-                ), $property->getJsonSchema());
+                throw new SchemaException(
+                    sprintf(
+                        "Can't apply enum filter to an already transformed value on property %s in file %s",
+                        $property->getName(),
+                        $property->getJsonSchema()->getFile(),
+                    ),
+                    $property->getJsonSchema(),
+                );
             }
         }
     }

--- a/src/SchemaProcessor/PostProcessor/Internal/ExtendObjectPropertiesMatchingPatternPropertiesPostProcessor.php
+++ b/src/SchemaProcessor/PostProcessor/Internal/ExtendObjectPropertiesMatchingPatternPropertiesPostProcessor.php
@@ -115,6 +115,7 @@ class ExtendObjectPropertiesMatchingPatternPropertiesPostProcessor extends PostP
                         $forbiddenValidator->getPattern(),
                         $property->getJsonSchema()->getFile(),
                     ),
+                    $property->getJsonSchema(),
                 );
             }
         }
@@ -187,7 +188,8 @@ class ExtendObjectPropertiesMatchingPatternPropertiesPostProcessor extends PostP
                             array_keys($matchingPatternDefaults),
                             array_values($matchingPatternDefaults),
                         )),
-                    )
+                    ),
+                    $property->getJsonSchema(),
                 );
             }
 
@@ -204,7 +206,8 @@ class ExtendObjectPropertiesMatchingPatternPropertiesPostProcessor extends PostP
                         var_export($existingDefault, true),
                         array_key_first($matchingPatternDefaults),
                         var_export($agreedPatternDefault, true),
-                    )
+                    ),
+                    $property->getJsonSchema(),
                 );
             }
 
@@ -422,7 +425,8 @@ class ExtendObjectPropertiesMatchingPatternPropertiesPostProcessor extends PostP
                                         . ' is not supported in file %s',
                                     $property->getName(),
                                     $property->getJsonSchema()->getFile(),
-                                )
+                                ),
+                                $property->getJsonSchema(),
                             );
                         }
                     }

--- a/src/SchemaProcessor/PostProcessor/Internal/PatternPropertiesPostProcessor.php
+++ b/src/SchemaProcessor/PostProcessor/Internal/PatternPropertiesPostProcessor.php
@@ -15,11 +15,6 @@ use PHPModelGenerator\Model\Validator\PatternPropertiesValidator;
 use PHPModelGenerator\SchemaProcessor\Hook\ConstructorBeforeValidationHookInterface;
 use PHPModelGenerator\SchemaProcessor\PostProcessor\PostProcessor;
 
-/**
- * Class PatternPropertiesPostProcessor
- *
- * @package PHPModelGenerator\SchemaProcessor\PostProcessor\Internal
- */
 class PatternPropertiesPostProcessor extends PostProcessor
 {
     /**
@@ -43,6 +38,7 @@ class PatternPropertiesPostProcessor extends PostProcessor
 
                     throw new SchemaException(
                         "Duplicate pattern property access key '$key' in file {$schema->getJsonSchema()->getFile()}",
+                        $schema->getJsonSchema(),
                     );
                 }
 

--- a/src/SchemaProcessor/SchemaProcessor.php
+++ b/src/SchemaProcessor/SchemaProcessor.php
@@ -31,11 +31,6 @@ use PHPModelGenerator\PropertyProcessor\PropertyFactory;
 use PHPModelGenerator\SchemaProvider\SchemaProviderInterface;
 use PHPModelGenerator\Utils\PropertyAttributeSynthesizer;
 
-/**
- * Class SchemaProcessor
- *
- * @package PHPModelGenerator\SchemaProcessor
- */
 class SchemaProcessor
 {
     protected string $currentClassPath;
@@ -527,7 +522,8 @@ class SchemaProcessor
                                 "No nested schema for composed property %s in file %s found",
                                 $property->getName(),
                                 $property->getJsonSchema()->getFile(),
-                            )
+                            ),
+                            $property->getJsonSchema(),
                         );
                     }
 
@@ -579,6 +575,7 @@ class SchemaProcessor
                                     $schema->getPropertyMerger()->checkForTotalConflict(
                                         $branchPropertyName,
                                         $totalBranches,
+                                        $schema->getJsonSchema(),
                                     );
                                 }
 
@@ -726,7 +723,8 @@ class SchemaProcessor
                         $existingDefault,
                         $branchLabel,
                         $branchDefault,
-                    )
+                    ),
+                    $branchProperty->getJsonSchema(),
                 );
             }
         }
@@ -761,7 +759,8 @@ class SchemaProcessor
                         $patternDefault,
                         $branchLabel,
                         $effectiveBranchDefault,
-                    )
+                    ),
+                    $branchProperty->getJsonSchema(),
                 );
             }
 
@@ -868,7 +867,8 @@ class SchemaProcessor
                     $keyword,
                     $compositionProperty->getJsonSchema()->getFile(),
                     implode(', ', $sites),
-                )
+                ),
+                $compositionProperty->getJsonSchema(),
             );
         }
     }

--- a/src/SchemaProvider/OpenAPIv3Provider.php
+++ b/src/SchemaProvider/OpenAPIv3Provider.php
@@ -7,17 +7,14 @@ namespace PHPModelGenerator\SchemaProvider;
 use PHPModelGenerator\Exception\SchemaException;
 use PHPModelGenerator\Model\SchemaDefinition\JsonSchema;
 
-/**
- * Class OpenAPIv3Provider
- *
- * @package PHPModelGenerator\SchemaProvider
- */
 class OpenAPIv3Provider implements SchemaProviderInterface
 {
     use RefResolverTrait;
 
     /** @var array */
     private $openAPIv3Spec;
+
+    private string $rawSource;
 
     /**
      * OpenAPIv3Provider constructor.
@@ -29,16 +26,30 @@ class OpenAPIv3Provider implements SchemaProviderInterface
         $this->sourceFile = realpath($this->sourceFile) ?: $this->sourceFile;
         $jsonSchema = file_get_contents($this->sourceFile);
 
-        if (!$jsonSchema || !($this->openAPIv3Spec = json_decode($jsonSchema, true))) {
+        if (!$jsonSchema) {
             throw new SchemaException("Invalid JSON-Schema file {$this->sourceFile}");
         }
+
+        $decoded = json_decode($jsonSchema, true);
+
+        if (json_last_error() !== JSON_ERROR_NONE) {
+            throw SchemaException::invalidJson($this->sourceFile, $jsonSchema);
+        }
+
+        if (!is_array($decoded)) {
+            throw new SchemaException("Invalid JSON-Schema file {$this->sourceFile}");
+        }
+
+        $this->openAPIv3Spec = $decoded;
+        $this->rawSource = $jsonSchema;
 
         if (
             !isset($this->openAPIv3Spec['components']['schemas']) ||
             empty($this->openAPIv3Spec['components']['schemas'])
         ) {
             throw new SchemaException(
-                "Open API v3 spec file {$this->sourceFile} doesn't contain any schemas to process"
+                "Open API v3 spec file {$this->sourceFile} doesn't contain any schemas to process",
+                new JsonSchema($this->sourceFile, $this->openAPIv3Spec, rawSource: $this->rawSource),
             );
         }
     }
@@ -57,7 +68,8 @@ class OpenAPIv3Provider implements SchemaProviderInterface
             yield new JsonSchema(
                 $this->sourceFile,
                 array_merge($this->openAPIv3Spec, $schema),
-                "/components/schemas/$schemaKey"
+                "/components/schemas/$schemaKey",
+                $this->rawSource,
             );
         }
     }

--- a/src/SchemaProvider/RecursiveDirectoryProvider.php
+++ b/src/SchemaProvider/RecursiveDirectoryProvider.php
@@ -11,11 +11,6 @@ use RecursiveDirectoryIterator;
 use RecursiveIteratorIterator;
 use RegexIterator;
 
-/**
- * Class RecursiveDirectoryProvider
- *
- * @package PHPModelGenerator\SchemaProvider
- */
 class RecursiveDirectoryProvider implements SchemaProviderInterface
 {
     use RefResolverTrait;
@@ -62,14 +57,14 @@ class RecursiveDirectoryProvider implements SchemaProviderInterface
             $decodedJsonSchema = json_decode($jsonSchema, true);
 
             if (json_last_error() !== JSON_ERROR_NONE) {
-                throw new SchemaException("Invalid JSON-Schema file $file");
+                throw SchemaException::invalidJson($file, $jsonSchema);
             }
 
             if (!is_array($decodedJsonSchema)) {
                 continue;
             }
 
-            yield new JsonSchema($file, $decodedJsonSchema);
+            yield new JsonSchema($file, $decodedJsonSchema, rawSource: $jsonSchema);
         }
     }
 

--- a/src/SchemaProvider/RefResolverTrait.php
+++ b/src/SchemaProvider/RefResolverTrait.php
@@ -21,14 +21,14 @@ trait RefResolverTrait
         $decodedJsonSchema = json_decode($jsonSchema, true);
 
         if (json_last_error() !== JSON_ERROR_NONE) {
-            throw new SchemaException("Invalid JSON-Schema file $jsonSchemaFilePath");
+            throw SchemaException::invalidJson($jsonSchemaFilePath, $jsonSchema);
         }
 
         if (!is_array($decodedJsonSchema)) {
             throw new SchemaException("Referenced JSON-Schema file $jsonSchemaFilePath must contain a JSON object");
         }
 
-        return new JsonSchema($jsonSchemaFilePath, $decodedJsonSchema);
+        return new JsonSchema($jsonSchemaFilePath, $decodedJsonSchema, rawSource: $jsonSchema);
     }
 
     /**

--- a/src/SchemaProvider/SingleFileProvider.php
+++ b/src/SchemaProvider/SingleFileProvider.php
@@ -7,16 +7,12 @@ namespace PHPModelGenerator\SchemaProvider;
 use PHPModelGenerator\Exception\SchemaException;
 use PHPModelGenerator\Model\SchemaDefinition\JsonSchema;
 
-/**
- * Class SingleFileProvider
- *
- * @package PHPModelGenerator\SchemaProvider
- */
 class SingleFileProvider implements SchemaProviderInterface
 {
     use RefResolverTrait;
 
     private array $schema;
+    private string $rawSource;
 
     public function __construct(private string $sourceFile)
     {
@@ -30,7 +26,7 @@ class SingleFileProvider implements SchemaProviderInterface
         $decoded = json_decode($jsonSchemaContent, true);
 
         if (json_last_error() !== JSON_ERROR_NONE) {
-            throw new SchemaException("Invalid JSON-Schema file {$this->sourceFile}");
+            throw SchemaException::invalidJson($this->sourceFile, $jsonSchemaContent);
         }
 
         if (!is_array($decoded)) {
@@ -38,6 +34,7 @@ class SingleFileProvider implements SchemaProviderInterface
         }
 
         $this->schema = $decoded;
+        $this->rawSource = $jsonSchemaContent;
     }
 
     /**
@@ -45,7 +42,7 @@ class SingleFileProvider implements SchemaProviderInterface
      */
     public function getSchemas(): iterable
     {
-        yield new JsonSchema($this->sourceFile, $this->schema);
+        yield new JsonSchema($this->sourceFile, $this->schema, rawSource: $this->rawSource);
     }
 
     /**

--- a/src/Utils/Json/JsonLexer.php
+++ b/src/Utils/Json/JsonLexer.php
@@ -1,0 +1,413 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PHPModelGenerator\Utils\Json;
+
+/**
+ * A forward-only, line/column-tracking cursor over a raw JSON source string.
+ *
+ * The lexer never validates that the source is well-formed JSON on its own — callers decide
+ * whether a failed token (null return) means "stop and report an error" (syntax checking) or
+ * "this cannot happen because json_decode already accepted this text" (pointer resolution).
+ */
+class JsonLexer
+{
+    private int $offset;
+    private int $line;
+    private int $column;
+
+    public function __construct(private readonly string $source, int $offset = 0, int $line = 1, int $column = 1)
+    {
+        $this->offset = $offset;
+        $this->line = $line;
+        $this->column = $column;
+    }
+
+    public function getPosition(): JsonSourcePosition
+    {
+        return new JsonSourcePosition($this->line, $this->column, $this->offset);
+    }
+
+    public function isEof(): bool
+    {
+        return $this->offset >= strlen($this->source);
+    }
+
+    public function peekChar(): ?string
+    {
+        return $this->isEof() ? null : $this->source[$this->offset];
+    }
+
+    public function skipWhitespace(): void
+    {
+        while (!$this->isEof() && in_array($this->source[$this->offset], [' ', "\t", "\n", "\r"], true)) {
+            $this->advanceChar();
+        }
+    }
+
+    public function matchChar(string $char): bool
+    {
+        if ($this->peekChar() !== $char) {
+            return false;
+        }
+
+        $this->advanceChar();
+
+        return true;
+    }
+
+    /**
+     * Lexes a JSON string starting at the current (already verified) opening quote. Returns the
+     * decoded string value, or null if the source doesn't contain a well-formed JSON string here
+     * (unterminated, invalid escape, unescaped control character).
+     */
+    public function lexString(): ?string
+    {
+        if ($this->peekChar() !== '"') {
+            return null;
+        }
+
+        $this->advanceChar();
+        $result = '';
+
+        while (true) {
+            if ($this->isEof()) {
+                return null;
+            }
+
+            $byte = ord($this->source[$this->offset]);
+
+            if ($byte === 0x22) {
+                $this->advanceChar();
+
+                return $result;
+            }
+
+            if ($byte === 0x5C) {
+                $escaped = $this->lexEscapeSequence();
+
+                if ($escaped === null) {
+                    return null;
+                }
+
+                $result .= $escaped;
+
+                continue;
+            }
+
+            if ($byte < 0x20) {
+                return null;
+            }
+
+            $start = $this->offset;
+            $this->advanceChar();
+            $result .= substr($this->source, $start, $this->offset - $start);
+        }
+    }
+
+    /**
+     * Matches the JSON number grammar at the current position. Returns the raw matched text, or
+     * null if no valid number starts here.
+     */
+    public function lexNumber(): ?string
+    {
+        $pattern = '/\G-?(?:0|[1-9][0-9]*)(?:\.[0-9]+)?(?:[eE][+-]?[0-9]+)?/';
+
+        if (!preg_match($pattern, $this->source, $matches, 0, $this->offset) || $matches[0] === '') {
+            return null;
+        }
+
+        $length = strlen($matches[0]);
+        $this->offset += $length;
+        $this->column += $length;
+
+        return $matches[0];
+    }
+
+    /**
+     * Matches one of the JSON literals (true, false, null) at the current position, requiring
+     * that it isn't immediately followed by another identifier character. Returns the matched
+     * literal, or null if none matches here.
+     */
+    public function lexLiteral(): ?string
+    {
+        foreach (['true', 'false', 'null'] as $literal) {
+            $length = strlen($literal);
+
+            if (substr($this->source, $this->offset, $length) !== $literal) {
+                continue;
+            }
+
+            $nextByte = $this->offset + $length < strlen($this->source) ? $this->source[$this->offset + $length] : null;
+
+            if ($nextByte !== null && (ctype_alnum($nextByte) || $nextByte === '_')) {
+                continue;
+            }
+
+            $this->offset += $length;
+            $this->column += $length;
+
+            return $literal;
+        }
+
+        return null;
+    }
+
+    /**
+     * Consumes and discards a full JSON value (string, number, literal, object or array) without
+     * validating it, trusting that the source has already passed json_decode successfully.
+     * Returns false if nothing recognizable as a JSON value starts here.
+     */
+    public function skipValue(): bool
+    {
+        $this->skipWhitespace();
+        $char = $this->peekChar();
+
+        if ($char === null) {
+            return false;
+        }
+
+        if ($char === '"') {
+            return $this->lexString() !== null;
+        }
+
+        if ($char === '{') {
+            return $this->skipObject();
+        }
+
+        if ($char === '[') {
+            return $this->skipArray();
+        }
+
+        if ($char === '-' || ($char >= '0' && $char <= '9')) {
+            return $this->lexNumber() !== null;
+        }
+
+        return $this->lexLiteral() !== null;
+    }
+
+    private function skipObject(): bool
+    {
+        $this->matchChar('{');
+        $this->skipWhitespace();
+
+        if ($this->matchChar('}')) {
+            return true;
+        }
+
+        while (true) {
+            $this->skipWhitespace();
+
+            if ($this->lexString() === null) {
+                return false;
+            }
+
+            $this->skipWhitespace();
+
+            if (!$this->matchChar(':')) {
+                return false;
+            }
+
+            if (!$this->skipValue()) {
+                return false;
+            }
+
+            $this->skipWhitespace();
+
+            if ($this->matchChar(',')) {
+                continue;
+            }
+
+            if ($this->matchChar('}')) {
+                return true;
+            }
+
+            return false;
+        }
+    }
+
+    private function skipArray(): bool
+    {
+        $this->matchChar('[');
+        $this->skipWhitespace();
+
+        if ($this->matchChar(']')) {
+            return true;
+        }
+
+        while (true) {
+            if (!$this->skipValue()) {
+                return false;
+            }
+
+            $this->skipWhitespace();
+
+            if ($this->matchChar(',')) {
+                continue;
+            }
+
+            if ($this->matchChar(']')) {
+                return true;
+            }
+
+            return false;
+        }
+    }
+
+    private function lexEscapeSequence(): ?string
+    {
+        $this->advanceChar();
+
+        if ($this->isEof()) {
+            return null;
+        }
+
+        $escapeChar = $this->source[$this->offset];
+
+        $simpleEscapes = [
+            '"' => '"',
+            '\\' => '\\',
+            '/' => '/',
+            'b' => "\x08",
+            'f' => "\x0C",
+            'n' => "\n",
+            'r' => "\r",
+            't' => "\t",
+        ];
+
+        if (isset($simpleEscapes[$escapeChar])) {
+            $this->advanceChar();
+
+            return $simpleEscapes[$escapeChar];
+        }
+
+        if ($escapeChar !== 'u') {
+            return null;
+        }
+
+        $this->advanceChar();
+        $codepoint = $this->readHex4();
+
+        if ($codepoint === null) {
+            return null;
+        }
+
+        if ($codepoint >= 0xD800 && $codepoint <= 0xDBFF) {
+            if (($this->source[$this->offset] ?? null) !== '\\' || ($this->source[$this->offset + 1] ?? null) !== 'u') {
+                return null;
+            }
+
+            $this->advanceChar();
+            $this->advanceChar();
+            $lowSurrogate = $this->readHex4();
+
+            if ($lowSurrogate === null || $lowSurrogate < 0xDC00 || $lowSurrogate > 0xDFFF) {
+                return null;
+            }
+
+            $codepoint = 0x10000 + (($codepoint - 0xD800) << 10) + ($lowSurrogate - 0xDC00);
+        }
+
+        return $this->encodeCodepoint($codepoint);
+    }
+
+    private function readHex4(): ?int
+    {
+        if ($this->offset + 4 > strlen($this->source)) {
+            return null;
+        }
+
+        $hex = substr($this->source, $this->offset, 4);
+
+        if (!preg_match('/^[0-9a-fA-F]{4}$/', $hex)) {
+            return null;
+        }
+
+        for ($index = 0; $index < 4; $index++) {
+            $this->advanceChar();
+        }
+
+        return hexdec($hex);
+    }
+
+    private function encodeCodepoint(int $codepoint): string
+    {
+        if ($codepoint <= 0x7F) {
+            return chr($codepoint);
+        }
+
+        if ($codepoint <= 0x7FF) {
+            return chr(0xC0 | ($codepoint >> 6)) . chr(0x80 | ($codepoint & 0x3F));
+        }
+
+        if ($codepoint <= 0xFFFF) {
+            return chr(0xE0 | ($codepoint >> 12))
+                . chr(0x80 | (($codepoint >> 6) & 0x3F))
+                . chr(0x80 | ($codepoint & 0x3F));
+        }
+
+        return chr(0xF0 | ($codepoint >> 18))
+            . chr(0x80 | (($codepoint >> 12) & 0x3F))
+            . chr(0x80 | (($codepoint >> 6) & 0x3F))
+            . chr(0x80 | ($codepoint & 0x3F));
+    }
+
+    /**
+     * Advances by exactly one logical character, tracking line/column. \r\n counts as a single
+     * line break; column counts UTF-8 characters, not bytes.
+     */
+    private function advanceChar(): void
+    {
+        if ($this->isEof()) {
+            return;
+        }
+
+        $byte = ord($this->source[$this->offset]);
+
+        if ($byte === 0x0D) {
+            $this->offset++;
+
+            if (!$this->isEof() && $this->source[$this->offset] === "\n") {
+                $this->offset++;
+            }
+
+            $this->line++;
+            $this->column = 1;
+
+            return;
+        }
+
+        if ($byte === 0x0A) {
+            $this->offset++;
+            $this->line++;
+            $this->column = 1;
+
+            return;
+        }
+
+        $this->offset += $this->utf8SequenceLength($byte);
+        $this->column++;
+    }
+
+    private function utf8SequenceLength(int $leadingByte): int
+    {
+        if ($leadingByte < 0x80) {
+            return 1;
+        }
+
+        if (($leadingByte & 0xE0) === 0xC0) {
+            return 2;
+        }
+
+        if (($leadingByte & 0xF0) === 0xE0) {
+            return 3;
+        }
+
+        if (($leadingByte & 0xF8) === 0xF0) {
+            return 4;
+        }
+
+        return 1;
+    }
+}

--- a/src/Utils/Json/JsonPointerLocator.php
+++ b/src/Utils/Json/JsonPointerLocator.php
@@ -61,10 +61,9 @@ class JsonPointerLocator
      */
     private static function findObjectKey(JsonLexer $lexer, string $segment): ?JsonSourcePosition
     {
-        if (!$lexer->matchChar('{')) {
-            return null;
-        }
-
+        // The opening brace is guaranteed by findSegment()'s dispatch on peekChar() - no need to
+        // guard against a failed match here.
+        $lexer->matchChar('{');
         $lexer->skipWhitespace();
 
         if ($lexer->matchChar('}')) {
@@ -122,10 +121,9 @@ class JsonPointerLocator
 
         $targetIndex = (int) $segment;
 
-        if (!$lexer->matchChar('[')) {
-            return null;
-        }
-
+        // The opening bracket is guaranteed by findSegment()'s dispatch on peekChar() - no need to
+        // guard against a failed match here.
+        $lexer->matchChar('[');
         $lexer->skipWhitespace();
 
         if ($lexer->matchChar(']')) {

--- a/src/Utils/Json/JsonPointerLocator.php
+++ b/src/Utils/Json/JsonPointerLocator.php
@@ -1,0 +1,166 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PHPModelGenerator\Utils\Json;
+
+use PHPModelGenerator\Model\SchemaDefinition\JsonSchema;
+
+/**
+ * Resolves an RFC 6901 JSON pointer against raw JSON source text to the source position of the
+ * value the pointer points at.
+ *
+ * The source text is assumed to already have passed json_decode successfully - this locator never
+ * validates JSON syntax, it only walks an already-known-valid document. It must never throw: a
+ * pointer that can't be resolved (should not normally happen, since pointers are derived from
+ * navigating the very same decoded structure) simply yields null, so a failed lookup never masks
+ * the real error being reported.
+ */
+class JsonPointerLocator
+{
+    public static function locate(string $source, string $pointer): ?JsonSourcePosition
+    {
+        $trimmedPointer = trim($pointer, '/');
+
+        $lexer = new JsonLexer($source);
+        $lexer->skipWhitespace();
+
+        if ($trimmedPointer === '') {
+            return $lexer->isEof() ? null : $lexer->getPosition();
+        }
+
+        foreach (explode('/', $trimmedPointer) as $segment) {
+            $decodedSegment = JsonSchema::decodePointer($segment);
+            $match = self::findSegment($lexer, $decodedSegment);
+
+            if ($match === null) {
+                return null;
+            }
+
+            $lexer = new JsonLexer($source, $match->offset, $match->line, $match->column);
+        }
+
+        return $lexer->getPosition();
+    }
+
+    private static function findSegment(JsonLexer $lexer, string $segment): ?JsonSourcePosition
+    {
+        $lexer->skipWhitespace();
+
+        return match ($lexer->peekChar()) {
+            '{' => self::findObjectKey($lexer, $segment),
+            '[' => self::findArrayIndex($lexer, $segment),
+            default => null,
+        };
+    }
+
+    /**
+     * Scans every key of the object at the current position, keeping the last occurrence that
+     * matches $segment - matching json_decode's own last-write-wins duplicate-key behavior, so
+     * the reported position always belongs to the value actually present in the decoded tree.
+     */
+    private static function findObjectKey(JsonLexer $lexer, string $segment): ?JsonSourcePosition
+    {
+        if (!$lexer->matchChar('{')) {
+            return null;
+        }
+
+        $lexer->skipWhitespace();
+
+        if ($lexer->matchChar('}')) {
+            return null;
+        }
+
+        $match = null;
+
+        while (true) {
+            $lexer->skipWhitespace();
+            $key = $lexer->lexString();
+
+            if ($key === null) {
+                return null;
+            }
+
+            $lexer->skipWhitespace();
+
+            if (!$lexer->matchChar(':')) {
+                return null;
+            }
+
+            $lexer->skipWhitespace();
+            $valuePosition = $lexer->getPosition();
+
+            if ($key === $segment) {
+                $match = $valuePosition;
+            }
+
+            if (!$lexer->skipValue()) {
+                return null;
+            }
+
+            $lexer->skipWhitespace();
+
+            if ($lexer->matchChar(',')) {
+                continue;
+            }
+
+            if ($lexer->matchChar('}')) {
+                break;
+            }
+
+            return null;
+        }
+
+        return $match;
+    }
+
+    private static function findArrayIndex(JsonLexer $lexer, string $segment): ?JsonSourcePosition
+    {
+        if (!preg_match('/^(?:0|[1-9][0-9]*)$/', $segment)) {
+            return null;
+        }
+
+        $targetIndex = (int) $segment;
+
+        if (!$lexer->matchChar('[')) {
+            return null;
+        }
+
+        $lexer->skipWhitespace();
+
+        if ($lexer->matchChar(']')) {
+            return null;
+        }
+
+        $currentIndex = 0;
+        $match = null;
+
+        while (true) {
+            $lexer->skipWhitespace();
+            $valuePosition = $lexer->getPosition();
+
+            if ($currentIndex === $targetIndex) {
+                $match = $valuePosition;
+            }
+
+            if (!$lexer->skipValue()) {
+                return null;
+            }
+
+            $currentIndex++;
+            $lexer->skipWhitespace();
+
+            if ($lexer->matchChar(',')) {
+                continue;
+            }
+
+            if ($lexer->matchChar(']')) {
+                break;
+            }
+
+            return null;
+        }
+
+        return $match;
+    }
+}

--- a/src/Utils/Json/JsonSourcePosition.php
+++ b/src/Utils/Json/JsonSourcePosition.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PHPModelGenerator\Utils\Json;
+
+/**
+ * A resolved position inside a raw JSON source string
+ */
+final class JsonSourcePosition
+{
+    public function __construct(
+        public readonly int $line,
+        public readonly int $column,
+        public readonly int $offset,
+    ) {
+    }
+}

--- a/src/Utils/Json/JsonSyntaxErrorLocator.php
+++ b/src/Utils/Json/JsonSyntaxErrorLocator.php
@@ -1,0 +1,136 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PHPModelGenerator\Utils\Json;
+
+/**
+ * Runs a minimal recursive-descent grammar walk over raw JSON source text that is already known
+ * to have failed json_decode, to pinpoint the first position where the input stops being valid
+ * JSON (unexpected character, unterminated string, trailing comma, unexpected end of input, ...).
+ *
+ * Returns null if the scanner can't pinpoint a position either, so callers can gracefully fall
+ * back to file-only error reporting instead of raising a confusing meta-error.
+ */
+class JsonSyntaxErrorLocator
+{
+    private ?JsonSourcePosition $errorPosition = null;
+
+    public static function locate(string $source): ?JsonSourcePosition
+    {
+        return (new self())->run($source);
+    }
+
+    private function run(string $source): ?JsonSourcePosition
+    {
+        $lexer = new JsonLexer($source);
+
+        if (!$this->parseValue($lexer)) {
+            return $this->errorPosition;
+        }
+
+        $lexer->skipWhitespace();
+
+        if (!$lexer->isEof()) {
+            $this->errorPosition ??= $lexer->getPosition();
+        }
+
+        return $this->errorPosition;
+    }
+
+    private function fail(JsonLexer $lexer): bool
+    {
+        $this->errorPosition ??= $lexer->getPosition();
+
+        return false;
+    }
+
+    private function parseValue(JsonLexer $lexer): bool
+    {
+        $lexer->skipWhitespace();
+        $char = $lexer->peekChar();
+
+        return match (true) {
+            $char === '"' => $lexer->lexString() !== null ? true : $this->fail($lexer),
+            $char === '{' => $this->parseObject($lexer),
+            $char === '[' => $this->parseArray($lexer),
+            $char === '-' || ($char !== null && $char >= '0' && $char <= '9')
+                => $lexer->lexNumber() !== null ? true : $this->fail($lexer),
+            $char === 't' || $char === 'f' || $char === 'n'
+                => $lexer->lexLiteral() !== null ? true : $this->fail($lexer),
+            default => $this->fail($lexer),
+        };
+    }
+
+    private function parseObject(JsonLexer $lexer): bool
+    {
+        $lexer->matchChar('{');
+        $lexer->skipWhitespace();
+
+        if ($lexer->matchChar('}')) {
+            return true;
+        }
+
+        while (true) {
+            $lexer->skipWhitespace();
+
+            if ($lexer->peekChar() !== '"') {
+                return $this->fail($lexer);
+            }
+
+            if ($lexer->lexString() === null) {
+                return $this->fail($lexer);
+            }
+
+            $lexer->skipWhitespace();
+
+            if (!$lexer->matchChar(':')) {
+                return $this->fail($lexer);
+            }
+
+            if (!$this->parseValue($lexer)) {
+                return false;
+            }
+
+            $lexer->skipWhitespace();
+
+            if ($lexer->matchChar(',')) {
+                continue;
+            }
+
+            if ($lexer->matchChar('}')) {
+                return true;
+            }
+
+            return $this->fail($lexer);
+        }
+    }
+
+    private function parseArray(JsonLexer $lexer): bool
+    {
+        $lexer->matchChar('[');
+        $lexer->skipWhitespace();
+
+        if ($lexer->matchChar(']')) {
+            return true;
+        }
+
+        while (true) {
+            if (!$this->parseValue($lexer)) {
+                return false;
+            }
+
+            $lexer->skipWhitespace();
+
+            if ($lexer->matchChar(',')) {
+                continue;
+            }
+
+            if ($lexer->matchChar(']')) {
+                return true;
+            }
+
+            return $this->fail($lexer);
+        }
+    }
+}

--- a/src/Utils/NormalizedName.php
+++ b/src/Utils/NormalizedName.php
@@ -30,7 +30,8 @@ class NormalizedName
                     "Name '%s' results in an empty name in file %s",
                     $name,
                     $jsonSchema->getFile(),
-                )
+                ),
+                $jsonSchema,
             );
         }
 

--- a/src/Utils/PropertyMerger.php
+++ b/src/Utils/PropertyMerger.php
@@ -149,11 +149,14 @@ class PropertyMerger
             isset($this->rootConflictCounts[$propertyName]) &&
             $this->rootConflictCounts[$propertyName] >= $branchCount
         ) {
-            throw new SchemaException(sprintf(
-                "Property '%s' is defined in root with a type that conflicts with all composition branches, " .
-                "making this schema unsatisfiable.",
-                $propertyName,
-            ), $jsonSchema);
+            throw new SchemaException(
+                sprintf(
+                    "Property '%s' is defined in root with a type that conflicts with all composition branches, " .
+                    "making this schema unsatisfiable.",
+                    $propertyName,
+                ),
+                $jsonSchema,
+            );
         }
     }
 

--- a/src/Utils/PropertyMerger.php
+++ b/src/Utils/PropertyMerger.php
@@ -8,6 +8,7 @@ use PHPModelGenerator\Exception\SchemaException;
 use PHPModelGenerator\Model\GeneratorConfiguration;
 use PHPModelGenerator\Model\Property\PropertyInterface;
 use PHPModelGenerator\Model\Property\PropertyType;
+use PHPModelGenerator\Model\SchemaDefinition\JsonSchema;
 use PHPModelGenerator\Model\Validator;
 use PHPModelGenerator\Model\Validator\TypeCheckInterface;
 use PHPModelGenerator\PropertyProcessor\Decorator\Property\IntToFloatCastDecorator;
@@ -142,7 +143,7 @@ class PropertyMerger
      *
      * @throws SchemaException
      */
-    public function checkForTotalConflict(string $propertyName, int $branchCount): void
+    public function checkForTotalConflict(string $propertyName, int $branchCount, JsonSchema $jsonSchema): void
     {
         if (
             isset($this->rootConflictCounts[$propertyName]) &&
@@ -152,7 +153,7 @@ class PropertyMerger
                 "Property '%s' is defined in root with a type that conflicts with all composition branches, " .
                 "making this schema unsatisfiable.",
                 $propertyName,
-            ));
+            ), $jsonSchema);
         }
     }
 
@@ -260,6 +261,7 @@ class PropertyMerger
             $incomingOutput,
             $incoming->isRequired(),
             $conflictMessage,
+            $existing->getJsonSchema(),
         );
 
         if ($intersection === null) {
@@ -302,6 +304,7 @@ class PropertyMerger
             $constraintType,
             $existing->isRequired(),
             $conflictMessage,
+            $existing->getJsonSchema(),
         );
 
         if ($intersection === null) {
@@ -326,11 +329,12 @@ class PropertyMerger
         PropertyType $incomingType,
         bool $incomingIsRequired,
         string $conflictMessage,
+        JsonSchema $jsonSchema,
     ): ?array {
         $implicitNull = $this->generatorConfiguration?->isImplicitNullAllowed() ?? false;
 
         if (!TypeIntersection::compute($existingType->getNames(), $incomingType->getNames())) {
-            throw new SchemaException($conflictMessage);
+            throw new SchemaException($conflictMessage, $jsonSchema);
         }
 
         $existingEffective = $this->buildEffectiveTypeSet($existingType, $existingIsRequired, $implicitNull);

--- a/tests/Basic/BasicSchemaGenerationTest.php
+++ b/tests/Basic/BasicSchemaGenerationTest.php
@@ -19,11 +19,6 @@ use PHPModelGenerator\SchemaProcessor\PostProcessor\PostProcessor;
 use PHPModelGenerator\Tests\AbstractPHPModelGeneratorTestCase;
 use PHPUnit\Framework\Attributes\DataProvider;
 
-/**
- * Class BasicSchemaGenerationTest
- *
- * @package PHPModelGenerator\Tests\Basic
- */
 class BasicSchemaGenerationTest extends AbstractPHPModelGeneratorTestCase
 {
     /**
@@ -365,9 +360,26 @@ class BasicSchemaGenerationTest extends AbstractPHPModelGeneratorTestCase
     public function testInvalidJsonSchemaFileThrowsAnException(): void
     {
         $this->expectException(SchemaException::class);
-        $this->expectExceptionMessageMatches('/^Invalid JSON-Schema file (.*)\.json$/');
+        $this->expectExceptionMessageMatches('/^Invalid JSON-Schema file (.*)\.json at line 6, column 2$/');
 
         $this->generateClassFromFile('InvalidJSONSchema.json');
+    }
+
+    /**
+     * Malformed JSON discovered via RecursiveDirectoryProvider (the default provider used by
+     * generateClassFromFile) exposes its location through SchemaException's structured accessors,
+     * not just through the message text.
+     */
+    public function testInvalidJsonSchemaFileExposesLocationThroughAccessors(): void
+    {
+        try {
+            $this->generateClassFromFile('InvalidJSONSchema.json');
+            $this->fail('Expected a SchemaException to be thrown');
+        } catch (SchemaException $exception) {
+            $this->assertStringEndsWith('.json', $exception->getSchemaFile());
+            $this->assertSame(6, $exception->getSourceLine());
+            $this->assertSame(2, $exception->getSourceColumn());
+        }
     }
 
     public function testJsonSchemaWithInvalidPropertyTypeThrowsAnException(): void

--- a/tests/Basic/PropertyNamesTest.php
+++ b/tests/Basic/PropertyNamesTest.php
@@ -11,11 +11,6 @@ use PHPModelGenerator\Model\GeneratorConfiguration;
 use PHPModelGenerator\Tests\AbstractPHPModelGeneratorTestCase;
 use PHPUnit\Framework\Attributes\DataProvider;
 
-/**
- * Class PropertyNamesTest
- *
- * @package PHPModelGenerator\Tests\Basic
- */
 class PropertyNamesTest extends AbstractPHPModelGeneratorTestCase
 {
     #[DataProvider('validationMethodDataProvider')]
@@ -220,32 +215,41 @@ class PropertyNamesTest extends AbstractPHPModelGeneratorTestCase
     {
         return [
             // kebab-case and camelCase normalize to the same attribute
-            'foo-bar and fooBar' => ['KebabAndCamelCase.json', 'foo-bar', 'fooBar', 'fooBar'],
+            'foo-bar and fooBar' => ['KebabAndCamelCase.json', 'foo-bar', 'fooBar', 'fooBar', 69],
             // underscore_case and camelCase normalize to the same attribute
-            'foo_bar and fooBar' => ['UnderscoreAndCamelCase.json', 'foo_bar', 'fooBar', 'fooBar'],
+            'foo_bar and fooBar' => ['UnderscoreAndCamelCase.json', 'foo_bar', 'fooBar', 'fooBar', 69],
             // dot.notation and camelCase normalize to the same attribute
-            'foo.bar and fooBar' => ['DotAndCamelCase.json', 'foo.bar', 'fooBar', 'fooBar'],
+            'foo.bar and fooBar' => ['DotAndCamelCase.json', 'foo.bar', 'fooBar', 'fooBar', 69],
             // leading underscore is stripped by the normalizer
-            '_foo and foo' => ['LeadingUnderscoreAndPlain.json', '_foo', 'foo', 'foo'],
+            '_foo and foo' => ['LeadingUnderscoreAndPlain.json', '_foo', 'foo', 'foo', 63],
             // multiple separators still collapse to the same attribute as a single separator
-            'foo--bar and foo_bar' => ['MultipleSeparators.json', 'foo--bar', 'foo_bar', 'fooBar'],
+            'foo--bar and foo_bar' => ['MultipleSeparators.json', 'foo--bar', 'foo_bar', 'fooBar', 71],
         ];
     }
 
+    /**
+     * The schema fixtures are re-encoded as compact, single-line JSON (with an injected "title"
+     * key) by the test harness before generation, so every collision is reported on line 1 - the
+     * expected column for each fixture was captured from an actual generation run and is asserted
+     * exactly rather than via a generic \d+ pattern.
+     */
     #[DataProvider('collidingPropertyPairProvider')]
     public function testCollidingPropertyNamesThrowSchemaException(
         string $schemaFile,
         string $firstRawName,
         string $secondRawName,
         string $expectedAttribute,
+        int $expectedColumn,
     ): void {
         $this->expectException(SchemaException::class);
         $this->expectExceptionMessageMatches(
             sprintf(
-                "/^Property names '%s' and '%s' both normalize to attribute '%s' in file .+\.json$/",
+                "/^Property names '%s' and '%s' both normalize to attribute '%s' in file .+\.json"
+                    . ' at line 1, column %d$/',
                 preg_quote($firstRawName, '/'),
                 preg_quote($secondRawName, '/'),
                 preg_quote($expectedAttribute, '/'),
+                $expectedColumn,
             ),
         );
 

--- a/tests/Exception/SchemaExceptionTest.php
+++ b/tests/Exception/SchemaExceptionTest.php
@@ -1,0 +1,155 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PHPModelGenerator\Tests\Exception;
+
+use Exception;
+use PHPModelGenerator\Exception\SchemaException;
+use PHPModelGenerator\Model\SchemaDefinition\JsonSchema;
+use PHPUnit\Framework\TestCase;
+
+class SchemaExceptionTest extends TestCase
+{
+    public function testWithoutAJsonSchemaTheMessageIsUnchangedAndAllLocationAccessorsAreNull(): void
+    {
+        $exception = new SchemaException('Something went wrong');
+
+        $this->assertSame('Something went wrong', $exception->getMessage());
+        $this->assertNull($exception->getSchemaFile());
+        $this->assertNull($exception->getSourceLine());
+        $this->assertNull($exception->getSourceColumn());
+    }
+
+    public function testAJsonSchemaWithoutRawSourcePopulatesTheFileButNotTheLocation(): void
+    {
+        $jsonSchema = new JsonSchema('/path/to/schema.json', ['type' => 'object']);
+
+        $exception = new SchemaException('Something went wrong', $jsonSchema);
+
+        $this->assertSame('Something went wrong', $exception->getMessage());
+        $this->assertSame('/path/to/schema.json', $exception->getSchemaFile());
+        $this->assertNull($exception->getSourceLine());
+        $this->assertNull($exception->getSourceColumn());
+    }
+
+    public function testAResolvablePointerAppendsTheLocationToTheMessageAndPopulatesTheAccessors(): void
+    {
+        $rawSource = <<<'JSON'
+        {
+          "properties": {
+            "age": {
+              "minimum": 5
+            }
+          }
+        }
+        JSON;
+
+        $jsonSchema = new JsonSchema('/path/to/schema.json', [], '/properties/age/minimum', $rawSource);
+
+        $exception = new SchemaException('Value too small', $jsonSchema);
+
+        $this->assertSame('Value too small at line 4, column 18', $exception->getMessage());
+        $this->assertSame('/path/to/schema.json', $exception->getSchemaFile());
+        $this->assertSame(4, $exception->getSourceLine());
+        $this->assertSame(18, $exception->getSourceColumn());
+    }
+
+    /**
+     * A pointer that can't be located against the raw source (should not normally happen, since
+     * pointers are derived from navigating the same decoded structure) must not crash or produce
+     * a misleading location - it silently degrades to file-only reporting, the same as when no
+     * raw source is available at all.
+     */
+    public function testAnUnresolvablePointerLeavesTheMessageUnchangedAndTheLocationNull(): void
+    {
+        $jsonSchema = (new JsonSchema('/path/to/schema.json', ['type' => 'object'], '', '{"type": "object"}'))
+            ->withPointer('/does/not/exist');
+
+        $exception = new SchemaException('Something went wrong', $jsonSchema);
+
+        $this->assertSame('Something went wrong', $exception->getMessage());
+        $this->assertSame('/path/to/schema.json', $exception->getSchemaFile());
+        $this->assertNull($exception->getSourceLine());
+        $this->assertNull($exception->getSourceColumn());
+    }
+
+    public function testInvalidJsonAppendsTheLocationWhenTheSyntaxErrorLocatorFindsOne(): void
+    {
+        $exception = SchemaException::invalidJson('/path/to/schema.json', '{"a": 1,}');
+
+        $this->assertSame(
+            'Invalid JSON-Schema file /path/to/schema.json at line 1, column 9',
+            $exception->getMessage(),
+        );
+        $this->assertSame('/path/to/schema.json', $exception->getSchemaFile());
+        $this->assertSame(1, $exception->getSourceLine());
+        $this->assertSame(9, $exception->getSourceColumn());
+    }
+
+    /**
+     * Malformed UTF-8 is rejected by json_decode() but the syntax locator's simplified grammar
+     * walk can't pinpoint it (see JsonSyntaxErrorLocatorTest). invalidJson() must still report
+     * the file, just without a line/column suffix, rather than crashing or fabricating a position.
+     */
+    public function testInvalidJsonLeavesTheMessageUnchangedWhenTheSyntaxErrorLocatorFindsNoPosition(): void
+    {
+        $exception = SchemaException::invalidJson('/path/to/schema.json', "{\"a\": \"bad\x80byte\"}");
+
+        $this->assertSame('Invalid JSON-Schema file /path/to/schema.json', $exception->getMessage());
+        $this->assertSame('/path/to/schema.json', $exception->getSchemaFile());
+        $this->assertNull($exception->getSourceLine());
+        $this->assertNull($exception->getSourceColumn());
+    }
+
+    /**
+     * A generic wrapper exception (e.g. PropertyFactory's "Unresolved Reference ..." around a
+     * caught exception) constructed without its own JsonSchema must not hide a more specific
+     * location that a wrapped SchemaException already resolved.
+     */
+    public function testLocationAccessorsFallBackToAWrappedSchemaExceptionWhenThisExceptionHasNoneOfItsOwn(): void
+    {
+        $inner = SchemaException::invalidJson('/path/to/inner.json', '{"a": 1,}');
+
+        $outer = new SchemaException('Unresolved Reference ../inner.json in file /path/to/outer.json', null, 0, $inner);
+
+        $this->assertSame('/path/to/inner.json', $outer->getSchemaFile());
+        $this->assertSame(1, $outer->getSourceLine());
+        $this->assertSame(9, $outer->getSourceColumn());
+    }
+
+    /**
+     * When the outer exception resolves its own location, that location wins - it must not be
+     * overridden by whatever a wrapped previous exception happens to carry.
+     */
+    public function testLocationAccessorsPreferTheExceptionsOwnValuesOverAWrappedPrevious(): void
+    {
+        $inner = SchemaException::invalidJson('/path/to/inner.json', '{"a": 1,}');
+
+        $outerJsonSchema = new JsonSchema('/path/to/outer.json', ['type' => 'object'], '', '{"type": "object"}');
+        $outer = new SchemaException('Outer problem', $outerJsonSchema, 0, $inner);
+
+        $this->assertSame('/path/to/outer.json', $outer->getSchemaFile());
+    }
+
+    public function testLocationAccessorsStayNullWhenTheWrappedPreviousIsNotASchemaException(): void
+    {
+        $inner = new Exception('some unrelated failure');
+
+        $outer = new SchemaException('Unresolved Reference ../inner.json in file /path/to/outer.json', null, 0, $inner);
+
+        $this->assertNull($outer->getSchemaFile());
+        $this->assertNull($outer->getSourceLine());
+        $this->assertNull($outer->getSourceColumn());
+    }
+
+    public function testCodeAndPreviousArePassedThroughToTheBaseException(): void
+    {
+        $previous = new Exception('cause');
+
+        $exception = new SchemaException('wrapped', null, 42, $previous);
+
+        $this->assertSame(42, $exception->getCode());
+        $this->assertSame($previous, $exception->getPrevious());
+    }
+}

--- a/tests/Model/SchemaDefinition/JsonSchemaTest.php
+++ b/tests/Model/SchemaDefinition/JsonSchemaTest.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PHPModelGenerator\Tests\Model\SchemaDefinition;
+
+use PHPModelGenerator\Exception\SchemaException;
+use PHPModelGenerator\Model\SchemaDefinition\JsonSchema;
+use PHPUnit\Framework\TestCase;
+
+class JsonSchemaTest extends TestCase
+{
+    /**
+     * The segment itself doesn't exist in the decoded structure, so JsonPointerLocator can't
+     * resolve a position for it either - the exception still names the file and the failing
+     * segment, it just has no line/column to report.
+     */
+    public function testNavigatingToAnUnresolvableSegmentThrowsASchemaException(): void
+    {
+        $rawSource = '{"properties": {"age": {"type": "integer"}}}';
+        $jsonSchema = new JsonSchema('/path/to/schema.json', json_decode($rawSource, true), '', $rawSource);
+
+        try {
+            $jsonSchema->navigate('/properties/missing');
+            $this->fail('Expected a SchemaException to be thrown');
+        } catch (SchemaException $exception) {
+            $this->assertSame(
+                'Unresolved path segment missing in file /path/to/schema.json',
+                $exception->getMessage(),
+            );
+            $this->assertSame('/path/to/schema.json', $exception->getSchemaFile());
+            $this->assertNull($exception->getSourceLine());
+            $this->assertNull($exception->getSourceColumn());
+        }
+    }
+
+    public function testNavigatingToAnExistingPathReturnsTheSubSchemaWithoutThrowing(): void
+    {
+        $rawSource = '{"properties": {"age": {"type": "integer"}}}';
+        $jsonSchema = new JsonSchema('/path/to/schema.json', json_decode($rawSource, true), '', $rawSource);
+
+        $navigated = $jsonSchema->navigate('/properties/age');
+
+        $this->assertSame(['type' => 'integer'], $navigated->getJson());
+        $this->assertSame('/properties/age', $navigated->getPointer());
+    }
+}

--- a/tests/Objects/ReferencePropertyTest.php
+++ b/tests/Objects/ReferencePropertyTest.php
@@ -18,11 +18,6 @@ use stdClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\WithoutErrorHandler;
 
-/**
- * Class ReferencePropertyTest
- *
- * @package PHPModelGenerator\Tests\Objects
- */
 class ReferencePropertyTest extends AbstractPHPModelGeneratorTestCase
 {
     protected const EXTERNAL_JSON_DIRECTORIES = ['../ReferencePropertyTest_external'];
@@ -207,8 +202,12 @@ class ReferencePropertyTest extends AbstractPHPModelGeneratorTestCase
         return [
             'Internal path reference' => ['#/definitions/yearBetween1900and2000'],
             'Internal direct reference' => ['#yearBetween1900and2000'],
-            'External path reference' => ['../ReferencePropertyTest_external/library.json#/definitions/yearBetween1900and2000'],
-            'External direct reference' => ['../ReferencePropertyTest_external/library.json#yearBetween1900and2000'],
+            'External path reference' => [
+                '../ReferencePropertyTest_external/library.json#/definitions/yearBetween1900and2000',
+            ],
+            'External direct reference' => [
+                '../ReferencePropertyTest_external/library.json#yearBetween1900and2000',
+            ],
         ];
     }
 
@@ -262,10 +261,18 @@ class ReferencePropertyTest extends AbstractPHPModelGeneratorTestCase
     public static function recursiveExternalReferenceProvider(): array
     {
         return [
-            'external path reference to direct recursion' => ['../ReferencePropertyTest_external/recursiveLibrary.json#/definitions/personDirect'],
-            'external direct reference to direct recursion' => ['../ReferencePropertyTest_external/recursiveLibrary.json#personDirect'],
-            'external path reference to path recursion' => ['../ReferencePropertyTest_external/recursiveLibrary.json#/definitions/personPath'],
-            'external direct reference to path recursion' => ['../ReferencePropertyTest_external/recursiveLibrary.json#personPath'],
+            'external path reference to direct recursion' => [
+                '../ReferencePropertyTest_external/recursiveLibrary.json#/definitions/personDirect',
+            ],
+            'external direct reference to direct recursion' => [
+                '../ReferencePropertyTest_external/recursiveLibrary.json#personDirect',
+            ],
+            'external path reference to path recursion' => [
+                '../ReferencePropertyTest_external/recursiveLibrary.json#/definitions/personPath',
+            ],
+            'external direct reference to path recursion' => [
+                '../ReferencePropertyTest_external/recursiveLibrary.json#personPath',
+            ],
         ];
     }
 
@@ -274,7 +281,10 @@ class ReferencePropertyTest extends AbstractPHPModelGeneratorTestCase
         return array_merge(
             self::combineDataProvider(self::internalReferenceProvider(), self::internalReferenceProvider()),
             self::combineDataProvider(static::recursiveExternalReferenceProvider(), self::internalReferenceProvider()),
-            self::combineDataProvider(static::recursiveExternalReferenceProvider(), static::recursiveExternalReferenceProvider()),
+            self::combineDataProvider(
+                static::recursiveExternalReferenceProvider(),
+                static::recursiveExternalReferenceProvider(),
+            ),
         );
     }
 
@@ -683,7 +693,8 @@ class ReferencePropertyTest extends AbstractPHPModelGeneratorTestCase
             ],
             'network reference - absolute path to full URL $id' => [
                 $baseURL . 'ReferencePropertyTest/NestedExternalReference.json',
-                '/wol-soft/php-json-schema-model-generator/master/tests/Schema/ReferencePropertyTest_external/library.json',
+                '/wol-soft/php-json-schema-model-generator/master/tests/Schema/'
+                    . 'ReferencePropertyTest_external/library.json',
             ],
         ];
     }
@@ -694,7 +705,10 @@ class ReferencePropertyTest extends AbstractPHPModelGeneratorTestCase
     {
         $this->expectException(SchemaException::class);
         $this->expectExceptionMessageMatches(
-            sprintf('/Unresolved Reference %s#\/definitions\/family in file .*\.json/', str_replace('/', '\/', $reference)),
+            sprintf(
+                '/Unresolved Reference %s#\/definitions\/family in file .*\.json/',
+                str_replace('/', '\/', $reference),
+            ),
         );
 
         $this->generateClassFromFileTemplate('NestedExternalReference.json', [$id, $reference]);
@@ -723,7 +737,8 @@ class ReferencePropertyTest extends AbstractPHPModelGeneratorTestCase
             ],
             'network reference - absolute path to full URL $id' => [
                 $baseURL . 'ReferencePropertyTest/NestedExternalReference.json',
-                '/wol-soft/php-json-schema-model-generator/master/tests/Schema/ReferencePropertyTest_external/nonexistent.json',
+                '/wol-soft/php-json-schema-model-generator/master/tests/Schema/'
+                    . 'ReferencePropertyTest_external/nonexistent.json',
             ],
         ];
     }
@@ -734,6 +749,33 @@ class ReferencePropertyTest extends AbstractPHPModelGeneratorTestCase
         $this->expectExceptionMessage('A referenced schema on base level must provide an object definition');
 
         $this->generateClassFromFile('InvalidBaseReference.json');
+    }
+
+    /**
+     * When a $ref points at an external file that isn't valid JSON, PropertyFactory wraps the
+     * underlying SchemaException into a generic "Unresolved Reference" message - but the
+     * structured accessors must still expose the referenced file's own line/column, falling back
+     * through the wrapped exception rather than reporting the referencing file's location.
+     */
+    public function testExternalReferenceToMalformedJsonReportsTheReferencedFilesOwnLocation(): void
+    {
+        $this->expectException(SchemaException::class);
+        $this->expectExceptionMessageMatches(
+            '/^Unresolved Reference \.\.\/ReferencePropertyTest_external\/malformed\.json in file (.*)\.json$/',
+        );
+
+        try {
+            $this->generateClassFromFileTemplate(
+                'ObjectReference.json',
+                ['../ReferencePropertyTest_external/malformed.json'],
+            );
+        } catch (SchemaException $exception) {
+            $this->assertStringEndsWith('malformed.json', $exception->getSchemaFile());
+            $this->assertSame(7, $exception->getSourceLine());
+            $this->assertSame(3, $exception->getSourceColumn());
+
+            throw $exception;
+        }
     }
 
     /**

--- a/tests/Schema/ReferencePropertyTest_external/malformed.json
+++ b/tests/Schema/ReferencePropertyTest_external/malformed.json
@@ -1,0 +1,8 @@
+{
+  "type": "object",
+  "properties": {
+    "name": {
+      "type": "string"
+    },
+  }
+}

--- a/tests/SchemaProvider/OpenAPIv3ProviderTest.php
+++ b/tests/SchemaProvider/OpenAPIv3ProviderTest.php
@@ -19,6 +19,36 @@ class OpenAPIv3ProviderTest extends AbstractPHPModelGeneratorTestCase
         $this->generateClassFromFile('InvalidJSONSchema.json', null, false, true, OpenAPIv3Provider::class);
     }
 
+    /**
+     * The spec file decodes successfully (valid JSON), but its root value isn't an object/array,
+     * so there is nothing to build an Open API v3 spec from. No JsonSchema can be constructed for
+     * a non-array value, so this case has no location - it is reported by file name only.
+     */
+    #[DataProvider('nonObjectRootDataProvider')]
+    public function testNonObjectRootValueThrowsSchemaException(string $jsonContent): void
+    {
+        $tempFile = sys_get_temp_dir() . '/openApiV3ProviderTest_' . uniqid() . '.json';
+        file_put_contents($tempFile, $jsonContent);
+
+        try {
+            $this->expectException(SchemaException::class);
+            $this->expectExceptionMessageMatches('/^Invalid JSON-Schema file .+\.json$/');
+            new OpenAPIv3Provider($tempFile);
+        } finally {
+            @unlink($tempFile);
+        }
+    }
+
+    public static function nonObjectRootDataProvider(): array
+    {
+        return [
+            'boolean' => ['true'],
+            'integer' => ['42'],
+            'string' => ['"hello"'],
+            'null' => ['null'],
+        ];
+    }
+
     #[DataProvider('missingSchemasDataProvider')]
     public function testOpenApiV3JsonSchemaFileWithoutSchemasThrowsAnException(string $file): void
     {

--- a/tests/SchemaProvider/OpenAPIv3ProviderTest.php
+++ b/tests/SchemaProvider/OpenAPIv3ProviderTest.php
@@ -9,17 +9,12 @@ use PHPModelGenerator\SchemaProvider\OpenAPIv3Provider;
 use PHPModelGenerator\Tests\AbstractPHPModelGeneratorTestCase;
 use PHPUnit\Framework\Attributes\DataProvider;
 
-/**
- * Class OpenAPIv3ProviderTest
- *
- * @package PHPModelGenerator\Tests\SchemaProvider
- */
 class OpenAPIv3ProviderTest extends AbstractPHPModelGeneratorTestCase
 {
     public function testInvalidJsonSchemaFileThrowsAnException(): void
     {
         $this->expectException(SchemaException::class);
-        $this->expectExceptionMessageMatches('/^Invalid JSON-Schema file (.*)\.json$/');
+        $this->expectExceptionMessageMatches('/^Invalid JSON-Schema file (.*)\.json at line 5, column 2$/');
 
         $this->generateClassFromFile('InvalidJSONSchema.json', null, false, true, OpenAPIv3Provider::class);
     }
@@ -29,7 +24,7 @@ class OpenAPIv3ProviderTest extends AbstractPHPModelGeneratorTestCase
     {
         $this->expectException(SchemaException::class);
         $this->expectExceptionMessageMatches(
-            "/^Open API v3 spec file (.*)\.json doesn't contain any schemas to process$/",
+            "/^Open API v3 spec file (.*)\.json doesn't contain any schemas to process at line 1, column 1$/",
         );
 
         $this->generateClassFromFile($file, null, false, true, OpenAPIv3Provider::class);

--- a/tests/SchemaProvider/SingleFileProviderTest.php
+++ b/tests/SchemaProvider/SingleFileProviderTest.php
@@ -11,11 +11,6 @@ use PHPModelGenerator\SchemaProvider\SingleFileProvider;
 use PHPModelGenerator\Tests\AbstractPHPModelGeneratorTestCase;
 use PHPUnit\Framework\Attributes\DataProvider;
 
-/**
- * Class SingleFileProviderTest
- *
- * @package PHPModelGenerator\Tests\SchemaProvider
- */
 class SingleFileProviderTest extends AbstractPHPModelGeneratorTestCase
 {
     /**
@@ -73,6 +68,32 @@ class SingleFileProviderTest extends AbstractPHPModelGeneratorTestCase
             'non-existing file' => ['/non/existing/path.json'],
             'invalid JSON file' => [__DIR__ . '/../Schema/SingleFileProviderTest/InvalidJSON.json'],
         ];
+    }
+
+    /**
+     * A non-existing file has no raw text to scan, so getSourceLine()/getSourceColumn() stay null
+     * even though the message names the file. A file with malformed JSON content does have raw
+     * text on hand, so its location is resolved and exposed through the structured accessors.
+     */
+    public function testInvalidSourceLocationAccessorsReflectWhetherRawTextWasAvailable(): void
+    {
+        try {
+            new SingleFileProvider('/non/existing/path.json');
+            $this->fail('Expected a SchemaException to be thrown');
+        } catch (SchemaException $exception) {
+            $this->assertNull($exception->getSchemaFile());
+            $this->assertNull($exception->getSourceLine());
+            $this->assertNull($exception->getSourceColumn());
+        }
+
+        try {
+            new SingleFileProvider(__DIR__ . '/../Schema/SingleFileProviderTest/InvalidJSON.json');
+            $this->fail('Expected a SchemaException to be thrown');
+        } catch (SchemaException $exception) {
+            $this->assertStringEndsWith('InvalidJSON.json', $exception->getSchemaFile());
+            $this->assertSame(1, $exception->getSourceLine());
+            $this->assertSame(1, $exception->getSourceColumn());
+        }
     }
 
     /**

--- a/tests/Utils/Json/JsonLexerTest.php
+++ b/tests/Utils/Json/JsonLexerTest.php
@@ -160,4 +160,114 @@ class JsonLexerTest extends TestCase
 
         $this->assertSame(2, $lexer->getPosition()->column);
     }
+
+    public function testLexStringReturnsNullWhenNotPositionedAtAQuote(): void
+    {
+        $this->assertNull((new JsonLexer('123'))->lexString());
+    }
+
+    public function testLexStringReturnsNullForABackslashAtEndOfInput(): void
+    {
+        $unterminatedEscape = '"abc' . chr(92);
+
+        $this->assertNull((new JsonLexer($unterminatedEscape))->lexString());
+    }
+
+    public function testLexStringReturnsNullForALowSurrogateOutOfRange(): void
+    {
+        // A valid high surrogate followed by \u, but the second unit isn't a low surrogate.
+        $lexer = new JsonLexer('"\\ud83dA"');
+
+        $this->assertNull($lexer->lexString());
+    }
+
+    public function testLexStringReturnsNullForInvalidHexDigitsInUnicodeEscape(): void
+    {
+        $lexer = new JsonLexer('"\\uZZZZ"');
+
+        $this->assertNull($lexer->lexString());
+    }
+
+    public function testLexStringDecodesAnAsciiUnicodeEscape(): void
+    {
+        $lexer = new JsonLexer('"\\u0041"');
+
+        $this->assertSame('A', $lexer->lexString());
+    }
+
+    public function testLexStringDecodesAThreeByteBmpUnicodeEscape(): void
+    {
+        $lexer = new JsonLexer('"\\u4e2d"');
+
+        $this->assertSame('中', $lexer->lexString());
+    }
+
+    public function testColumnCountsARawThreeByteUtf8CharacterAsOneColumn(): void
+    {
+        $lexer = new JsonLexer("\"\xE4\xB8\xAD\"x");
+
+        $this->assertSame('中', $lexer->lexString());
+        $this->assertSame(4, $lexer->getPosition()->column);
+        $this->assertSame(5, $lexer->getPosition()->offset);
+    }
+
+    public function testColumnCountsARawFourByteUtf8CharacterAsOneColumn(): void
+    {
+        $lexer = new JsonLexer("\"\xF0\x9F\x98\x80\"x");
+
+        $this->assertSame("\u{1F600}", $lexer->lexString());
+        $this->assertSame(4, $lexer->getPosition()->column);
+        $this->assertSame(6, $lexer->getPosition()->offset);
+    }
+
+    public function testSkipValueReturnsFalseAtEndOfInput(): void
+    {
+        $this->assertFalse((new JsonLexer(''))->skipValue());
+    }
+
+    public function testSkipValueConsumesAnEmptyObject(): void
+    {
+        $lexer = new JsonLexer('{}x');
+
+        $this->assertTrue($lexer->skipValue());
+        $this->assertSame('x', $lexer->peekChar());
+    }
+
+    public function testSkipValueConsumesAnEmptyArray(): void
+    {
+        $lexer = new JsonLexer('[]x');
+
+        $this->assertTrue($lexer->skipValue());
+        $this->assertSame('x', $lexer->peekChar());
+    }
+
+    public function testSkipValueReturnsFalseForAnObjectWithANonStringKey(): void
+    {
+        $this->assertFalse((new JsonLexer('{bad: 1}'))->skipValue());
+    }
+
+    public function testSkipValueReturnsFalseForAnObjectMissingAColon(): void
+    {
+        $this->assertFalse((new JsonLexer('{"a" 1}'))->skipValue());
+    }
+
+    public function testSkipValueReturnsFalseForAnObjectWithAnInvalidValue(): void
+    {
+        $this->assertFalse((new JsonLexer('{"a": }'))->skipValue());
+    }
+
+    public function testSkipValueReturnsFalseForAnObjectWithUnexpectedTrailingContent(): void
+    {
+        $this->assertFalse((new JsonLexer('{"a": 1 "b": 2}'))->skipValue());
+    }
+
+    public function testSkipValueReturnsFalseForAnArrayWithAnInvalidElement(): void
+    {
+        $this->assertFalse((new JsonLexer('[1,]'))->skipValue());
+    }
+
+    public function testSkipValueReturnsFalseForAnArrayWithUnexpectedTrailingContent(): void
+    {
+        $this->assertFalse((new JsonLexer('[1 2]'))->skipValue());
+    }
 }

--- a/tests/Utils/Json/JsonLexerTest.php
+++ b/tests/Utils/Json/JsonLexerTest.php
@@ -1,0 +1,163 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PHPModelGenerator\Tests\Utils\Json;
+
+use PHPModelGenerator\Utils\Json\JsonLexer;
+use PHPUnit\Framework\TestCase;
+
+class JsonLexerTest extends TestCase
+{
+    public function testSkipWhitespaceAdvancesPastSpacesTabsAndNewlines(): void
+    {
+        $lexer = new JsonLexer(" \t\n\r \"x\"");
+        $lexer->skipWhitespace();
+
+        $this->assertSame('"', $lexer->peekChar());
+    }
+
+    public function testLexStringDecodesSimpleEscapeSequences(): void
+    {
+        $lexer = new JsonLexer('"a\\"b\\\\c\\/d\\be\\ff\\ng\\rh\\ti"');
+
+        $this->assertSame("a\"b\\c/d\x08e\x0Cf\ng\rh\ti", $lexer->lexString());
+    }
+
+    public function testLexStringDecodesUnicodeEscape(): void
+    {
+        $lexer = new JsonLexer('"caf\\u00e9"');
+
+        $this->assertSame('café', $lexer->lexString());
+    }
+
+    public function testLexStringDecodesSurrogatePairEscape(): void
+    {
+        $lexer = new JsonLexer('"\\ud83d\\ude00"');
+
+        $this->assertSame("\u{1F600}", $lexer->lexString());
+    }
+
+    public function testLexStringReturnsNullForUnterminatedString(): void
+    {
+        $lexer = new JsonLexer('"unterminated');
+
+        $this->assertNull($lexer->lexString());
+    }
+
+    public function testLexStringReturnsNullForUnescapedControlCharacter(): void
+    {
+        $lexer = new JsonLexer("\"broken\nstring\"");
+
+        $this->assertNull($lexer->lexString());
+    }
+
+    public function testLexStringReturnsNullForInvalidEscapeSequence(): void
+    {
+        $lexer = new JsonLexer('"bad\\qescape"');
+
+        $this->assertNull($lexer->lexString());
+    }
+
+    public function testLexStringReturnsNullForIncompleteUnicodeEscape(): void
+    {
+        $lexer = new JsonLexer('"bad\\u12"');
+
+        $this->assertNull($lexer->lexString());
+    }
+
+    public function testLexStringReturnsNullForUnpairedHighSurrogate(): void
+    {
+        $lexer = new JsonLexer('"\\ud83donly"');
+
+        $this->assertNull($lexer->lexString());
+    }
+
+    public function testLexNumberMatchesIntegerFloatAndExponentForms(): void
+    {
+        $this->assertSame('42', (new JsonLexer('42'))->lexNumber());
+        $this->assertSame('-42', (new JsonLexer('-42'))->lexNumber());
+        $this->assertSame('3.14', (new JsonLexer('3.14'))->lexNumber());
+        $this->assertSame('1.5e10', (new JsonLexer('1.5e10'))->lexNumber());
+        $this->assertSame('1E-10', (new JsonLexer('1E-10'))->lexNumber());
+    }
+
+    public function testLexNumberStopsAtLeadingZeroBoundary(): void
+    {
+        $lexer = new JsonLexer('01');
+
+        // "0" is the longest valid JSON number at this position; the leading-zero rule means
+        // the following "1" is not part of it and is left for the caller to reject.
+        $this->assertSame('0', $lexer->lexNumber());
+        $this->assertSame('1', $lexer->peekChar());
+    }
+
+    public function testLexNumberReturnsNullWhenNoNumberStartsHere(): void
+    {
+        $lexer = new JsonLexer('"not a number"');
+
+        $this->assertNull($lexer->lexNumber());
+    }
+
+    public function testLexLiteralMatchesTrueFalseAndNull(): void
+    {
+        $this->assertSame('true', (new JsonLexer('true'))->lexLiteral());
+        $this->assertSame('false', (new JsonLexer('false'))->lexLiteral());
+        $this->assertSame('null', (new JsonLexer('null'))->lexLiteral());
+    }
+
+    public function testLexLiteralRejectsPartialMatchFollowedByIdentifierChar(): void
+    {
+        $this->assertNull((new JsonLexer('truex'))->lexLiteral());
+        $this->assertNull((new JsonLexer('nullable'))->lexLiteral());
+    }
+
+    public function testMatchCharConsumesOnlyOnExactMatch(): void
+    {
+        $lexer = new JsonLexer('{}');
+
+        $this->assertFalse($lexer->matchChar('['));
+        $this->assertTrue($lexer->matchChar('{'));
+        $this->assertSame('}', $lexer->peekChar());
+    }
+
+    public function testSkipValueConsumesNestedObjectsAndArraysWithoutValidating(): void
+    {
+        $lexer = new JsonLexer('{"a": [1, 2, {"b": "c"}], "d": null}, "next"');
+
+        $this->assertTrue($lexer->skipValue());
+        $this->assertSame(',', $lexer->peekChar());
+    }
+
+    public function testCrlfLineBreakIsCountedAsASingleLine(): void
+    {
+        $lexer = new JsonLexer("\"a\"\r\n\"b\"");
+
+        $lexer->lexString();
+        $lexer->skipWhitespace();
+        $position = $lexer->getPosition();
+
+        $this->assertSame(2, $position->line);
+        $this->assertSame(1, $position->column);
+    }
+
+    public function testColumnCountsUtf8CharactersNotBytes(): void
+    {
+        $lexer = new JsonLexer('"café"x');
+
+        $lexer->lexString();
+        $position = $lexer->getPosition();
+
+        // the 4-char string "café" (é is a 2-byte UTF-8 sequence) plus 2 quotes = column 7
+        $this->assertSame(7, $position->column);
+        $this->assertSame(7, $position->offset);
+    }
+
+    public function testTabCountsAsASingleColumn(): void
+    {
+        $lexer = new JsonLexer("\t\"x\"");
+        $lexer->skipWhitespace();
+
+        $this->assertSame(2, $lexer->getPosition()->column);
+    }
+}

--- a/tests/Utils/Json/JsonPointerLocatorTest.php
+++ b/tests/Utils/Json/JsonPointerLocatorTest.php
@@ -1,0 +1,96 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PHPModelGenerator\Tests\Utils\Json;
+
+use PHPModelGenerator\Model\SchemaDefinition\JsonSchema;
+use PHPModelGenerator\Utils\Json\JsonPointerLocator;
+use PHPUnit\Framework\TestCase;
+
+class JsonPointerLocatorTest extends TestCase
+{
+    public function testLocatesValueThroughNestedObjectPointer(): void
+    {
+        $json = <<<'JSON'
+        {
+          "properties": {
+            "age": {
+              "minimum": 5
+            }
+          }
+        }
+        JSON;
+
+        $position = JsonPointerLocator::locate($json, '/properties/age/minimum');
+
+        $this->assertSame(4, $position->line);
+        $this->assertSame(18, $position->column);
+    }
+
+    public function testLocatesValueThroughArrayIndexPointer(): void
+    {
+        $position = JsonPointerLocator::locate('{"items": [10, 20, 30]}', '/items/2');
+
+        $this->assertSame(1, $position->line);
+        $this->assertSame(20, $position->column);
+    }
+
+    public function testEmptyPointerLocatesTheDocumentRoot(): void
+    {
+        $position = JsonPointerLocator::locate('  {"a": 1}', '');
+
+        $this->assertSame(1, $position->line);
+        $this->assertSame(3, $position->column);
+    }
+
+    public function testDuplicateObjectKeysResolveToTheLastOccurrence(): void
+    {
+        $json = <<<'JSON'
+        {
+          "a": 1,
+          "a": 2
+        }
+        JSON;
+
+        $position = JsonPointerLocator::locate($json, '/a');
+
+        $this->assertSame(3, $position->line);
+    }
+
+    public function testPatternPropertiesKeyContainingTildeAndSlashResolvesViaPointerEscaping(): void
+    {
+        $regexKey = '^S~/';
+        $json = '{"patternProperties": {"' . $regexKey . '": {"type": "string"}}}';
+        $pointer = '/patternProperties/' . JsonSchema::encodePointer($regexKey);
+
+        $position = JsonPointerLocator::locate($json, $pointer);
+
+        $this->assertSame(strpos($json, '{"type"'), $position->offset);
+    }
+
+    public function testUnresolvedPointerReturnsNullInsteadOfThrowing(): void
+    {
+        $this->assertNull(JsonPointerLocator::locate('{"a": 1}', '/b'));
+        $this->assertNull(JsonPointerLocator::locate('{"a": 1}', '/a/b'));
+        $this->assertNull(JsonPointerLocator::locate('{"items": [1, 2]}', '/items/5'));
+        $this->assertNull(JsonPointerLocator::locate('{"a": 1}', '/-'));
+    }
+
+    public function testUnicodeEscapedKeyMatchesTheDecodedPointerSegment(): void
+    {
+        $position = JsonPointerLocator::locate('{"caf\\u00e9": 1}', '/café');
+
+        $this->assertSame(14, $position->offset);
+        $this->assertSame(15, $position->column);
+    }
+
+    public function testCrlfLineEndingsAreCountedAsASingleLineBreak(): void
+    {
+        $json = "{\r\n  \"a\": {\r\n    \"b\": 1\r\n  }\r\n}";
+
+        $position = JsonPointerLocator::locate($json, '/a/b');
+
+        $this->assertSame(3, $position->line);
+    }
+}

--- a/tests/Utils/Json/JsonPointerLocatorTest.php
+++ b/tests/Utils/Json/JsonPointerLocatorTest.php
@@ -93,4 +93,35 @@ class JsonPointerLocatorTest extends TestCase
 
         $this->assertSame(3, $position->line);
     }
+
+    public function testAnEmptyObjectResolvesNoSegment(): void
+    {
+        $this->assertNull(JsonPointerLocator::locate('{}', '/a'));
+    }
+
+    public function testAnEmptyArrayResolvesNoSegment(): void
+    {
+        $this->assertNull(JsonPointerLocator::locate('{"items": []}', '/items/0'));
+    }
+
+    /**
+     * The locator assumes it is only ever given text that already passed json_decode, but it must
+     * still degrade gracefully - never throw or produce a wrong position - if that assumption is
+     * ever violated (a caller bug, or a race between reading the file and reporting the error).
+     */
+    public function testMalformedTextIsResolvedAsNullRatherThanThrowingOrMisreporting(): void
+    {
+        $this->assertNull(JsonPointerLocator::locate('{bad: 1}', '/a'));
+        $this->assertNull(JsonPointerLocator::locate('{"a" 1}', '/a'));
+        $this->assertNull(JsonPointerLocator::locate('{"a": }', '/a'));
+        $this->assertNull(JsonPointerLocator::locate('{"a": 1 "b": 2}', '/b'));
+        $this->assertNull(JsonPointerLocator::locate('[}]', '/0'));
+        $this->assertNull(JsonPointerLocator::locate('[1 2]', '/1'));
+    }
+
+    public function testAnArrayIndexSegmentInAnInvalidFormatResolvesToNull(): void
+    {
+        $this->assertNull(JsonPointerLocator::locate('{"items": [1, 2]}', '/items/abc'));
+        $this->assertNull(JsonPointerLocator::locate('{"items": [1, 2]}', '/items/-1'));
+    }
 }

--- a/tests/Utils/Json/JsonSyntaxErrorLocatorTest.php
+++ b/tests/Utils/Json/JsonSyntaxErrorLocatorTest.php
@@ -90,6 +90,34 @@ class JsonSyntaxErrorLocatorTest extends TestCase
         $this->assertSame(5, $position->offset);
     }
 
+    public function testAnInvalidEscapeInAnObjectKeyIsReportedAtTheKey(): void
+    {
+        $position = JsonSyntaxErrorLocator::locate('{"ab\\c": 1}');
+
+        $this->assertSame(1, $position->line);
+        $this->assertSame(6, $position->column);
+        $this->assertSame(5, $position->offset);
+    }
+
+    public function testAnEmptyArrayIsFullyValidAndReportsNoError(): void
+    {
+        $this->assertNull(JsonSyntaxErrorLocator::locate('[]'));
+    }
+
+    public function testAPopulatedArrayThatClosesCleanlyIsFullyValidAndReportsNoError(): void
+    {
+        $this->assertNull(JsonSyntaxErrorLocator::locate('{"a": [1, 2, 3]}'));
+    }
+
+    public function testAMissingCommaBetweenArrayElementsIsReportedAtTheUnexpectedToken(): void
+    {
+        $position = JsonSyntaxErrorLocator::locate('[1 2]');
+
+        $this->assertSame(1, $position->line);
+        $this->assertSame(4, $position->column);
+        $this->assertSame(3, $position->offset);
+    }
+
     /**
      * The lexer's grammar walk treats any byte sequence starting with 0x80-0xF7 as a plausible
      * multi-byte UTF-8 character without validating the continuation bytes - it does not perform

--- a/tests/Utils/Json/JsonSyntaxErrorLocatorTest.php
+++ b/tests/Utils/Json/JsonSyntaxErrorLocatorTest.php
@@ -1,0 +1,110 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PHPModelGenerator\Tests\Utils\Json;
+
+use PHPModelGenerator\Utils\Json\JsonSyntaxErrorLocator;
+use PHPUnit\Framework\TestCase;
+
+class JsonSyntaxErrorLocatorTest extends TestCase
+{
+    public function testEmptyFileIsReportedAtTheDocumentStart(): void
+    {
+        $position = JsonSyntaxErrorLocator::locate('');
+
+        $this->assertSame(1, $position->line);
+        $this->assertSame(1, $position->column);
+        $this->assertSame(0, $position->offset);
+    }
+
+    public function testTrailingCommaIsReportedAtTheUnexpectedClosingBrace(): void
+    {
+        $position = JsonSyntaxErrorLocator::locate('{"a": 1,}');
+
+        $this->assertSame(1, $position->line);
+        $this->assertSame(9, $position->column);
+        $this->assertSame(8, $position->offset);
+    }
+
+    public function testUnterminatedStringIsReportedAtTheOffendingRawNewline(): void
+    {
+        $position = JsonSyntaxErrorLocator::locate("{\n  \"a\": \"unterminated\n}");
+
+        $this->assertSame(2, $position->line);
+        $this->assertSame(21, $position->column);
+        $this->assertSame(22, $position->offset);
+    }
+
+    public function testTruncatedInputIsReportedAtTheEndOfFile(): void
+    {
+        $position = JsonSyntaxErrorLocator::locate('{"a": 1');
+
+        $this->assertSame(1, $position->line);
+        $this->assertSame(8, $position->column);
+        $this->assertSame(7, $position->offset);
+    }
+
+    public function testUnexpectedTokenIsReportedAtItsStart(): void
+    {
+        $position = JsonSyntaxErrorLocator::locate('{"a": tru}');
+
+        $this->assertSame(1, $position->line);
+        $this->assertSame(7, $position->column);
+        $this->assertSame(6, $position->offset);
+    }
+
+    public function testTrailingGarbageAfterAValidDocumentIsReportedAtItsStart(): void
+    {
+        $position = JsonSyntaxErrorLocator::locate('{"a": 1} extra');
+
+        $this->assertSame(1, $position->line);
+        $this->assertSame(10, $position->column);
+        $this->assertSame(9, $position->offset);
+    }
+
+    public function testLeadingZeroLeavesTheExtraDigitAsAnUnexpectedToken(): void
+    {
+        $position = JsonSyntaxErrorLocator::locate('{"a": 01}');
+
+        $this->assertSame(1, $position->line);
+        $this->assertSame(8, $position->column);
+        $this->assertSame(7, $position->offset);
+    }
+
+    public function testUnexpectedCharacterInsideANestedArrayIsReportedAtThatDepth(): void
+    {
+        $position = JsonSyntaxErrorLocator::locate('{"items": [1, 2, ,]}');
+
+        $this->assertSame(1, $position->line);
+        $this->assertSame(18, $position->column);
+        $this->assertSame(17, $position->offset);
+    }
+
+    public function testMissingColonAfterKeyIsReportedAtTheUnexpectedToken(): void
+    {
+        $position = JsonSyntaxErrorLocator::locate('{"a" 1}');
+
+        $this->assertSame(1, $position->line);
+        $this->assertSame(6, $position->column);
+        $this->assertSame(5, $position->offset);
+    }
+
+    /**
+     * The lexer's grammar walk treats any byte sequence starting with 0x80-0xF7 as a plausible
+     * multi-byte UTF-8 character without validating the continuation bytes - it does not perform
+     * the strict UTF-8 validation json_decode() does. A lone/invalid continuation byte therefore
+     * "parses" cleanly under this scanner even though json_decode() rejects the same input with
+     * JSON_ERROR_UTF8. The locator must return null (not a wrong/misleading position) so callers
+     * fall back to file-only reporting rather than presenting a confusing location.
+     */
+    public function testMalformedUtf8ThatOnlyJsonDecodeRejectsReturnsNullInsteadOfAWrongPosition(): void
+    {
+        $json = "{\"a\": \"bad\x80byte\"}";
+
+        $this->assertNull(json_decode($json, true));
+        $this->assertSame(JSON_ERROR_UTF8, json_last_error());
+
+        $this->assertNull(JsonSyntaxErrorLocator::locate($json));
+    }
+}


### PR DESCRIPTION
Schema-processing errors now report where in the source file the problem
occurred. A minimal JSON lexer (src/Utils/Json/) resolves a JsonSchema's
RFC 6901 pointer against the raw source text for semantic errors, or scans
for the first syntax break when JSON decoding fails outright. JsonSchema
gained an optional raw-source parameter so built-in providers (and custom
SchemaProviderInterface implementations that opt in) can supply it.

SchemaException exposes getSchemaFile()/getSourceLine()/getSourceColumn()
and appends "at line X, column Y" to the message when resolvable; the
accessors fall back through a wrapped previous SchemaException so generic
wrapper messages (e.g. "Unresolved Reference ...") don't hide a more
specific nested location. Every existing throw site was migrated to pass
its JsonSchema where one is in scope.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>