### PR TITLE
Validation error message readability (issue #131): jsonPointer + real array-item names

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -223,6 +223,55 @@ If a production-library class lacks the required type hints (needed for reflecti
 derivation), the fix is to add or update the callable in the production library, not to create
 a wrapper class here.
 
+### Exception message conventions
+
+`ValidationException` subclasses live in `php-json-schema-model-generator-production`
+(`src/Exception/**`), not in this repo, but message wording must stay consistent across both
+repos since a single wording pass touches both. Follow these conventions for every new or edited
+exception message:
+
+- **Quote every interpolated identifier.** Property names, nested keys, patterns, filter tokens,
+  and type/class names embedded directly in message text are wrapped in single quotes:
+  `"Value for '$propertyName' must not be smaller than {$this->minimum}"`. This applies even to
+  synthetic/placeholder names used as a message-text label (e.g. `'additional property'`,
+  `'pattern property'`, `'additional item'`) and to the class-name placeholder used by base
+  validators that have no access to the real property name — quote it too, for visual consistency
+  with every other message, even though it isn't a real property name.
+- **No trailing periods**, including on header sentences that introduce a nested bullet list
+  (composition, conditional, tuple, additional/pattern properties). A two-clause message uses a
+  colon instead of splicing two sentences together: `"Tuple array '%s' contains not allowed
+  additional items: expected %s items, got %s"`, not `"... items. Expected %s items, got %s"`.
+- **Lists of names get every entry quoted individually**, not just wrapped as a group:
+  `['additional1', 'additional2']`, not `[additional1, additional2]`.
+- **The expected ("requires") and actual ("got") sides of a type mismatch are not
+  interchangeable formats.** `InvalidTypeException`'s expected side uses the generator's internal
+  type name (`'int'`, `'bool'`, `'float'`, `'object'`, `'array'`, `'string'`, `'null'`) — the same
+  short forms `Model\Property\PropertyType` uses — while the actual/"got" side is always
+  `gettype($providedValue)` (or `$providedValue::class` for objects) *verbatim*, never abbreviated:
+  `"integer"`, `"boolean"`, `"double"`, `"NULL"`, `"array"`, or a class name. Do not "normalize"
+  one side to match the other's format — they come from different sources and are deliberately
+  different token sets. A test asserting `"got int"` instead of `"got integer"` happens to still
+  pass today only because `"int"` is a text-prefix of `"integer"` and the assertion uses substring
+  containment — that's a latent bug in the test, not a sign the abbreviated form is correct; fix
+  the test to the full `gettype()` word instead of copying the abbreviation forward.
+- **Enum/const values** render through `PHPModelGenerator\Exception\ValueFormatter::format()`
+  (json_encode-based, `var_export` fallback for non-encodable values) — never hand-roll formatting
+  for a provided/expected/allowed value; add a case to `ValueFormatter` if a new value shape needs
+  special handling.
+- **Watch for message-prefix collisions with unrelated exceptions.** More than one
+  generation-time `SchemaException` in this repo's `src/` builds a message that shares an exact
+  literal prefix with a different runtime exception in the production repo (e.g. both
+  `FilterValidator`'s zero-overlap `SchemaException` and `IncompatibleFilterException` start with
+  `"Filter %s is not compatible with property type %s for property %s"`; both
+  `DefaultValueModifier`'s `SchemaException` and `InvalidTypeException` start with `"Invalid type
+  for "`). When editing one, grep the *other* repo for the same leading phrase before assuming a
+  wording change is isolated to the exception you're touching — a shared prefix means a test
+  asserting a substring/prefix match against one can silently start matching (or stop matching)
+  text produced by the other.
+- When changing wording, grep both repos' `tests/` and `docs/source/` for the old phrase before
+  considering the change done — message text is asserted in dozens of places across the generator
+  repo's integration tests and documented as literal examples in `docs/source/**/*.rst`.
+
 ### Staging changes
 
 After finishing an implementation task, always stage all relevant changed files for commit using

--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ $person->setAge(-10);
 More complex exception messages eg. from a [allOf](https://json-schema.org/understanding-json-schema/reference/combining.html#allof) composition may look like:
 ```
 Invalid value for Animal declined by composition constraint.
-  Requires to match 3 composition elements but matched 1 elements.
+  Requires to match 3 composition elements but matched 1 element.
   - Composition element #1: Failed
     * Value for age must not be smaller than 0
   - Composition element #2: Valid

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     ],
     "require": {
         "wol-soft/php-json-schema-model-generator-production": "dev-master",
-        "wol-soft/php-micro-template": "^1.10.2",
+        "wol-soft/php-micro-template": "^1.11.0",
         "psr/log": "^3.0",
 
         "php": ">=8.4",

--- a/docs/source/combinedSchemas/allOf.rst
+++ b/docs/source/combinedSchemas/allOf.rst
@@ -50,7 +50,7 @@ Possible exception (if eg. 5 is provided, which matches only one subschema):
 .. code-block:: none
 
     Invalid value for 'example' declined by composition constraint
-      Requires to match all composition elements but matched 1 elements
+      Requires to match all composition elements but matched 1 element
       - Composition element #1: Valid
       - Composition element #2: Failed
         * Value for 'example' must be a multiple of 3

--- a/docs/source/combinedSchemas/allOf.rst
+++ b/docs/source/combinedSchemas/allOf.rst
@@ -38,22 +38,22 @@ Possible exception (eg. if a string is provided):
 
 .. code-block:: none
 
-    Invalid value for example declined by composition constraint.
-      Requires to match all composition elements but matched 0 elements.
+    Invalid value for 'example' declined by composition constraint
+      Requires to match all composition elements but matched 0 elements
       - Composition element #1: Failed
-        * Invalid type for example. Requires float, got string
+        * Invalid type for 'example': requires 'float', got 'string'
       - Composition element #2: Failed
-        * Invalid type for example. Requires float, got string
+        * Invalid type for 'example': requires 'float', got 'string'
 
 Possible exception (if eg. 5 is provided, which matches only one subschema):
 
 .. code-block:: none
 
-    Invalid value for example declined by composition constraint.
-      Requires to match all composition elements but matched 1 elements.
+    Invalid value for 'example' declined by composition constraint
+      Requires to match all composition elements but matched 1 elements
       - Composition element #1: Valid
       - Composition element #2: Failed
-        * Value for example must be a multiple of 3
+        * Value for 'example' must be a multiple of 3
 
 The thrown exception will be a *PHPModelGenerator\\Exception\\ComposedValue\\AllOfException* which provides the following methods to get further error details:
 

--- a/docs/source/combinedSchemas/anyOf.rst
+++ b/docs/source/combinedSchemas/anyOf.rst
@@ -38,12 +38,12 @@ Possible exception (if a string is provided):
 
 .. code-block:: none
 
-    Invalid value for example declined by composition constraint.
-      Requires to match at least one composition element.
+    Invalid value for 'example' declined by composition constraint
+      Requires to match at least one composition element
       - Composition element #1: Failed
-        * Invalid type for example. Requires float, got string
+        * Invalid type for 'example': requires 'float', got 'string'
       - Composition element #2: Failed
-        * Invalid type for example. Requires float, got string
+        * Invalid type for 'example': requires 'float', got 'string'
 
 The thrown exception will be a *PHPModelGenerator\\Exception\\ComposedValue\\AnyOfException* which provides the following methods to get further error details:
 

--- a/docs/source/combinedSchemas/if.rst
+++ b/docs/source/combinedSchemas/if.rst
@@ -37,20 +37,20 @@ Possible exception (in this case 50 was provided so the if condition succeeds bu
 
 .. code-block:: none
 
-    Invalid value for example declined by conditional composition constraint
+    Invalid value for 'example' declined by conditional composition constraint
       - Condition: Valid
       - Conditional branch failed:
-        * Value for example must not be smaller than 100
+        * Value for 'example' must not be smaller than 100
 
 Another example exception with 101 as value for the property:
 
 .. code-block:: none
 
-    Invalid value for example declined by conditional composition constraint
+    Invalid value for 'example' declined by conditional composition constraint
       - Condition: Failed
-        * Value for example must be a multiple of 5
+        * Value for 'example' must be a multiple of 5
       - Conditional branch failed:
-        * Value for example must not be larger than 100
+        * Value for 'example' must not be larger than 100
 
 The thrown exception will be a *PHPModelGenerator\\Exception\\ComposedValue\\ConditionalException* which provides the following methods to get further error details:
 

--- a/docs/source/combinedSchemas/not.rst
+++ b/docs/source/combinedSchemas/not.rst
@@ -30,7 +30,7 @@ Possible exceptions:
 .. code-block:: none
 
     Invalid value for 'example' declined by composition constraint
-      Requires to match none composition element but matched 1 elements
+      Requires to match none composition element but matched 1 element
       - Composition element #1: Valid
 
 The thrown exception will be a *PHPModelGenerator\\Exception\\ComposedValue\\NotException* which provides the following methods to get further error details:

--- a/docs/source/combinedSchemas/not.rst
+++ b/docs/source/combinedSchemas/not.rst
@@ -29,8 +29,8 @@ Possible exceptions:
 
 .. code-block:: none
 
-    Invalid value for property declined by composition constraint.
-      Requires to match none composition element but matched 1 elements.
+    Invalid value for 'example' declined by composition constraint
+      Requires to match none composition element but matched 1 elements
       - Composition element #1: Valid
 
 The thrown exception will be a *PHPModelGenerator\\Exception\\ComposedValue\\NotException* which provides the following methods to get further error details:

--- a/docs/source/combinedSchemas/oneOf.rst
+++ b/docs/source/combinedSchemas/oneOf.rst
@@ -38,20 +38,20 @@ Possible exception (if a string is provided):
 
 .. code-block:: none
 
-    Invalid value for example declined by composition constraint.
-      Requires to match one composition element but matched 0 elements.
+    Invalid value for 'example' declined by composition constraint
+      Requires to match one composition element but matched 0 elements
       - Composition element #1: Failed
-        * Invalid type for example. Requires float, got string
+        * Invalid type for 'example': requires 'float', got 'string'
       - Composition element #2: Failed
-        * Invalid type for example. Requires float, got string
+        * Invalid type for 'example': requires 'float', got 'string'
 
 
 Possible exception (if eg. 15 is provided, which matches both subschemas):
 
 .. code-block:: none
 
-    Invalid value for example declined by composition constraint.
-      Requires to match one composition element but matched 2 elements.
+    Invalid value for 'example' declined by composition constraint
+      Requires to match one composition element but matched 2 elements
       - Composition element #1: Valid
       - Composition element #2: Valid
 

--- a/docs/source/complexTypes/array.rst
+++ b/docs/source/complexTypes/array.rst
@@ -30,7 +30,7 @@ Generated interface:
 
 Possible exceptions:
 
-* Invalid type for example. Requires array, got __TYPE__
+* Invalid type for 'example': requires 'array', got '__TYPE__'
 
 The thrown exception will be a *PHPModelGenerator\\Exception\\Generic\\InvalidTypeException* which provides the following methods to get further error details:
 
@@ -70,9 +70,9 @@ With a schema like this all items must contain a string with at least two charac
 
 .. code-block:: none
 
-    Invalid items in array example:
+    Invalid items in array 'example':
       - invalid item #3
-        * Invalid type for item of array example. Requires string, got double
+        * Invalid type for 'example': requires 'string', got 'double'
 
 The thrown exception will be a *PHPModelGenerator\\Exception\\Arrays\\InvalidItemException* which provides the following methods to get further error details:
 
@@ -192,11 +192,11 @@ If invalid tuples are provided a detailed exception will be thrown containing al
 
 .. code-block:: none
 
-    Invalid tuple item in array example:
+    Invalid tuple item in array 'example':
       - invalid tuple #1
-        * Invalid type for tuple item #1 of array example. Requires string, got int
+        * Invalid type for 'tuple item #1 of array example': requires 'string', got 'integer'
       - invalid tuple #1
-        * Invalid type for name. Requires string, got boolean
+        * Invalid type for 'name': requires 'string', got 'boolean'
 
 The thrown exception will be a *PHPModelGenerator\\Exception\\Arrays\\InvalidTupleException* which provides the following methods to get further error details:
 
@@ -251,7 +251,7 @@ Using the keyword `additionalItems` the array can be limited to not contain any 
 
 Possible exceptions:
 
-* Tuple array example contains not allowed additional items. Expected 2 items, got 3
+* Tuple array 'example' contains not allowed additional items: expected 2 items, got 3
 
 The thrown exception will be a *PHPModelGenerator\\Exception\\Arrays\\AdditionalTupleItemsException* which provides the following methods to get further error details:
 
@@ -272,11 +272,11 @@ If invalid additional items are provided a detailed exception will be thrown con
 
 .. code-block:: none
 
-    Tuple array property contains invalid additional items.
+    Tuple array 'property' contains invalid additional items
       - invalid additional item '3'
-        * Invalid type for name. Requires string, got integer
+        * Invalid type for 'name': requires 'string', got 'integer'
       - invalid additional item '5'
-        * Invalid type for additional item. Requires object, got int
+        * Invalid type for 'additional item': requires 'object', got 'integer'
 
 The thrown exception will be a *PHPModelGenerator\\Exception\\Arrays\\InvalidAdditionalTupleItemsException* which provides the following methods to get further error details:
 
@@ -313,7 +313,7 @@ The contains check uses a schema which must match at least one of the items prov
 
 Possible exceptions:
 
-* No item in array example matches contains constraint
+* No item in array 'example' matches the 'contains' constraint
 
 The thrown exception will be a *PHPModelGenerator\\Exception\\Arrays\\ContainsException* which provides the following methods to get further error details:
 
@@ -355,8 +355,8 @@ To limit the size of an array use the `minItems` and `maxItems` keywords.
 
 Possible exceptions:
 
-* Array example must not contain less than 2 items
-* Array example must not contain more than 5 items
+* Array 'example' must not contain less than 2 items
+* Array 'example' must not contain more than 5 items
 
 The thrown exception will be a *PHPModelGenerator\\Exception\\Arrays\\MaxItemsException* or a *PHPModelGenerator\\Exception\\Arrays\\MinItemsException* which provides the following methods to get further error details:
 
@@ -393,7 +393,7 @@ The items of an array can be forced to be unique with the `uniqueItems` keyword.
 
 Possible exceptions:
 
-* Items of array example are not unique
+* Items of array 'example' are not unique
 
 The thrown exception will be an *PHPModelGenerator\\Exception\\Arrays\\UniqueItemsException* which provides the following methods to get further error details:
 

--- a/docs/source/complexTypes/enum.rst
+++ b/docs/source/complexTypes/enum.rst
@@ -29,7 +29,7 @@ Generated interface:
 
 Possible exceptions:
 
-* Invalid type for example. Requires string, got __TYPE__
+* Invalid type for 'example': requires 'string', got '__TYPE__'
 * Value for 'example' must be one of ["ABC","DEF"], got "GHI"
 
 Untyped Enum

--- a/docs/source/complexTypes/enum.rst
+++ b/docs/source/complexTypes/enum.rst
@@ -30,7 +30,7 @@ Generated interface:
 Possible exceptions:
 
 * Invalid type for example. Requires string, got __TYPE__
-* Invalid value for example declined by enum constraint
+* Value for 'example' must be one of ["ABC","DEF"], got "GHI"
 
 Untyped Enum
 ------------
@@ -58,7 +58,7 @@ Generated interface (no typehints are generated as it's a mixed untyped enum. If
 
 Possible exceptions:
 
-* Invalid value for example declined by enum constraint
+* Value for 'example' must be one of ["ABC",10,true,null], got "GHI"
 
 The thrown exception will be an *PHPModelGenerator\\Exception\\Generic\\EnumException* which provides the following methods to get further error details:
 

--- a/docs/source/complexTypes/multiType.rst
+++ b/docs/source/complexTypes/multiType.rst
@@ -25,7 +25,7 @@ Generated interface:
 
 Possible exceptions:
 
-* Invalid type for property. Requires [float, string], got __TYPE__
+* Invalid type for 'example': requires ['float', 'string'], got '__TYPE__'
 
 The thrown exception will be a *PHPModelGenerator\\Exception\\Generic\\InvalidTypeException* which provides the following methods to get further error details:
 
@@ -69,6 +69,6 @@ For example if an array **["Hello", 123, "Goodbye"]** is given the validation wi
 
 .. code-block:: none
 
-    Invalid items in array example:
+    Invalid items in array 'example':
       - invalid item #1
-        * Invalid type for item of array example. Requires string, got integer
+        * Invalid type for 'example': requires 'string', got 'integer'

--- a/docs/source/complexTypes/object.rst
+++ b/docs/source/complexTypes/object.rst
@@ -48,10 +48,10 @@ Possible exceptions:
 
 .. code-block:: none
 
-    * Invalid type for car. Requires object, got __TYPE__
+    * Invalid type for 'car': requires 'object', got '__TYPE__'
 
-    * Invalid nested object for property car:
-      - Invalid type for model. Requires string, got __TYPE__
+    * Invalid nested object for property 'car':
+      - Invalid type for 'model': requires 'string', got '__TYPE__'
 
 The thrown exception will be a *PHPModelGenerator\\Exception\\Generic\\InvalidTypeException* which provides the following methods to get further error details:
 
@@ -194,7 +194,7 @@ Using the keyword `required` a list of properties may be defined which must be p
 
 Possible exceptions:
 
-* Missing required value for name
+* Missing required value for 'name'
 
 .. hint::
 
@@ -251,8 +251,8 @@ With the keywords `minProperties` and `maxProperties` the number of allowed prop
 
 Possible exceptions:
 
-* Provided object for person must not contain less than 2 properties
-* Provided object for person must not contain more than 3 properties
+* Provided object for 'person' must not contain less than 2 properties
+* Provided object for 'person' must not contain more than 3 properties
 
 The thrown exception will be a *PHPModelGenerator\\Exception\\Object\\MaxPropertiesException* or a *PHPModelGenerator\\Exception\\Object\\MinPropertiesException* which provides the following methods to get further error details:
 
@@ -303,7 +303,7 @@ Using the keyword `additionalProperties` the object can be limited to not contai
 
 Possible exceptions:
 
-* Provided JSON for example contains not allowed additional properties [additional1, additional2]
+* Provided JSON for 'example' contains not allowed additional properties ['additional1', 'additional2']
 
 The thrown exception will be a *PHPModelGenerator\\Exception\\Object\\AdditionalPropertiesException* which provides the following methods to get further error details:
 
@@ -322,11 +322,11 @@ If invalid additional properties are provided a detailed exception will be throw
 
 .. code-block:: none
 
-    Provided JSON for example contains invalid additional properties.
+    Provided JSON for 'example' contains invalid additional properties
       - invalid additional property 'additional1'
-        * Invalid type for name. Requires string, got integer
+        * Invalid type for 'name': requires 'string', got 'integer'
       - invalid additional property 'additional2'
-        * Invalid type for age. Requires int, got string
+        * Invalid type for 'age': requires 'int', got 'string'
 
 The thrown exception will be a *PHPModelGenerator\\Exception\\Object\\InvalidAdditionalPropertiesException* which provides the following methods to get further error details:
 
@@ -418,12 +418,12 @@ Exceptions contain detailed information about the violations:
 
 .. code-block:: none
 
-    Provided JSON for example contains properties with invalid names.
+    Provided JSON for 'example' contains properties with invalid names
       - invalid property 'test12345a'
-        * Value for property name doesn't match pattern ^test[0-9]+$
-        * Value for property name must not be longer than 8
+        * Value for 'property name' does not match pattern '^test[0-9]+$'
+        * Value for 'property name' must not be longer than 8
       - invalid property 'test123456789'
-        * Value for property name must not be longer than 8
+        * Value for 'property name' must not be longer than 8
 
 The thrown exception will be a *PHPModelGenerator\\Exception\\Object\\InvalidPropertyNamesException* which provides the following methods to get further error details:
 
@@ -474,8 +474,8 @@ Exceptions contain a list of all violated properties which are declared as a dep
 
 .. code-block:: none
 
-    Missing required attributes which are dependants of credit_card:
-      - billing_address
+    Missing required attributes which are dependants of 'credit_card':
+      - 'billing_address'
 
 The thrown exception will be a *PHPModelGenerator\\Exception\\Dependency\\InvalidPropertyDependencyException* which provides the following methods to get further error details:
 
@@ -573,8 +573,8 @@ Possible exceptions:
 
 .. code-block:: none
 
-    Invalid schema which is dependant on credit_card:
-      - Missing required value for date_of_birth
+    Invalid schema which is dependant on 'credit_card':
+      - Missing required value for 'date_of_birth'
 
 The thrown exception will be a *PHPModelGenerator\\Exception\\Dependency\\InvalidSchemaDependencyException* which provides the following methods to get further error details:
 
@@ -623,9 +623,9 @@ If invalid pattern properties are provided a detailed exception will be thrown c
 
 .. code-block:: none
 
-    Provided JSON for Example contains invalid pattern properties.
+    Provided JSON for 'Example' contains invalid pattern properties
       - invalid property 'a0' matching pattern '\^a'
-        * Invalid type for pattern property. Requires string, got integer
+        * Invalid type for 'pattern property': requires 'string', got 'integer'
 
 The thrown exception will be a *PHPModelGenerator\\Exception\\Object\\InvalidPatternPropertiesException* which provides the following methods to get further error details:
 

--- a/docs/source/generic/combinedException.rst
+++ b/docs/source/generic/combinedException.rst
@@ -63,7 +63,7 @@ The exception which will be thrown (combined array-exception and combined-schema
     Invalid items in array 'property':
       - invalid item #0
         * Invalid value for 'property' declined by composition constraint
-          Requires to match all composition elements but matched 1 elements
+          Requires to match all composition elements but matched 1 element
           - Composition element #1: Failed
             * Invalid type for 'name': requires 'string', got 'boolean'
           - Composition element #2: Valid
@@ -83,7 +83,7 @@ The exception which will be thrown (combined array-exception and combined-schema
             * Invalid type for 'property': requires 'object', got 'integer'
       - invalid item #3
         * Invalid value for 'property' declined by composition constraint
-          Requires to match all composition elements but matched 1 elements
+          Requires to match all composition elements but matched 1 element
           - Composition element #1: Failed
             * Missing required value for 'name'
             * Invalid type for 'name': requires 'string', got 'NULL'

--- a/docs/source/generic/combinedException.rst
+++ b/docs/source/generic/combinedException.rst
@@ -60,33 +60,33 @@ The exception which will be thrown (combined array-exception and combined-schema
 
 .. code-block:: none
 
-    Invalid items in array property:
+    Invalid items in array 'property':
       - invalid item #0
-        * Invalid value for item of array property declined by composition constraint.
-          Requires to match all composition elements but matched 1 elements.
+        * Invalid value for 'property' declined by composition constraint
+          Requires to match all composition elements but matched 1 elements
           - Composition element #1: Failed
-            * Invalid type for name. Requires string, got boolean
+            * Invalid type for 'name': requires 'string', got 'boolean'
           - Composition element #2: Valid
       - invalid item #1
-        * Invalid value for item of array property declined by composition constraint.
-          Requires to match all composition elements but matched 0 elements.
+        * Invalid value for 'property' declined by composition constraint
+          Requires to match all composition elements but matched 0 elements
           - Composition element #1: Failed
-            * Value for name must not be shorter than 2
+            * Value for 'name' must not be shorter than 2
           - Composition element #2: Failed
-            * Invalid type for age. Requires int, got string
+            * Invalid type for 'age': requires 'int', got 'string'
       - invalid item #2
-        * Invalid value for item of array property declined by composition constraint.
-          Requires to match all composition elements but matched 0 elements.
+        * Invalid value for 'property' declined by composition constraint
+          Requires to match all composition elements but matched 0 elements
           - Composition element #1: Failed
-            * Invalid type for item of array property. Requires object, got integer
+            * Invalid type for 'property': requires 'object', got 'integer'
           - Composition element #2: Failed
-            * Invalid type for item of array property. Requires object, got integer
+            * Invalid type for 'property': requires 'object', got 'integer'
       - invalid item #3
-        * Invalid value for item of array property declined by composition constraint.
-          Requires to match all composition elements but matched 1 elements.
+        * Invalid value for 'property' declined by composition constraint
+          Requires to match all composition elements but matched 1 elements
           - Composition element #1: Failed
-            * Missing required value for name
-            * Invalid type for name. Requires string, got NULL
+            * Missing required value for 'name'
+            * Invalid type for 'name': requires 'string', got 'NULL'
           - Composition element #2: Valid
 
 .. seealso::

--- a/docs/source/generic/required.rst
+++ b/docs/source/generic/required.rst
@@ -68,7 +68,7 @@ Generated interface (type hints not nullable any longer):
 
 Possible exceptions:
 
-* Missing required value for example
+* Missing required value for 'example'
 
 The thrown exception will be an *PHPModelGenerator\\Exception\\Object\\RequiredValueException* which provides the following methods to get further error details:
 

--- a/docs/source/gettingStarted.rst
+++ b/docs/source/gettingStarted.rst
@@ -146,15 +146,15 @@ Now let's have a look at the behaviour of the generated model:
 .. code-block:: php
 
     // Throws an exception as the required name isn't provided.
-    // Exception: 'Missing required value for name'
+    // Exception: "Missing required value for 'name'"
     $person = new Person([]);
 
     // Throws an exception as the name provides an invalid value.
-    // Exception: 'Invalid type for name. Requires string, got int'
+    // Exception: "Invalid type for 'name': requires 'string', got 'integer'"
     $person = new Person(['name' => 12]);
 
     // Throws an exception as the age contains an invalid value due to the minimum definition.
-    // Exception: 'Value for age must not be smaller than 0'
+    // Exception: "Value for 'age' must not be smaller than 0"
     $person = new Person(['name' => 'Albert', 'age' => -1]);
 
     // A valid example as the age isn't required
@@ -164,7 +164,7 @@ Now let's have a look at the behaviour of the generated model:
     $person->meta()->rawInput(); // returns ['name' => 'Albert']
 
     // If setters are generated the setters also perform validations.
-    // Exception: 'Value for age must not be smaller than 0'
+    // Exception: "Value for 'age' must not be smaller than 0"
     $person->setAge(-10);
 
 Each generated class will implement the interface **PHPModelGenerator\\Interfaces\\JSONModelInterface** implemented in the php-json-schema-model-generator-production repository and thus provide the method *meta()* which exposes ``rawInput()`` for access to the original data provided on instantiation.

--- a/docs/source/nonStandardExtensions/filter.rst
+++ b/docs/source/nonStandardExtensions/filter.rst
@@ -216,7 +216,7 @@ Let's have a look how the generated model behaves:
     $person = new Person([]);
 
     // Throws an exception as the name provides an invalid value after being trimmed.
-    // MinLengthException: 'Value for name must not be shorter than 2'
+    // MinLengthException: "Value for 'name' must not be shorter than 2"
     $person = new Person(['name' => '   A   ']);
 
     // A valid example
@@ -226,7 +226,7 @@ Let's have a look how the generated model behaves:
     $person->meta()->rawInput(); // returns ['name' => '   Albert ']
 
     // If setters are generated the setters also execute the filter and perform validations.
-    // MinLengthException: 'Value for name must not be shorter than 2'
+    // MinLengthException: "Value for 'name' must not be shorter than 2"
     $person->setName('  D ');
 
 If trim is applied to a property whose type has zero overlap with string or null (e.g. a pure boolean property), a ``SchemaException`` is raised at generation time:

--- a/docs/source/types/boolean.rst
+++ b/docs/source/types/boolean.rst
@@ -25,7 +25,7 @@ Generated interface:
 
 Possible exceptions:
 
-* Invalid type for example. Requires bool, got __TYPE__
+* Invalid type for 'example': requires 'bool', got '__TYPE__'
 
 The thrown exception will be a *PHPModelGenerator\\Exception\\Generic\\InvalidTypeException* which provides the following methods to get further error details:
 

--- a/docs/source/types/const.rst
+++ b/docs/source/types/const.rst
@@ -24,7 +24,7 @@ Generated interface (the typehint is auto-detected from the given constant value
 
 Possible exceptions:
 
-* Invalid value for example declined by const constraint
+* Value for 'example' must be 42, got 41
 
 The thrown exception will be a *PHPModelGenerator\\Exception\\Generic\\InvalidConstException* which provides the following methods to get further error details:
 

--- a/docs/source/types/null.rst
+++ b/docs/source/types/null.rst
@@ -24,7 +24,7 @@ Generated interface (as null is no explicit type no typehints are generated):
 
 Possible exceptions:
 
-* Invalid type for property. Requires null, got __TYPE__
+* Invalid type for 'example': requires 'null', got '__TYPE__'
 
 The main use case for the **null** type is a property with `multiple types <complexTypes/multiType.html>`__ accepting for example a string and null values when using explicit null types.
 

--- a/docs/source/types/number.rst
+++ b/docs/source/types/number.rst
@@ -31,8 +31,8 @@ Generated interface:
 
 Possible exceptions:
 
-* Invalid type for example. Requires int, got __TYPE__
-* Invalid type for example. Requires double, got __TYPE__
+* Invalid type for 'example': requires 'int', got '__TYPE__'
+* Invalid type for 'example': requires 'double', got '__TYPE__'
 
 The thrown exception will be a *PHPModelGenerator\\Exception\\Generic\\InvalidTypeException* which provides the following methods to get further error details:
 
@@ -73,10 +73,10 @@ To add a range validation to the property use the `minimum`, `maximum` and `excl
 
 Possible exceptions:
 
-* Value for example1 must not be smaller than 3
-* Value for example1 must not be larger than 5
-* Value for example2 must be larger than 1.0
-* Value for example2 must be smaller than 2.0
+* Value for 'example1' must not be smaller than 3
+* Value for 'example1' must not be larger than 5
+* Value for 'example2' must be larger than 1.0
+* Value for 'example2' must be smaller than 2.0
 
 The thrown exception will be one of the following, corresponding to the JSON schema keywords with the methods to get the constraint:
 
@@ -120,7 +120,7 @@ To add a multiple of validation to the property use the `multipleOf` keyword.
 
 Possible exceptions:
 
-* Value for example must be a multiple of 3
+* Value for 'example' must be a multiple of 3
 
 The thrown exception will be a *PHPModelGenerator\\Exception\\Number\\MultipleOfException* which provides the following methods to get further error details:
 

--- a/docs/source/types/string.rst
+++ b/docs/source/types/string.rst
@@ -25,7 +25,7 @@ Generated interface:
 
 Possible exceptions:
 
-* Invalid type for example. Requires string, got __TYPE__
+* Invalid type for 'example': requires 'string', got '__TYPE__'
 
 The thrown exception will be a *PHPModelGenerator\\Exception\\Generic\\InvalidTypeException* which provides the following methods to get further error details:
 
@@ -61,8 +61,8 @@ To add a length validation to the property use the `minLength` and `maxLength` k
 
 Possible exceptions:
 
-* Value for example must not be shorter than 3
-* Value for example must not be longer than 5
+* Value for 'example' must not be shorter than 3
+* Value for 'example' must not be longer than 5
 
 The thrown exception will be a *PHPModelGenerator\\Exception\\String\\MinLengthException* or a *PHPModelGenerator\\Exception\\String\\MaxLengthException* which provides the following methods to get further error details:
 
@@ -103,7 +103,7 @@ To add a pattern validation to the property use the `pattern` keyword.
 
 Possible exceptions:
 
-* Value for property doesn't match pattern ^[a-zA-Z]*$
+* Value for 'example' does not match pattern '^[a-zA-Z]*$'
 
 The thrown exception will be a *PHPModelGenerator\\Exception\\String\\PatternException* which provides the following methods to get further error details:
 
@@ -138,7 +138,7 @@ To add a format validation to the property use the `format` keyword.
 
 Possible exceptions:
 
-* Value for property must match the format __FORMAT__
+* Value for 'example' must match the format '__FORMAT__'
 
 The thrown exception will be a *PHPModelGenerator\\Exception\\String\\FormatException* which provides the following methods to get further error details:
 

--- a/src/Draft/Modifier/ConstModifier.php
+++ b/src/Draft/Modifier/ConstModifier.php
@@ -42,11 +42,13 @@ class ConstModifier implements ModifierInterface
                     . var_export($json['const'], true),
         };
 
-        $property->addValidator(new PropertyValidator(
-            $property,
-            $check,
-            InvalidConstException::class,
-            [$json['const']],
-        ));
+        $property->addValidator(
+            (new PropertyValidator(
+                $property,
+                $check,
+                InvalidConstException::class,
+                [$json['const']],
+            ))->withJsonPointer($propertySchema->getPointer() . '/const'),
+        );
     }
 }

--- a/src/Model/Property/Property.php
+++ b/src/Model/Property/Property.php
@@ -26,6 +26,8 @@ class Property extends AbstractProperty
     /** @var bool */
     protected $isPropertyRequired = true;
     /** @var bool */
+    protected $isPropertyArrayItem = false;
+    /** @var bool */
     protected $isPropertyReadOnly = false;
     /** @var bool */
     protected $isPropertyWriteOnly = false;
@@ -312,6 +314,24 @@ class Property extends AbstractProperty
     /**
      * @inheritdoc
      */
+    public function setArrayItem(bool $isArrayItem): PropertyInterface
+    {
+        $this->isPropertyArrayItem = $isArrayItem;
+
+        return $this;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function isArrayItem(): bool
+    {
+        return $this->isPropertyArrayItem;
+    }
+
+    /**
+     * @inheritdoc
+     */
     public function setReadOnly(bool $isPropertyReadOnly): PropertyInterface
     {
         $this->isPropertyReadOnly = $isPropertyReadOnly;
@@ -352,7 +372,7 @@ class Property extends AbstractProperty
      */
     public function isRequired(): bool
     {
-        return $this->isPropertyRequired || str_starts_with($this->name, 'item of array ');
+        return $this->isPropertyRequired || $this->isPropertyArrayItem;
     }
 
     /**

--- a/src/Model/Property/PropertyInterface.php
+++ b/src/Model/Property/PropertyInterface.php
@@ -130,6 +130,15 @@ interface PropertyInterface extends ResolvableInterface
 
     public function setRequired(bool $isPropertyRequired): PropertyInterface;
 
+    /**
+     * Mark the property as representing an item of an array (as opposed to an object property).
+     * Array items have no "required" keyword of their own — they are unconditionally mandatory —
+     * and must never receive a RequiredPropertyValidator.
+     */
+    public function setArrayItem(bool $isArrayItem): PropertyInterface;
+
+    public function isArrayItem(): bool;
+
     public function setReadOnly(bool $isPropertyReadOnly): PropertyInterface;
 
     public function setInternal(bool $isPropertyInternal): PropertyInterface;

--- a/src/Model/Property/PropertyProxy.php
+++ b/src/Model/Property/PropertyProxy.php
@@ -25,6 +25,7 @@ class PropertyProxy extends AbstractProperty
 {
     private ?JsonSchema $overrideJsonSchema = null;
     private ?PhpAttribute $overrideJsonPointer = null;
+    private bool $isProxyArrayItem = false;
 
     /**
      * PropertyProxy constructor.
@@ -221,7 +222,30 @@ class PropertyProxy extends AbstractProperty
      */
     public function isRequired(): bool
     {
-        return $this->getProperty()->isRequired();
+        return $this->isProxyArrayItem || $this->getProperty()->isRequired();
+    }
+
+    /**
+     * @inheritdoc
+     *
+     * Stores the array-item flag locally rather than delegating: the same $ref-resolved
+     * property can be reused as a plain property in one place and as an array item in
+     * another (each usage gets its own PropertyProxy), so the flag must not be shared via
+     * the underlying property.
+     */
+    public function setArrayItem(bool $isArrayItem): PropertyInterface
+    {
+        $this->isProxyArrayItem = $isArrayItem;
+
+        return $this;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function isArrayItem(): bool
+    {
+        return $this->isProxyArrayItem;
     }
 
     /**

--- a/src/Model/SchemaDefinition/SchemaDefinition.php
+++ b/src/Model/SchemaDefinition/SchemaDefinition.php
@@ -52,6 +52,7 @@ class SchemaDefinition
         string $path,
         bool $required,
         ?array $dependencies = null,
+        bool $isArrayItem = false,
     ): PropertyInterface {
         $jsonSchema = $this->source->navigate($path);
 
@@ -72,6 +73,7 @@ class SchemaDefinition
                         $propertyName,
                         $jsonSchema,
                         $required,
+                        $isArrayItem,
                     );
 
                 $this->resolvedPaths->offsetSet($key, $property);
@@ -90,7 +92,12 @@ class SchemaDefinition
             }
         }
 
+        // The cache key deliberately does not include $isArrayItem: the same $ref definition can
+        // be reused as a plain property in one place and as an array item in another. Each usage
+        // gets its own proxy, so the flag is set directly on the proxy rather than shared via the
+        // cached underlying property.
         $proxy = new PropertyProxy($propertyName, $this->source, $this->resolvedPaths, $key);
+        $proxy->setArrayItem($isArrayItem);
         $this->unresolvedProxies[$key][] = $proxy;
 
         if ($this->resolvedPaths->offsetGet($key)) {

--- a/src/Model/Validator/ArrayItemValidator.php
+++ b/src/Model/Validator/ArrayItemValidator.php
@@ -35,7 +35,7 @@ class ArrayItemValidator extends ExtractedMethodValidator
         JsonSchema $itemStructure,
         PropertyInterface $property,
     ) {
-        $nestedPropertyName = "item of array {$property->getName()}";
+        $nestedPropertyName = $property->getName();
         $this->variableSuffix = '_' . md5($nestedPropertyName);
 
         // an item of the array behaves like a nested property to add item-level validation
@@ -45,6 +45,7 @@ class ArrayItemValidator extends ExtractedMethodValidator
                 $schema,
                 $nestedPropertyName,
                 $itemStructure,
+                isArrayItem: true,
             );
 
         $this->nestedProperty->onResolve(function () use ($property): void {

--- a/src/Model/Validator/Factory/Arrays/ContainsValidatorFactory.php
+++ b/src/Model/Validator/Factory/Arrays/ContainsValidatorFactory.php
@@ -55,8 +55,9 @@ class ContainsValidatorFactory extends AbstractValidatorFactory
             ->create(
                 $schemaProcessor,
                 $schema,
-                "item of array {$property->getName()}",
+                $property->getName(),
                 $propertySchema->navigate($this->key),
+                isArrayItem: true,
             );
 
         $property->addValidator(

--- a/src/PropertyProcessor/PropertyFactory.php
+++ b/src/PropertyProcessor/PropertyFactory.php
@@ -50,6 +50,7 @@ class PropertyFactory
         string $propertyName,
         JsonSchema $propertySchema,
         bool $required = false,
+        bool $isArrayItem = false,
     ): PropertyInterface {
         $json = $propertySchema->getJson();
 
@@ -64,10 +65,18 @@ class PropertyFactory
                     $propertyName,
                     $propertySchema,
                     $required,
+                    $isArrayItem,
                 );
             }
 
-            return $this->processReference($schemaProcessor, $schema, $propertyName, $propertySchema, $required);
+            return $this->processReference(
+                $schemaProcessor,
+                $schema,
+                $propertyName,
+                $propertySchema,
+                $required,
+                $isArrayItem,
+            );
         }
 
         $resolvedType = $json['type'] ?? 'any';
@@ -80,6 +89,7 @@ class PropertyFactory
                 $propertySchema,
                 $resolvedType,
                 $required,
+                $isArrayItem,
             );
         }
 
@@ -92,6 +102,7 @@ class PropertyFactory
                 $propertyName,
                 $propertySchema,
                 $required,
+                $isArrayItem,
             ),
             'base'   => $this->createBaseProperty($schemaProcessor, $schema, $propertyName, $propertySchema),
             default  => $this->createTypedProperty(
@@ -101,6 +112,7 @@ class PropertyFactory
                 $propertySchema,
                 $resolvedType,
                 $required,
+                $isArrayItem,
             ),
         };
     }
@@ -117,9 +129,17 @@ class PropertyFactory
         string $propertyName,
         JsonSchema $propertySchema,
         bool $required,
+        bool $isArrayItem = false,
     ): PropertyInterface {
         $json     = $propertySchema->getJson();
-        $property = $this->buildProperty($schemaProcessor, $propertyName, null, $propertySchema, $required);
+        $property = $this->buildProperty(
+            $schemaProcessor,
+            $propertyName,
+            null,
+            $propertySchema,
+            $required,
+            $isArrayItem,
+        );
 
         $className = $schemaProcessor->getGeneratorConfiguration()->getClassNameGenerator()->getClassName(
             $propertyName,
@@ -187,6 +207,7 @@ class PropertyFactory
         JsonSchema $propertySchema,
         string $type,
         bool $required,
+        bool $isArrayItem = false,
     ): PropertyInterface {
         $phpType  = $type !== 'any' ? TypeConverter::jsonSchemaToPHP($type) : null;
         $property = $this->buildProperty(
@@ -195,6 +216,7 @@ class PropertyFactory
             $phpType !== null ? new PropertyType($phpType) : null,
             $propertySchema,
             $required,
+            $isArrayItem,
         );
 
         $this->applyModifiers($schemaProcessor, $schema, $property, $propertySchema);
@@ -213,6 +235,7 @@ class PropertyFactory
         ?PropertyType $type,
         JsonSchema $propertySchema,
         bool $required,
+        bool $isArrayItem = false,
     ): Property {
         $json = $propertySchema->getJson();
 
@@ -232,6 +255,7 @@ class PropertyFactory
 
         $property = (new Property($propertyName, $type, $propertySchema, $json['description'] ?? ''))
             ->setRequired($required)
+            ->setArrayItem($isArrayItem)
             ->setReadOnly($isSchemaReadOnly || $schemaProcessor->getGeneratorConfiguration()->isImmutable())
             ->setWriteOnly($isWriteOnly);
 
@@ -243,7 +267,7 @@ class PropertyFactory
             $property->setExamples($json['examples']);
         }
 
-        if ($required && !str_starts_with($propertyName, 'item of array ')) {
+        if ($required && !$isArrayItem) {
             // Compute the parent object schema pointer by stripping '<name>/properties' (last two
             // path segments) from the property pointer, then appending the 'required' keyword.
             $propertyPointer = $propertySchema->getPointer();
@@ -315,6 +339,7 @@ class PropertyFactory
         string $propertyName,
         JsonSchema $propertySchema,
         bool $required,
+        bool $isArrayItem = false,
     ): PropertyInterface {
         $path       = [];
         $reference  = $propertySchema->getJson()['$ref'];
@@ -352,6 +377,7 @@ class PropertyFactory
                     implode('/', $path),
                     $required,
                     $propertySchema->getJson()['_dependencies'] ?? null,
+                    $isArrayItem,
                 );
 
                 // Use the reference site's pointer (where $ref appears in the schema) rather
@@ -389,10 +415,18 @@ class PropertyFactory
         string $propertyName,
         JsonSchema $propertySchema,
         bool $required,
+        bool $isArrayItem = false,
     ): PropertyInterface {
         $schema->getSchemaDictionary()->setUpDefinitionDictionary($schemaProcessor, $schema);
 
-        $property = $this->processReference($schemaProcessor, $schema, $propertyName, $propertySchema, $required);
+        $property = $this->processReference(
+            $schemaProcessor,
+            $schema,
+            $propertyName,
+            $propertySchema,
+            $required,
+            $isArrayItem,
+        );
 
         if (!$property->getNestedSchema()) {
             throw new SchemaException(
@@ -427,9 +461,17 @@ class PropertyFactory
         JsonSchema $propertySchema,
         array $types,
         bool $required,
+        bool $isArrayItem = false,
     ): PropertyInterface {
         $json     = $propertySchema->getJson();
-        $property = $this->buildProperty($schemaProcessor, $propertyName, null, $propertySchema, $required);
+        $property = $this->buildProperty(
+            $schemaProcessor,
+            $propertyName,
+            null,
+            $propertySchema,
+            $required,
+            $isArrayItem,
+        );
 
         $collectedTypes   = [];
         $typeHints        = [];
@@ -449,7 +491,14 @@ class PropertyFactory
 
             // For type=object, delegate to the same object path (processSchema + wireObjectProperty).
             $subProperty = $type === 'object'
-                ? $this->createObjectProperty($schemaProcessor, $schema, $propertyName, $subSchema, $required)
+                ? $this->createObjectProperty(
+                    $schemaProcessor,
+                    $schema,
+                    $propertyName,
+                    $subSchema,
+                    $required,
+                    $isArrayItem,
+                )
                 : $this->createSubTypeProperty(
                     $schemaProcessor,
                     $schema,
@@ -457,6 +506,7 @@ class PropertyFactory
                     $subSchema,
                     $type,
                     $required,
+                    $isArrayItem,
                 );
 
             $subProperty->onResolve(function () use (
@@ -522,6 +572,7 @@ class PropertyFactory
         JsonSchema $propertySchema,
         string $type,
         bool $required,
+        bool $isArrayItem = false,
     ): Property {
         $subProperty = $this->buildProperty(
             $schemaProcessor,
@@ -529,6 +580,7 @@ class PropertyFactory
             new PropertyType(TypeConverter::jsonSchemaToPHP($type)),
             $propertySchema,
             $required,
+            $isArrayItem,
         );
 
         $this->applyModifiers($schemaProcessor, $schema, $subProperty, $propertySchema, anyOnly: false, typeOnly: true);

--- a/src/SchemaProcessor/PostProcessor/Templates/Companion/PatternPropertiesCompanion.phptpl
+++ b/src/SchemaProcessor/PostProcessor/Templates/Companion/PatternPropertiesCompanion.phptpl
@@ -27,7 +27,7 @@ class {{ companionClassName }}
         $hash = md5($key);
 
         if (!isset($this->patternProperties[$hash])) {
-            throw new UnknownPatternPropertyException("Tried to access unknown pattern properties with key $key");
+            throw new UnknownPatternPropertyException("Tried to access an unknown pattern property with key '$key'");
         }
 
         return $this->patternProperties[$hash];

--- a/src/Templates/Validator/ComposedItem.phptpl
+++ b/src/Templates/Validator/ComposedItem.phptpl
@@ -117,12 +117,14 @@
         $validatorComponentIndex++;
     {% endforeach %}
 
-    // Only a satisfied composition may adopt a branch's (possibly decorator-transformed)
-    // proposed value. If no branch succeeded, $proposedValue never advanced past its initial
-    // null (each branch only reaches "$proposedValue = $proposedValue ?? $value;" once it has
-    // already passed its own composition-error check), so unconditionally assigning it to $value
-    // would replace the real input with null — corrupting both this validator's own reported
-    // value and, since array/object items are validated by reference, the original data itself.
+    {#
+        Only a satisfied composition may adopt a branch's (possibly decorator-transformed)
+        proposed value. If no branch succeeded, $proposedValue never advanced past its initial
+        null (each branch only reaches "$proposedValue = $proposedValue ?? $value;" once it has
+        already passed its own composition-error check), so unconditionally assigning it to $value
+        would replace the real input with null — corrupting both this validator's own reported
+        value and, since array/object items are validated by reference, the original data itself.
+    #}
     $compositionSatisfied = {{ composedValueValidation }};
 
     {% if mergedProperty %}

--- a/src/Templates/Validator/ComposedItem.phptpl
+++ b/src/Templates/Validator/ComposedItem.phptpl
@@ -117,34 +117,48 @@
         $validatorComponentIndex++;
     {% endforeach %}
 
+    // Only a satisfied composition may adopt a branch's (possibly decorator-transformed)
+    // proposed value. If no branch succeeded, $proposedValue never advanced past its initial
+    // null (each branch only reaches "$proposedValue = $proposedValue ?? $value;" once it has
+    // already passed its own composition-error check), so unconditionally assigning it to $value
+    // would replace the real input with null — corrupting both this validator's own reported
+    // value and, since array/object items are validated by reference, the original data itself.
+    $compositionSatisfied = {{ composedValueValidation }};
+
     {% if mergedProperty %}
-        if (is_object($proposedValue)) {
+        if ($compositionSatisfied && is_object($proposedValue)) {
             if ($modifiedValues) {
                 $value = array_merge($value, $modifiedValues);
             }
 
             {{ viewHelper.resolvePropertyDecorator(mergedProperty) }}
-        } else {
+        } elseif ($compositionSatisfied) {
             $value = $proposedValue;
+        } else {
+            $value = $originalModelData;
         }
     {% else %}
-        {% if hasModifiedValuesMethod %}
-            foreach ({{ allBranchDefaultAttributeMap }} as $branchDefaultKey => $branchDefaultAttr) {
-                if (!array_key_exists($branchDefaultKey, $originalModelData)) {
-                    $this->$branchDefaultAttr = array_key_exists($branchDefaultKey, $modifiedValues)
-                        ? $modifiedValues[$branchDefaultKey]
-                        : null;
+        if ($compositionSatisfied) {
+            {% if hasModifiedValuesMethod %}
+                foreach ({{ allBranchDefaultAttributeMap }} as $branchDefaultKey => $branchDefaultAttr) {
+                    if (!array_key_exists($branchDefaultKey, $originalModelData)) {
+                        $this->$branchDefaultAttr = array_key_exists($branchDefaultKey, $modifiedValues)
+                            ? $modifiedValues[$branchDefaultKey]
+                            : null;
+                    }
                 }
-            }
-        {% endif %}
-        $value = $proposedValue;
+            {% endif %}
+            $value = $proposedValue;
+        } else {
+            $value = $originalModelData;
+        }
     {% endif %}
 
     {% if generatorConfiguration.collectErrors() %}
         $this->_errorRegistry = $originalErrorRegistry;
     {% endif %}
 
-    $result = !({{ composedValueValidation }});
+    $result = !$compositionSatisfied;
 
     {% if viewHelper.isMutableBaseValidator(generatorConfiguration, isBaseValidator) %}
         if ($result) {

--- a/src/Templates/Validator/ConditionalComposedItem.phptpl
+++ b/src/Templates/Validator/ConditionalComposedItem.phptpl
@@ -104,5 +104,17 @@
         }
     {% endif %}
 
+    // A failed then/else branch may have left $value as the leftover result of a nested object
+    // instantiation attempt (an exception object, when the decorator's instantiation try/catch
+    // caught a validation failure) rather than the original input. Unlike the "if" branch, which
+    // always restores $originalModelData right after its own check, the then/else branch does not
+    // reset on its own — restore it here so a failure reports the real input value instead of an
+    // internal exception object. Left untouched on success: hasModifiedValuesMethod above still
+    // needs the branch's transformed value, and a successful branch's instantiated object is the
+    // correct resulting value for a property whose shape is defined entirely by that branch.
+    if ($thenException || $elseException) {
+        $value = $originalModelData;
+    }
+
     return $thenException || $elseException;
 })($value)

--- a/src/Templates/Validator/ConditionalComposedItem.phptpl
+++ b/src/Templates/Validator/ConditionalComposedItem.phptpl
@@ -104,14 +104,16 @@
         }
     {% endif %}
 
-    // A failed then/else branch may have left $value as the leftover result of a nested object
-    // instantiation attempt (an exception object, when the decorator's instantiation try/catch
-    // caught a validation failure) rather than the original input. Unlike the "if" branch, which
-    // always restores $originalModelData right after its own check, the then/else branch does not
-    // reset on its own — restore it here so a failure reports the real input value instead of an
-    // internal exception object. Left untouched on success: hasModifiedValuesMethod above still
-    // needs the branch's transformed value, and a successful branch's instantiated object is the
-    // correct resulting value for a property whose shape is defined entirely by that branch.
+    {#
+        A failed then/else branch may have left $value as the leftover result of a nested object
+        instantiation attempt (an exception object, when the decorator's instantiation try/catch
+        caught a validation failure) rather than the original input. Unlike the "if" branch, which
+        always restores $originalModelData right after its own check, the then/else branch does not
+        reset on its own — restore it here so a failure reports the real input value instead of an
+        internal exception object. Left untouched on success: hasModifiedValuesMethod above still
+        needs the branch's transformed value, and a successful branch's instantiated object is the
+        correct resulting value for a property whose shape is defined entirely by that branch.
+    #}
     if ($thenException || $elseException) {
         $value = $originalModelData;
     }

--- a/tests/Basic/AdditionalPropertiesTest.php
+++ b/tests/Basic/AdditionalPropertiesTest.php
@@ -85,7 +85,7 @@ class AdditionalPropertiesTest extends AbstractPHPModelGeneratorTestCase
             $this->fail('Expected AdditionalPropertiesException');
         } catch (AdditionalPropertiesException $exception) {
             $this->assertMatchesRegularExpression(
-                '/Provided JSON for .* contains not allowed additional properties \[additional\]/',
+                '/Provided JSON for .* contains not allowed additional properties \[\'additional\'\]/',
                 $exception->getMessage(),
             );
             $this->assertSame('/additionalProperties', $exception->getJsonPointer()->pointer);
@@ -106,7 +106,7 @@ class AdditionalPropertiesTest extends AbstractPHPModelGeneratorTestCase
             $this->fail('Expected AdditionalPropertiesException');
         } catch (AdditionalPropertiesException $exception) {
             $this->assertMatchesRegularExpression(
-                '/Provided JSON for .* contains not allowed additional properties \[additional\]/',
+                '/Provided JSON for .* contains not allowed additional properties \[\'additional\'\]/',
                 $exception->getMessage(),
             );
             // denyAdditionalProperties() synthesizes the check without a literal "additionalProperties"
@@ -170,7 +170,7 @@ class AdditionalPropertiesTest extends AbstractPHPModelGeneratorTestCase
     public static function invalidTypedAdditionalPropertiesDataProvider(): array
     {
         $exception = <<<ERROR
-        contains invalid additional properties.
+        contains invalid additional properties
           - invalid additional property 'additional1'
             * %s
         ERROR;
@@ -180,39 +180,51 @@ class AdditionalPropertiesTest extends AbstractPHPModelGeneratorTestCase
             [
                 'invalid type for additional property (null)' => [
                     ['additional1' => null, 'additional2' => 'Hello'],
-                    sprintf($exception, 'Invalid type for additional property. Requires string, got NULL')
+                    sprintf($exception, 'Invalid type for \'additional property\': requires \'string\', got \'NULL\'')
                 ],
                 'invalid type for additional property (int)' => [
                     ['additional1' => 1, 'additional2' => 'Hello'],
-                    sprintf($exception, 'Invalid type for additional property. Requires string, got int')
+                    sprintf(
+                        $exception,
+                        'Invalid type for \'additional property\': requires \'string\', got \'integer\'',
+                    )
                 ],
                 'invalid type for additional property (float)' => [
                     ['additional1' => 0.92, 'additional2' => 'Hello'],
-                    sprintf($exception, 'Invalid type for additional property. Requires string, got double')
+                    sprintf(
+                        $exception,
+                        'Invalid type for \'additional property\': requires \'string\', got \'double\'',
+                    )
                 ],
                 'invalid type for additional property (bool)' => [
                     ['additional1' => true, 'additional2' => 'Hello'],
-                    sprintf($exception, 'Invalid type for additional property. Requires string, got bool')
+                    sprintf(
+                        $exception,
+                        'Invalid type for \'additional property\': requires \'string\', got \'boolean\'',
+                    )
                 ],
                 'invalid type for additional property (array)' => [
                     ['additional1' => [], 'additional2' => 'Hello'],
-                    sprintf($exception, 'Invalid type for additional property. Requires string, got array')
+                    sprintf($exception, 'Invalid type for \'additional property\': requires \'string\', got \'array\'')
                 ],
                 'invalid type for additional property (object)' => [
                     ['additional1' => new stdClass(), 'additional2' => 'Hello'],
-                    sprintf($exception, 'Invalid type for additional property. Requires string, got stdClass')
+                    sprintf(
+                        $exception,
+                        'Invalid type for \'additional property\': requires \'string\', got \'stdClass\'',
+                    )
                 ],
                 'empty short string' => [
                     ['additional1' => '', 'additional2' => 'Hello'],
-                    sprintf($exception, 'Value for additional property must not be shorter than 2')
+                    sprintf($exception, 'Value for \'additional property\' must not be shorter than 2')
                 ],
                 'too short string' => [
                     ['additional1' => '1', 'additional2' => 'Hello'],
-                    sprintf($exception, 'Value for additional property must not be shorter than 2')
+                    sprintf($exception, 'Value for \'additional property\' must not be shorter than 2')
                 ],
                 'too long string' => [
                     ['additional1' => '12345678', 'additional2' => 'Hello'],
-                    sprintf($exception, 'Value for additional property must not be longer than 5')
+                    sprintf($exception, 'Value for \'additional property\' must not be longer than 5')
                 ],
             ],
         );
@@ -293,7 +305,7 @@ class AdditionalPropertiesTest extends AbstractPHPModelGeneratorTestCase
     public static function invalidAdditionalPropertiesObjectsDataProvider(): array
     {
         $exception = <<<ERROR
-        contains invalid additional properties.
+        contains invalid additional properties
           - invalid additional property 'additional1'
             * %s
         ERROR;
@@ -303,40 +315,49 @@ class AdditionalPropertiesTest extends AbstractPHPModelGeneratorTestCase
             [
                 'invalid type for additional property (null)' => [
                     ['additional1' => null, 'additional2' => ['name' => 'AB', 'age' => 12]],
-                    sprintf($exception, 'Invalid type for additional property. Requires object, got NULL')
+                    sprintf($exception, 'Invalid type for \'additional property\': requires \'object\', got \'NULL\'')
                 ],
                 'invalid type for additional property (int)' => [
                     ['additional1' => 1, 'additional2' => ['name' => 'AB', 'age' => 12]],
-                    sprintf($exception, 'Invalid type for additional property. Requires object, got int')
+                    sprintf(
+                        $exception,
+                        'Invalid type for \'additional property\': requires \'object\', got \'integer\'',
+                    )
                 ],
                 'invalid type for additional property (float)' => [
                     ['additional1' => 0.92, 'additional2' => ['name' => 'AB', 'age' => 12]],
-                    sprintf($exception, 'Invalid type for additional property. Requires object, got double')
+                    sprintf(
+                        $exception,
+                        'Invalid type for \'additional property\': requires \'object\', got \'double\'',
+                    )
                 ],
                 'invalid type for additional property (bool)' => [
                     ['additional1' => true, 'additional2' => ['name' => 'AB', 'age' => 12]],
-                    sprintf($exception, 'Invalid type for additional property. Requires object, got bool')
+                    sprintf(
+                        $exception,
+                        'Invalid type for \'additional property\': requires \'object\', got \'boolean\'',
+                    )
                 ],
                 'invalid type for additional property (object)' => [
                     ['additional1' => 'Hello', 'additional2' => ['name' => 'AB', 'age' => 12]],
-                    sprintf($exception, 'Invalid type for additional property. Requires object, got string')
+                    sprintf($exception, 'Invalid type for \'additional property\': requires \'object\', got \'string\'')
                 ],
                 'Missing required name' => [
                     ['additional1' => ['age' => 12], 'additional2' => ['name' => 'AB', 'age' => 12]],
-                    sprintf($exception, 'Missing required value for name')
+                    sprintf($exception, 'Missing required value for \'name\'')
                 ],
-                'Invalid type for name' => [
+                'Invalid type for \'name\'' => [
                     ['additional1' => ['name' => 12], 'additional2' => ['name' => 'AB', 'age' => 12]],
-                    sprintf($exception, 'Invalid type for name. Requires string, got integer')
+                    sprintf($exception, 'Invalid type for \'name\': requires \'string\', got \'integer\'')
                 ],
                 'Multiple violations' => [
                     ['additional1' => ['name' => 12], 'additional2' => ['name' => 'AB', 'age' => '12']],
                     <<<ERROR
-                    contains invalid additional properties.
+                    contains invalid additional properties
                       - invalid additional property 'additional1'
-                        * Invalid type for name. Requires string, got integer
+                        * Invalid type for 'name': requires 'string', got 'integer'
                       - invalid additional property 'additional2'
-                        * Invalid type for age. Requires int, got string
+                        * Invalid type for 'age': requires 'int', got 'string'
                     ERROR,
                 ],
             ],

--- a/tests/Basic/AdditionalPropertiesTest.php
+++ b/tests/Basic/AdditionalPropertiesTest.php
@@ -85,7 +85,7 @@ class AdditionalPropertiesTest extends AbstractPHPModelGeneratorTestCase
             $this->fail('Expected AdditionalPropertiesException');
         } catch (AdditionalPropertiesException $exception) {
             $this->assertMatchesRegularExpression(
-                '/Provided JSON for .* contains not allowed additional properties \[\'additional\'\]/',
+                "/Provided JSON for .* contains not allowed additional properties \['additional'\]/",
                 $exception->getMessage(),
             );
             $this->assertSame('/additionalProperties', $exception->getJsonPointer()->pointer);
@@ -106,7 +106,7 @@ class AdditionalPropertiesTest extends AbstractPHPModelGeneratorTestCase
             $this->fail('Expected AdditionalPropertiesException');
         } catch (AdditionalPropertiesException $exception) {
             $this->assertMatchesRegularExpression(
-                '/Provided JSON for .* contains not allowed additional properties \[\'additional\'\]/',
+                "/Provided JSON for .* contains not allowed additional properties \['additional'\]/",
                 $exception->getMessage(),
             );
             // denyAdditionalProperties() synthesizes the check without a literal "additionalProperties"
@@ -180,51 +180,51 @@ class AdditionalPropertiesTest extends AbstractPHPModelGeneratorTestCase
             [
                 'invalid type for additional property (null)' => [
                     ['additional1' => null, 'additional2' => 'Hello'],
-                    sprintf($exception, 'Invalid type for \'additional property\': requires \'string\', got \'NULL\'')
+                    sprintf($exception, "Invalid type for 'additional property': requires 'string', got 'NULL'")
                 ],
                 'invalid type for additional property (int)' => [
                     ['additional1' => 1, 'additional2' => 'Hello'],
                     sprintf(
                         $exception,
-                        'Invalid type for \'additional property\': requires \'string\', got \'integer\'',
+                        "Invalid type for 'additional property': requires 'string', got 'integer'",
                     )
                 ],
                 'invalid type for additional property (float)' => [
                     ['additional1' => 0.92, 'additional2' => 'Hello'],
                     sprintf(
                         $exception,
-                        'Invalid type for \'additional property\': requires \'string\', got \'double\'',
+                        "Invalid type for 'additional property': requires 'string', got 'double'",
                     )
                 ],
                 'invalid type for additional property (bool)' => [
                     ['additional1' => true, 'additional2' => 'Hello'],
                     sprintf(
                         $exception,
-                        'Invalid type for \'additional property\': requires \'string\', got \'boolean\'',
+                        "Invalid type for 'additional property': requires 'string', got 'boolean'",
                     )
                 ],
                 'invalid type for additional property (array)' => [
                     ['additional1' => [], 'additional2' => 'Hello'],
-                    sprintf($exception, 'Invalid type for \'additional property\': requires \'string\', got \'array\'')
+                    sprintf($exception, "Invalid type for 'additional property': requires 'string', got 'array'")
                 ],
                 'invalid type for additional property (object)' => [
                     ['additional1' => new stdClass(), 'additional2' => 'Hello'],
                     sprintf(
                         $exception,
-                        'Invalid type for \'additional property\': requires \'string\', got \'stdClass\'',
+                        "Invalid type for 'additional property': requires 'string', got 'stdClass'",
                     )
                 ],
                 'empty short string' => [
                     ['additional1' => '', 'additional2' => 'Hello'],
-                    sprintf($exception, 'Value for \'additional property\' must not be shorter than 2')
+                    sprintf($exception, "Value for 'additional property' must not be shorter than 2")
                 ],
                 'too short string' => [
                     ['additional1' => '1', 'additional2' => 'Hello'],
-                    sprintf($exception, 'Value for \'additional property\' must not be shorter than 2')
+                    sprintf($exception, "Value for 'additional property' must not be shorter than 2")
                 ],
                 'too long string' => [
                     ['additional1' => '12345678', 'additional2' => 'Hello'],
-                    sprintf($exception, 'Value for \'additional property\' must not be longer than 5')
+                    sprintf($exception, "Value for 'additional property' must not be longer than 5")
                 ],
             ],
         );
@@ -315,40 +315,40 @@ class AdditionalPropertiesTest extends AbstractPHPModelGeneratorTestCase
             [
                 'invalid type for additional property (null)' => [
                     ['additional1' => null, 'additional2' => ['name' => 'AB', 'age' => 12]],
-                    sprintf($exception, 'Invalid type for \'additional property\': requires \'object\', got \'NULL\'')
+                    sprintf($exception, "Invalid type for 'additional property': requires 'object', got 'NULL'")
                 ],
                 'invalid type for additional property (int)' => [
                     ['additional1' => 1, 'additional2' => ['name' => 'AB', 'age' => 12]],
                     sprintf(
                         $exception,
-                        'Invalid type for \'additional property\': requires \'object\', got \'integer\'',
+                        "Invalid type for 'additional property': requires 'object', got 'integer'",
                     )
                 ],
                 'invalid type for additional property (float)' => [
                     ['additional1' => 0.92, 'additional2' => ['name' => 'AB', 'age' => 12]],
                     sprintf(
                         $exception,
-                        'Invalid type for \'additional property\': requires \'object\', got \'double\'',
+                        "Invalid type for 'additional property': requires 'object', got 'double'",
                     )
                 ],
                 'invalid type for additional property (bool)' => [
                     ['additional1' => true, 'additional2' => ['name' => 'AB', 'age' => 12]],
                     sprintf(
                         $exception,
-                        'Invalid type for \'additional property\': requires \'object\', got \'boolean\'',
+                        "Invalid type for 'additional property': requires 'object', got 'boolean'",
                     )
                 ],
                 'invalid type for additional property (object)' => [
                     ['additional1' => 'Hello', 'additional2' => ['name' => 'AB', 'age' => 12]],
-                    sprintf($exception, 'Invalid type for \'additional property\': requires \'object\', got \'string\'')
+                    sprintf($exception, "Invalid type for 'additional property': requires 'object', got 'string'")
                 ],
                 'Missing required name' => [
                     ['additional1' => ['age' => 12], 'additional2' => ['name' => 'AB', 'age' => 12]],
-                    sprintf($exception, 'Missing required value for \'name\'')
+                    sprintf($exception, "Missing required value for 'name'")
                 ],
-                'Invalid type for \'name\'' => [
+                "Invalid type for 'name'" => [
                     ['additional1' => ['name' => 12], 'additional2' => ['name' => 'AB', 'age' => 12]],
-                    sprintf($exception, 'Invalid type for \'name\': requires \'string\', got \'integer\'')
+                    sprintf($exception, "Invalid type for 'name': requires 'string', got 'integer'")
                 ],
                 'Multiple violations' => [
                     ['additional1' => ['name' => 12], 'additional2' => ['name' => 'AB', 'age' => '12']],

--- a/tests/Basic/BasicSchemaGenerationTest.php
+++ b/tests/Basic/BasicSchemaGenerationTest.php
@@ -277,20 +277,20 @@ class BasicSchemaGenerationTest extends AbstractPHPModelGeneratorTestCase
                 'Too long string' => [
                     'HelloMyOldFriend',
                     [
-                        'Value for property must not be longer than 8'
+                        'Value for \'property\' must not be longer than 8'
                     ]
                 ],
                 'Invalid pattern' => [
                     '123456789',
                     [
-                        'property doesn\'t match pattern ^[a-zA-Z]*$'
+                        'Value for \'property\' does not match pattern \'^[a-zA-Z]*$\''
                     ]
                 ],
                 'Too long and invalid pattern' => [
                     'HelloMyOld1234567',
                     [
-                        'property doesn\'t match pattern ^[a-zA-Z]*$',
-                        'Value for property must not be longer than 8',
+                        'Value for \'property\' does not match pattern \'^[a-zA-Z]*$\'',
+                        'Value for \'property\' must not be longer than 8',
                     ]
                 ]
             ],

--- a/tests/Basic/BasicSchemaGenerationTest.php
+++ b/tests/Basic/BasicSchemaGenerationTest.php
@@ -277,7 +277,7 @@ class BasicSchemaGenerationTest extends AbstractPHPModelGeneratorTestCase
                 'Too long string' => [
                     'HelloMyOldFriend',
                     [
-                        'Value for \'property\' must not be longer than 8'
+                        "Value for 'property' must not be longer than 8"
                     ]
                 ],
                 'Invalid pattern' => [
@@ -290,7 +290,7 @@ class BasicSchemaGenerationTest extends AbstractPHPModelGeneratorTestCase
                     'HelloMyOld1234567',
                     [
                         'Value for \'property\' does not match pattern \'^[a-zA-Z]*$\'',
-                        'Value for \'property\' must not be longer than 8',
+                        "Value for 'property' must not be longer than 8",
                     ]
                 ]
             ],

--- a/tests/Basic/BooleanCompositionSchemaTest.php
+++ b/tests/Basic/BooleanCompositionSchemaTest.php
@@ -51,7 +51,7 @@ class BooleanCompositionSchemaTest extends AbstractPHPModelGeneratorTestCase
         string $schemaFile,
         mixed $value,
     ): void {
-        $this->expectValidationError($configuration, 'Invalid value for value');
+        $this->expectValidationError($configuration, 'Invalid value for \'value\'');
 
         $className = $this->generateClassFromFile($schemaFile, $configuration);
         new $className(['value' => $value]);
@@ -163,7 +163,7 @@ class BooleanCompositionSchemaTest extends AbstractPHPModelGeneratorTestCase
         bool $valid,
     ): void {
         if (!$valid) {
-            $this->expectValidationError($configuration, 'Invalid value for value');
+            $this->expectValidationError($configuration, 'Invalid value for \'value\'');
         }
 
         $className = $this->generateClassFromFile($schemaFile, $configuration);
@@ -216,7 +216,7 @@ class BooleanCompositionSchemaTest extends AbstractPHPModelGeneratorTestCase
         bool $valid,
     ): void {
         if (!$valid) {
-            $this->expectValidationError($configuration, 'Invalid value for value');
+            $this->expectValidationError($configuration, 'Invalid value for \'value\'');
         }
 
         $className = $this->generateClassFromFile($schemaFile, $configuration);

--- a/tests/Basic/BooleanCompositionSchemaTest.php
+++ b/tests/Basic/BooleanCompositionSchemaTest.php
@@ -51,7 +51,7 @@ class BooleanCompositionSchemaTest extends AbstractPHPModelGeneratorTestCase
         string $schemaFile,
         mixed $value,
     ): void {
-        $this->expectValidationError($configuration, 'Invalid value for \'value\'');
+        $this->expectValidationError($configuration, "Invalid value for 'value'");
 
         $className = $this->generateClassFromFile($schemaFile, $configuration);
         new $className(['value' => $value]);
@@ -163,7 +163,7 @@ class BooleanCompositionSchemaTest extends AbstractPHPModelGeneratorTestCase
         bool $valid,
     ): void {
         if (!$valid) {
-            $this->expectValidationError($configuration, 'Invalid value for \'value\'');
+            $this->expectValidationError($configuration, "Invalid value for 'value'");
         }
 
         $className = $this->generateClassFromFile($schemaFile, $configuration);
@@ -216,7 +216,7 @@ class BooleanCompositionSchemaTest extends AbstractPHPModelGeneratorTestCase
         bool $valid,
     ): void {
         if (!$valid) {
-            $this->expectValidationError($configuration, 'Invalid value for \'value\'');
+            $this->expectValidationError($configuration, "Invalid value for 'value'");
         }
 
         $className = $this->generateClassFromFile($schemaFile, $configuration);

--- a/tests/Basic/BooleanContainsSchemaTest.php
+++ b/tests/Basic/BooleanContainsSchemaTest.php
@@ -41,7 +41,7 @@ class BooleanContainsSchemaTest extends AbstractPHPModelGeneratorTestCase
     ): void {
         $this->expectValidationError(
             $configuration,
-            'No item in array \'property\' matches the \'contains\' constraint',
+            "No item in array 'property' matches the 'contains' constraint",
         );
 
         $className = $this->generateClassFromFile('FalseContains.json', $configuration);
@@ -74,7 +74,7 @@ class BooleanContainsSchemaTest extends AbstractPHPModelGeneratorTestCase
     {
         $this->expectValidationError(
             $configuration,
-            'No item in array \'property\' matches the \'contains\' constraint',
+            "No item in array 'property' matches the 'contains' constraint",
         );
 
         $className = $this->generateClassFromFile('TrueContains.json', $configuration);

--- a/tests/Basic/BooleanContainsSchemaTest.php
+++ b/tests/Basic/BooleanContainsSchemaTest.php
@@ -39,7 +39,10 @@ class BooleanContainsSchemaTest extends AbstractPHPModelGeneratorTestCase
         GeneratorConfiguration $configuration,
         array $value,
     ): void {
-        $this->expectValidationError($configuration, 'No item in array property matches contains constraint');
+        $this->expectValidationError(
+            $configuration,
+            'No item in array \'property\' matches the \'contains\' constraint',
+        );
 
         $className = $this->generateClassFromFile('FalseContains.json', $configuration);
         new $className(['property' => $value]);
@@ -69,7 +72,10 @@ class BooleanContainsSchemaTest extends AbstractPHPModelGeneratorTestCase
     #[DataProvider('validationMethodDataProvider')]
     public function testContainsTrueRejectsEmptyArray(GeneratorConfiguration $configuration): void
     {
-        $this->expectValidationError($configuration, 'No item in array property matches contains constraint');
+        $this->expectValidationError(
+            $configuration,
+            'No item in array \'property\' matches the \'contains\' constraint',
+        );
 
         $className = $this->generateClassFromFile('TrueContains.json', $configuration);
 

--- a/tests/Basic/BooleanItemsSchemaTest.php
+++ b/tests/Basic/BooleanItemsSchemaTest.php
@@ -33,7 +33,7 @@ class BooleanItemsSchemaTest extends AbstractPHPModelGeneratorTestCase
     ): void {
         $this->expectValidationError(
             $configuration,
-            'Array \'items\' must not contain more than 0 items',
+            "Array 'items' must not contain more than 0 items",
         );
 
         $className = $this->generateClassFromFile('FalseItems.json', $configuration);

--- a/tests/Basic/BooleanItemsSchemaTest.php
+++ b/tests/Basic/BooleanItemsSchemaTest.php
@@ -33,7 +33,7 @@ class BooleanItemsSchemaTest extends AbstractPHPModelGeneratorTestCase
     ): void {
         $this->expectValidationError(
             $configuration,
-            'Array items must not contain more than 0 items',
+            'Array \'items\' must not contain more than 0 items',
         );
 
         $className = $this->generateClassFromFile('FalseItems.json', $configuration);

--- a/tests/Basic/BooleanPatternPropertySchemaTest.php
+++ b/tests/Basic/BooleanPatternPropertySchemaTest.php
@@ -77,11 +77,11 @@ class BooleanPatternPropertySchemaTest extends AbstractPHPModelGeneratorTestCase
         $this->expectException(InvalidPatternPropertiesException::class);
         $this->expectExceptionMessage(
             <<<EOT
-            Provided JSON for $className contains invalid pattern properties.
+            Provided JSON for '$className' contains invalid pattern properties
               - invalid property 'secret_a' matching pattern '^secret_.*'
-                * Value for secret_a is not allowed
+                * Value for 'secret_a' is not allowed
               - invalid property 'secret_b' matching pattern '^secret_.*'
-                * Value for secret_b is not allowed
+                * Value for 'secret_b' is not allowed
             EOT,
         );
 

--- a/tests/Basic/BooleanPropertySchemaTest.php
+++ b/tests/Basic/BooleanPropertySchemaTest.php
@@ -53,7 +53,7 @@ class BooleanPropertySchemaTest extends AbstractPHPModelGeneratorTestCase
         GeneratorConfiguration $configuration,
         mixed $value,
     ): void {
-        $this->expectValidationError($configuration, 'Value for forbidden is not allowed');
+        $this->expectValidationError($configuration, 'Value for \'forbidden\' is not allowed');
         $className = $this->generateClassFromFile('FalseProperty.json', $configuration);
         new $className(['forbidden' => $value]);
     }
@@ -113,7 +113,10 @@ class BooleanPropertySchemaTest extends AbstractPHPModelGeneratorTestCase
     #[DataProvider('validationMethodDataProvider')]
     public function testTruePropertyDependencyIsEnforced(GeneratorConfiguration $configuration): void
     {
-        $this->expectValidationError($configuration, "Missing required attributes which are dependants of anything");
+        $this->expectValidationError(
+            $configuration,
+            "Missing required attributes which are dependants of 'anything'",
+        );
 
         $className = $this->generateClassFromFile('TruePropertyWithDependency.json', $configuration);
         new $className(['anything' => 'hello']);

--- a/tests/Basic/BooleanPropertySchemaTest.php
+++ b/tests/Basic/BooleanPropertySchemaTest.php
@@ -53,7 +53,7 @@ class BooleanPropertySchemaTest extends AbstractPHPModelGeneratorTestCase
         GeneratorConfiguration $configuration,
         mixed $value,
     ): void {
-        $this->expectValidationError($configuration, 'Value for \'forbidden\' is not allowed');
+        $this->expectValidationError($configuration, "Value for 'forbidden' is not allowed");
         $className = $this->generateClassFromFile('FalseProperty.json', $configuration);
         new $className(['forbidden' => $value]);
     }

--- a/tests/Basic/ContentMediaStringTest.php
+++ b/tests/Basic/ContentMediaStringTest.php
@@ -85,7 +85,7 @@ class ContentMediaStringTest extends AbstractPHPModelGeneratorTestCase
 
         // Missing required property → throws
         $this->expectException(ErrorRegistryException::class);
-        $this->expectExceptionMessageMatches('/Missing required value for \'requiredContent\'/');
+        $this->expectExceptionMessageMatches("/Missing required value for 'requiredContent'/");
         new $className([]);
     }
 

--- a/tests/Basic/ContentMediaStringTest.php
+++ b/tests/Basic/ContentMediaStringTest.php
@@ -85,7 +85,7 @@ class ContentMediaStringTest extends AbstractPHPModelGeneratorTestCase
 
         // Missing required property → throws
         $this->expectException(ErrorRegistryException::class);
-        $this->expectExceptionMessageMatches('/Missing required value for requiredContent/');
+        $this->expectExceptionMessageMatches('/Missing required value for \'requiredContent\'/');
         new $className([]);
     }
 

--- a/tests/Basic/ErrorCollectionTest.php
+++ b/tests/Basic/ErrorCollectionTest.php
@@ -81,14 +81,14 @@ class ErrorCollectionTest extends AbstractPHPModelGeneratorTestCase
             ],
             'length invalid' => [
                 'a',
-                [MinLengthException::class => 'Value for \'property\' must not be shorter than 2'],
+                [MinLengthException::class => "Value for 'property' must not be shorter than 2"],
                 [MinLengthException::class => '/properties/property/minLength'],
             ],
             'pattern and length invalid' => [
                 ' ',
                 [
                     PatternException::class => 'Value for \'property\' does not match pattern \'^[^\\s]+$\'',
-                    MinLengthException::class => 'Value for \'property\' must not be shorter than 2',
+                    MinLengthException::class => "Value for 'property' must not be shorter than 2",
                 ],
                 [
                     PatternException::class => '/properties/property/pattern',
@@ -97,32 +97,32 @@ class ErrorCollectionTest extends AbstractPHPModelGeneratorTestCase
             ],
             'null' => [
                 null,
-                [InvalidTypeException::class => 'Invalid type for \'property\''],
+                [InvalidTypeException::class => "Invalid type for 'property'"],
                 [InvalidTypeException::class => '/properties/property/type'],
             ],
             'int' => [
                 1,
-                [InvalidTypeException::class => 'Invalid type for \'property\''],
+                [InvalidTypeException::class => "Invalid type for 'property'"],
                 [InvalidTypeException::class => '/properties/property/type'],
             ],
             'float' => [
                 0.92,
-                [InvalidTypeException::class => 'Invalid type for \'property\''],
+                [InvalidTypeException::class => "Invalid type for 'property'"],
                 [InvalidTypeException::class => '/properties/property/type'],
             ],
             'bool' => [
                 true,
-                [InvalidTypeException::class => 'Invalid type for \'property\''],
+                [InvalidTypeException::class => "Invalid type for 'property'"],
                 [InvalidTypeException::class => '/properties/property/type'],
             ],
             'array' => [
                 [],
-                [InvalidTypeException::class => 'Invalid type for \'property\''],
+                [InvalidTypeException::class => "Invalid type for 'property'"],
                 [InvalidTypeException::class => '/properties/property/type'],
             ],
             'object' => [
                 new stdClass(),
-                [InvalidTypeException::class => 'Invalid type for \'property\''],
+                [InvalidTypeException::class => "Invalid type for 'property'"],
                 [InvalidTypeException::class => '/properties/property/type'],
             ],
         ];

--- a/tests/Basic/ErrorCollectionTest.php
+++ b/tests/Basic/ErrorCollectionTest.php
@@ -76,19 +76,19 @@ class ErrorCollectionTest extends AbstractPHPModelGeneratorTestCase
             // PatternException → /pattern suffix; minLength → /minLength suffix; type check → /type suffix
             'pattern invalid' => [
                 '  ',
-                [PatternException::class => 'Value for property doesn\'t match pattern ^[^\s]+$'],
+                [PatternException::class => 'Value for \'property\' does not match pattern \'^[^\\s]+$\''],
                 [PatternException::class => '/properties/property/pattern'],
             ],
             'length invalid' => [
                 'a',
-                [MinLengthException::class => 'Value for property must not be shorter than 2'],
+                [MinLengthException::class => 'Value for \'property\' must not be shorter than 2'],
                 [MinLengthException::class => '/properties/property/minLength'],
             ],
             'pattern and length invalid' => [
                 ' ',
                 [
-                    PatternException::class => 'Value for property doesn\'t match pattern ^[^\s]+$',
-                    MinLengthException::class => 'Value for property must not be shorter than 2',
+                    PatternException::class => 'Value for \'property\' does not match pattern \'^[^\\s]+$\'',
+                    MinLengthException::class => 'Value for \'property\' must not be shorter than 2',
                 ],
                 [
                     PatternException::class => '/properties/property/pattern',
@@ -97,32 +97,32 @@ class ErrorCollectionTest extends AbstractPHPModelGeneratorTestCase
             ],
             'null' => [
                 null,
-                [InvalidTypeException::class => 'Invalid type for property'],
+                [InvalidTypeException::class => 'Invalid type for \'property\''],
                 [InvalidTypeException::class => '/properties/property/type'],
             ],
             'int' => [
                 1,
-                [InvalidTypeException::class => 'Invalid type for property'],
+                [InvalidTypeException::class => 'Invalid type for \'property\''],
                 [InvalidTypeException::class => '/properties/property/type'],
             ],
             'float' => [
                 0.92,
-                [InvalidTypeException::class => 'Invalid type for property'],
+                [InvalidTypeException::class => 'Invalid type for \'property\''],
                 [InvalidTypeException::class => '/properties/property/type'],
             ],
             'bool' => [
                 true,
-                [InvalidTypeException::class => 'Invalid type for property'],
+                [InvalidTypeException::class => 'Invalid type for \'property\''],
                 [InvalidTypeException::class => '/properties/property/type'],
             ],
             'array' => [
                 [],
-                [InvalidTypeException::class => 'Invalid type for property'],
+                [InvalidTypeException::class => 'Invalid type for \'property\''],
                 [InvalidTypeException::class => '/properties/property/type'],
             ],
             'object' => [
                 new stdClass(),
-                [InvalidTypeException::class => 'Invalid type for property'],
+                [InvalidTypeException::class => 'Invalid type for \'property\''],
                 [InvalidTypeException::class => '/properties/property/type'],
             ],
         ];
@@ -147,8 +147,8 @@ class ErrorCollectionTest extends AbstractPHPModelGeneratorTestCase
             'matching both composition elements' => [
                 6,
                 <<<ERROR
-                Invalid value for (.*?) declined by composition constraint\.
-                  Requires to match one composition element but matched 2 elements\.
+                Invalid value for (.*?) declined by composition constraint
+                  Requires to match one composition element but matched 2 elements
                   - Composition element #1: Valid
                   - Composition element #2: Valid
                 ERROR,
@@ -156,36 +156,36 @@ class ErrorCollectionTest extends AbstractPHPModelGeneratorTestCase
             'too low number both' => [
                 0,
                 <<<ERROR
-                Invalid value for (.*?) declined by composition constraint\.
-                  Requires to match one composition element but matched 0 elements\.
+                Invalid value for (.*?) declined by composition constraint
+                  Requires to match one composition element but matched 0 elements
                   - Composition element #1: Failed
-                    \* Value for integerProperty must not be smaller than 2
+                    \* Value for 'integerProperty' must not be smaller than 2
                   - Composition element #2: Failed
-                    \* Value for integerProperty must not be smaller than 3
+                    \* Value for 'integerProperty' must not be smaller than 3
                 ERROR,
             ],
             'nothing matches' => [
                 1,
                 <<<ERROR
-                Invalid value for (.*?) declined by composition constraint\.
-                  Requires to match one composition element but matched 0 elements\.
+                Invalid value for (.*?) declined by composition constraint
+                  Requires to match one composition element but matched 0 elements
                   - Composition element #1: Failed
-                    \* Value for integerProperty must not be smaller than 2
-                    \* Value for integerProperty must be a multiple of 2
+                    \* Value for 'integerProperty' must not be smaller than 2
+                    \* Value for 'integerProperty' must be a multiple of 2
                   - Composition element #2: Failed
-                    \* Value for integerProperty must not be smaller than 3
-                    \* Value for integerProperty must be a multiple of 3
+                    \* Value for 'integerProperty' must not be smaller than 3
+                    \* Value for 'integerProperty' must be a multiple of 3
                 ERROR,
             ],
             'invalid type' => [
                 "4",
                 <<<ERROR
-                Invalid value for (.*?) declined by composition constraint\.
-                  Requires to match one composition element but matched 0 elements\.
+                Invalid value for (.*?) declined by composition constraint
+                  Requires to match one composition element but matched 0 elements
                   - Composition element #1: Failed
-                    \* Invalid type for integerProperty. Requires int, got string
+                    \* Invalid type for 'integerProperty': requires 'int', got 'string'
                   - Composition element #2: Failed
-                    \* Invalid type for integerProperty. Requires int, got string
+                    \* Invalid type for 'integerProperty': requires 'int', got 'string'
                 ERROR,
             ],
         ];

--- a/tests/Basic/ExplicitNullTest.php
+++ b/tests/Basic/ExplicitNullTest.php
@@ -18,7 +18,7 @@ class ExplicitNullTest extends AbstractPHPModelGeneratorTestCase
     public function testNullForOptionalValueWithoutImplicitNullThrowsAnException(): void
     {
         $this->expectException(ValidationException::class);
-        $this->expectExceptionMessage('Invalid type for age. Requires int, got NULL');
+        $this->expectExceptionMessage('Invalid type for \'age\': requires \'int\', got \'NULL\'');
 
         $className = $this->generateClassFromFile('ImplicitNull.json', null, false, false);
 
@@ -28,7 +28,7 @@ class ExplicitNullTest extends AbstractPHPModelGeneratorTestCase
     public function testNullForRequiredValueWithoutImplicitNullThrowsAnException(): void
     {
         $this->expectException(ValidationException::class);
-        $this->expectExceptionMessage('Invalid type for name. Requires string, got NULL');
+        $this->expectExceptionMessage('Invalid type for \'name\': requires \'string\', got \'NULL\'');
 
         $className = $this->generateClassFromFile('ImplicitNull.json', null, false, false);
 
@@ -45,7 +45,7 @@ class ExplicitNullTest extends AbstractPHPModelGeneratorTestCase
     public function testNullForRequiredValueWithImplicitNullThrowsAnException(): void
     {
         $this->expectException(ValidationException::class);
-        $this->expectExceptionMessage('Invalid type for name. Requires string, got NULL');
+        $this->expectExceptionMessage('Invalid type for \'name\': requires \'string\', got \'NULL\'');
 
         $className = $this->generateClassFromFile('ImplicitNull.json');
 

--- a/tests/Basic/ExplicitNullTest.php
+++ b/tests/Basic/ExplicitNullTest.php
@@ -18,7 +18,7 @@ class ExplicitNullTest extends AbstractPHPModelGeneratorTestCase
     public function testNullForOptionalValueWithoutImplicitNullThrowsAnException(): void
     {
         $this->expectException(ValidationException::class);
-        $this->expectExceptionMessage('Invalid type for \'age\': requires \'int\', got \'NULL\'');
+        $this->expectExceptionMessage("Invalid type for 'age': requires 'int', got 'NULL'");
 
         $className = $this->generateClassFromFile('ImplicitNull.json', null, false, false);
 
@@ -28,7 +28,7 @@ class ExplicitNullTest extends AbstractPHPModelGeneratorTestCase
     public function testNullForRequiredValueWithoutImplicitNullThrowsAnException(): void
     {
         $this->expectException(ValidationException::class);
-        $this->expectExceptionMessage('Invalid type for \'name\': requires \'string\', got \'NULL\'');
+        $this->expectExceptionMessage("Invalid type for 'name': requires 'string', got 'NULL'");
 
         $className = $this->generateClassFromFile('ImplicitNull.json', null, false, false);
 
@@ -45,7 +45,7 @@ class ExplicitNullTest extends AbstractPHPModelGeneratorTestCase
     public function testNullForRequiredValueWithImplicitNullThrowsAnException(): void
     {
         $this->expectException(ValidationException::class);
-        $this->expectExceptionMessage('Invalid type for \'name\': requires \'string\', got \'NULL\'');
+        $this->expectExceptionMessage("Invalid type for 'name': requires 'string', got 'NULL'");
 
         $className = $this->generateClassFromFile('ImplicitNull.json');
 

--- a/tests/Basic/FormatTest.php
+++ b/tests/Basic/FormatTest.php
@@ -71,7 +71,7 @@ class FormatTest extends AbstractPHPModelGeneratorTestCase
     public function testInvalidDateTime(string $value): void
     {
         $this->expectException(ErrorRegistryException::class);
-        $this->expectExceptionMessageMatches('/must match the format \'date-time\'/');
+        $this->expectExceptionMessageMatches("/must match the format 'date-time'/");
 
         $className = $this->generateClassFromFile(
             'DateTime.json',
@@ -116,7 +116,7 @@ class FormatTest extends AbstractPHPModelGeneratorTestCase
     public function testInvalidDate(string $value): void
     {
         $this->expectException(ErrorRegistryException::class);
-        $this->expectExceptionMessageMatches('/must match the format \'date\'/');
+        $this->expectExceptionMessageMatches("/must match the format 'date'/");
 
         $className = $this->generateClassFromFile(
             'Date.json',
@@ -162,7 +162,7 @@ class FormatTest extends AbstractPHPModelGeneratorTestCase
     public function testInvalidTime(string $value): void
     {
         $this->expectException(ErrorRegistryException::class);
-        $this->expectExceptionMessageMatches('/must match the format \'time\'/');
+        $this->expectExceptionMessageMatches("/must match the format 'time'/");
 
         $className = $this->generateClassFromFile(
             'Time.json',
@@ -215,7 +215,7 @@ class FormatTest extends AbstractPHPModelGeneratorTestCase
             new $className(['value' => $value]);
             $this->fail('Expected exception for invalid email format');
         } catch (ErrorRegistryException | FormatException $exception) {
-            $this->assertMatchesRegularExpression('/must match the format \'email\'/', $exception->getMessage());
+            $this->assertMatchesRegularExpression("/must match the format 'email'/", $exception->getMessage());
 
             // collectErrors(true) wraps the format exception in an ErrorRegistryException.
             $innerException = $exception instanceof ErrorRegistryException
@@ -266,7 +266,7 @@ class FormatTest extends AbstractPHPModelGeneratorTestCase
     public function testInvalidHostname(string $value): void
     {
         $this->expectException(ErrorRegistryException::class);
-        $this->expectExceptionMessageMatches('/must match the format \'hostname\'/');
+        $this->expectExceptionMessageMatches("/must match the format 'hostname'/");
 
         $className = $this->generateClassFromFile(
             'Hostname.json',
@@ -312,7 +312,7 @@ class FormatTest extends AbstractPHPModelGeneratorTestCase
     public function testInvalidIpv4(string $value): void
     {
         $this->expectException(ErrorRegistryException::class);
-        $this->expectExceptionMessageMatches('/must match the format \'ipv4\'/');
+        $this->expectExceptionMessageMatches("/must match the format 'ipv4'/");
 
         $className = $this->generateClassFromFile(
             'Ipv4.json',
@@ -358,7 +358,7 @@ class FormatTest extends AbstractPHPModelGeneratorTestCase
     public function testInvalidIpv6(string $value): void
     {
         $this->expectException(ErrorRegistryException::class);
-        $this->expectExceptionMessageMatches('/must match the format \'ipv6\'/');
+        $this->expectExceptionMessageMatches("/must match the format 'ipv6'/");
 
         $className = $this->generateClassFromFile(
             'Ipv6.json',
@@ -404,7 +404,7 @@ class FormatTest extends AbstractPHPModelGeneratorTestCase
     public function testInvalidUri(string $value): void
     {
         $this->expectException(ErrorRegistryException::class);
-        $this->expectExceptionMessageMatches('/must match the format \'uri\'/');
+        $this->expectExceptionMessageMatches("/must match the format 'uri'/");
 
         $className = $this->generateClassFromFile(
             'Uri.json',
@@ -452,7 +452,7 @@ class FormatTest extends AbstractPHPModelGeneratorTestCase
     public function testInvalidJsonPointer(string $value): void
     {
         $this->expectException(ErrorRegistryException::class);
-        $this->expectExceptionMessageMatches('/must match the format \'json-pointer\'/');
+        $this->expectExceptionMessageMatches("/must match the format 'json-pointer'/");
 
         $className = $this->generateClassFromFile(
             'JsonPointer.json',
@@ -497,7 +497,7 @@ class FormatTest extends AbstractPHPModelGeneratorTestCase
     public function testInvalidRegex(string $value): void
     {
         $this->expectException(ErrorRegistryException::class);
-        $this->expectExceptionMessageMatches('/must match the format \'regex\'/');
+        $this->expectExceptionMessageMatches("/must match the format 'regex'/");
 
         $className = $this->generateClassFromFile(
             'Regex.json',

--- a/tests/Basic/FormatTest.php
+++ b/tests/Basic/FormatTest.php
@@ -71,7 +71,7 @@ class FormatTest extends AbstractPHPModelGeneratorTestCase
     public function testInvalidDateTime(string $value): void
     {
         $this->expectException(ErrorRegistryException::class);
-        $this->expectExceptionMessageMatches('/must match the format date-time/');
+        $this->expectExceptionMessageMatches('/must match the format \'date-time\'/');
 
         $className = $this->generateClassFromFile(
             'DateTime.json',
@@ -116,7 +116,7 @@ class FormatTest extends AbstractPHPModelGeneratorTestCase
     public function testInvalidDate(string $value): void
     {
         $this->expectException(ErrorRegistryException::class);
-        $this->expectExceptionMessageMatches('/must match the format date/');
+        $this->expectExceptionMessageMatches('/must match the format \'date\'/');
 
         $className = $this->generateClassFromFile(
             'Date.json',
@@ -162,7 +162,7 @@ class FormatTest extends AbstractPHPModelGeneratorTestCase
     public function testInvalidTime(string $value): void
     {
         $this->expectException(ErrorRegistryException::class);
-        $this->expectExceptionMessageMatches('/must match the format time/');
+        $this->expectExceptionMessageMatches('/must match the format \'time\'/');
 
         $className = $this->generateClassFromFile(
             'Time.json',
@@ -215,7 +215,7 @@ class FormatTest extends AbstractPHPModelGeneratorTestCase
             new $className(['value' => $value]);
             $this->fail('Expected exception for invalid email format');
         } catch (ErrorRegistryException | FormatException $exception) {
-            $this->assertMatchesRegularExpression('/must match the format email/', $exception->getMessage());
+            $this->assertMatchesRegularExpression('/must match the format \'email\'/', $exception->getMessage());
 
             // collectErrors(true) wraps the format exception in an ErrorRegistryException.
             $innerException = $exception instanceof ErrorRegistryException
@@ -266,7 +266,7 @@ class FormatTest extends AbstractPHPModelGeneratorTestCase
     public function testInvalidHostname(string $value): void
     {
         $this->expectException(ErrorRegistryException::class);
-        $this->expectExceptionMessageMatches('/must match the format hostname/');
+        $this->expectExceptionMessageMatches('/must match the format \'hostname\'/');
 
         $className = $this->generateClassFromFile(
             'Hostname.json',
@@ -312,7 +312,7 @@ class FormatTest extends AbstractPHPModelGeneratorTestCase
     public function testInvalidIpv4(string $value): void
     {
         $this->expectException(ErrorRegistryException::class);
-        $this->expectExceptionMessageMatches('/must match the format ipv4/');
+        $this->expectExceptionMessageMatches('/must match the format \'ipv4\'/');
 
         $className = $this->generateClassFromFile(
             'Ipv4.json',
@@ -358,7 +358,7 @@ class FormatTest extends AbstractPHPModelGeneratorTestCase
     public function testInvalidIpv6(string $value): void
     {
         $this->expectException(ErrorRegistryException::class);
-        $this->expectExceptionMessageMatches('/must match the format ipv6/');
+        $this->expectExceptionMessageMatches('/must match the format \'ipv6\'/');
 
         $className = $this->generateClassFromFile(
             'Ipv6.json',
@@ -404,7 +404,7 @@ class FormatTest extends AbstractPHPModelGeneratorTestCase
     public function testInvalidUri(string $value): void
     {
         $this->expectException(ErrorRegistryException::class);
-        $this->expectExceptionMessageMatches('/must match the format uri/');
+        $this->expectExceptionMessageMatches('/must match the format \'uri\'/');
 
         $className = $this->generateClassFromFile(
             'Uri.json',
@@ -452,7 +452,7 @@ class FormatTest extends AbstractPHPModelGeneratorTestCase
     public function testInvalidJsonPointer(string $value): void
     {
         $this->expectException(ErrorRegistryException::class);
-        $this->expectExceptionMessageMatches('/must match the format json-pointer/');
+        $this->expectExceptionMessageMatches('/must match the format \'json-pointer\'/');
 
         $className = $this->generateClassFromFile(
             'JsonPointer.json',
@@ -497,7 +497,7 @@ class FormatTest extends AbstractPHPModelGeneratorTestCase
     public function testInvalidRegex(string $value): void
     {
         $this->expectException(ErrorRegistryException::class);
-        $this->expectExceptionMessageMatches('/must match the format regex/');
+        $this->expectExceptionMessageMatches('/must match the format \'regex\'/');
 
         $className = $this->generateClassFromFile(
             'Regex.json',

--- a/tests/Basic/ObjectSizeTest.php
+++ b/tests/Basic/ObjectSizeTest.php
@@ -54,17 +54,17 @@ class ObjectSizeTest extends AbstractPHPModelGeneratorTestCase
         return [
             'empty object' => [
                 [],
-                'Provided object for \'ObjectSizeTest_(.*)\' must not contain less than 2 properties',
+                "Provided object for 'ObjectSizeTest_(.*)' must not contain less than 2 properties",
                 '/minProperties',
             ],
             'too few properties' => [
                 ['b' => 2],
-                'Provided object for \'ObjectSizeTest_(.*)\' must not contain less than 2 properties',
+                "Provided object for 'ObjectSizeTest_(.*)' must not contain less than 2 properties",
                 '/minProperties',
             ],
             'too many properties' => [
                 ['a' => 1, 'b' => 2, 'c' => 3, 'd' => 4],
-                'Provided object for \'ObjectSizeTest_(.*)\' must not contain more than 3 properties',
+                "Provided object for 'ObjectSizeTest_(.*)' must not contain more than 3 properties",
                 '/maxProperties',
             ],
         ];

--- a/tests/Basic/ObjectSizeTest.php
+++ b/tests/Basic/ObjectSizeTest.php
@@ -54,17 +54,17 @@ class ObjectSizeTest extends AbstractPHPModelGeneratorTestCase
         return [
             'empty object' => [
                 [],
-                'Provided object for ObjectSizeTest_(.*) must not contain less than 2 properties',
+                'Provided object for \'ObjectSizeTest_(.*)\' must not contain less than 2 properties',
                 '/minProperties',
             ],
             'too few properties' => [
                 ['b' => 2],
-                'Provided object for ObjectSizeTest_(.*) must not contain less than 2 properties',
+                'Provided object for \'ObjectSizeTest_(.*)\' must not contain less than 2 properties',
                 '/minProperties',
             ],
             'too many properties' => [
                 ['a' => 1, 'b' => 2, 'c' => 3, 'd' => 4],
-                'Provided object for ObjectSizeTest_(.*) must not contain more than 3 properties',
+                'Provided object for \'ObjectSizeTest_(.*)\' must not contain more than 3 properties',
                 '/maxProperties',
             ],
         ];

--- a/tests/Basic/PatternPropertiesTest.php
+++ b/tests/Basic/PatternPropertiesTest.php
@@ -34,8 +34,8 @@ class PatternPropertiesTest extends AbstractPHPModelGeneratorTestCase
         GeneratorConfiguration $configuration,
         $propertyValue,
     ): void {
-        $expectedMessage = 'Invalid type for pattern property. Requires string, got ' .
-            (is_object($propertyValue) ? $propertyValue::class : gettype($propertyValue));
+        $expectedMessage = "Invalid type for 'pattern property': requires 'string', got '" .
+            (is_object($propertyValue) ? $propertyValue::class : gettype($propertyValue)) . "'";
 
         $className = $this->generateClassFromFile('TypedPatternProperty.json', $configuration);
 

--- a/tests/Basic/PropertyDependencyTest.php
+++ b/tests/Basic/PropertyDependencyTest.php
@@ -89,8 +89,8 @@ class PropertyDependencyTest extends AbstractPHPModelGeneratorTestCase
         } catch (ErrorRegistryException | InvalidPropertyDependencyException $exception) {
             $this->assertSame(
                 <<<ERROR
-                Missing required attributes which are dependants of credit_card:
-                  - billing_address
+                Missing required attributes which are dependants of 'credit_card':
+                  - 'billing_address'
                 ERROR,
                 $exception->getMessage(),
             );
@@ -126,23 +126,23 @@ class PropertyDependencyTest extends AbstractPHPModelGeneratorTestCase
                 'no required attribute provided' => [
                     ['credit_card' => 12345],
                     <<<ERROR
-                    Missing required attributes which are dependants of credit_card:
-                      - billing_address
-                      - name
+                    Missing required attributes which are dependants of 'credit_card':
+                      - 'billing_address'
+                      - 'name'
                     ERROR,
                 ],
                 'only one required attribute provided 1' => [
                     ['credit_card' => 12345, 'billing_address' => '555 Debitors Lane'],
                     <<<ERROR
-                    Missing required attributes which are dependants of credit_card:
-                      - name
+                    Missing required attributes which are dependants of 'credit_card':
+                      - 'name'
                     ERROR,
                 ],
                 'only one required attribute provided 2' => [
                     ['credit_card' => 12345, 'name' => 'John'],
                     <<<ERROR
-                    Missing required attributes which are dependants of credit_card:
-                      - billing_address
+                    Missing required attributes which are dependants of 'credit_card':
+                      - 'billing_address'
                     ERROR,
                 ],
             ],
@@ -170,15 +170,15 @@ class PropertyDependencyTest extends AbstractPHPModelGeneratorTestCase
                 [
                     ['credit_card' => 12345],
                     <<<ERROR
-                    Missing required attributes which are dependants of credit_card:
-                      - billing_address
+                    Missing required attributes which are dependants of 'credit_card':
+                      - 'billing_address'
                     ERROR,
                 ],
                 [
                     ['billing_address' => '555 Debitors Lane'],
                     <<<ERROR
-                    Missing required attributes which are dependants of billing_address:
-                      - credit_card
+                    Missing required attributes which are dependants of 'billing_address':
+                      - 'credit_card'
                     ERROR,
                 ],
             ],

--- a/tests/Basic/PropertyNamesTest.php
+++ b/tests/Basic/PropertyNamesTest.php
@@ -162,9 +162,9 @@ class PropertyNamesTest extends AbstractPHPModelGeneratorTestCase
                     <<<ERROR
                     contains properties with invalid names.
                       - invalid property 'test1'
-                        * Invalid value for property name declined by const constraint
+                        * Value for 'property name' must be "test", got "test1"
                       - invalid property 'bla'
-                        * Invalid value for property name declined by const constraint
+                        * Value for 'property name' must be "test", got "bla"
                     ERROR,
                 ],
             ],

--- a/tests/Basic/PropertyNamesTest.php
+++ b/tests/Basic/PropertyNamesTest.php
@@ -127,11 +127,11 @@ class PropertyNamesTest extends AbstractPHPModelGeneratorTestCase
                         'abc' => 1,
                     ],
                     <<<ERROR
-                    contains properties with invalid names.
+                    contains properties with invalid names
                       - invalid property '12'
-                        * Value for property name must not be shorter than 3
+                        * Value for 'property name' must not be shorter than 3
                       - invalid property '123456'
-                        * Value for property name must not be longer than 5
+                        * Value for 'property name' must not be longer than 5
                     ERROR,
                 ],
                 'pattern violation' => [
@@ -143,13 +143,13 @@ class PropertyNamesTest extends AbstractPHPModelGeneratorTestCase
                         'test12w12' => 1,
                     ],
                     <<<ERROR
-                    contains properties with invalid names.
+                    contains properties with invalid names
                       - invalid property '12test12'
-                        * Value for property name doesn't match pattern ^test[0-9]+$
+                        * Value for 'property name' does not match pattern '^test[0-9]+$'
                       - invalid property 'test'
-                        * Value for property name doesn't match pattern ^test[0-9]+$
+                        * Value for 'property name' does not match pattern '^test[0-9]+$'
                       - invalid property 'test12w12'
-                        * Value for property name doesn't match pattern ^test[0-9]+$
+                        * Value for 'property name' does not match pattern '^test[0-9]+$'
                     ERROR,
                 ],
                 'const violation' => [
@@ -160,7 +160,7 @@ class PropertyNamesTest extends AbstractPHPModelGeneratorTestCase
                         'bla' => 3,
                     ],
                     <<<ERROR
-                    contains properties with invalid names.
+                    contains properties with invalid names
                       - invalid property 'test1'
                         * Value for 'property name' must be "test", got "test1"
                       - invalid property 'bla'
@@ -183,11 +183,11 @@ class PropertyNamesTest extends AbstractPHPModelGeneratorTestCase
                     'test' => 1,
                 ],
                 <<<ERROR
-                contains properties with invalid names.
+                contains properties with invalid names
                   - invalid property 'test12345a'
-                    * Value for property name doesn't match pattern ^test[0-9]+$
+                    * Value for 'property name' does not match pattern '^test[0-9]+$'
                   - invalid property 'test'
-                    * Value for property name doesn't match pattern ^test[0-9]+$
+                    * Value for 'property name' does not match pattern '^test[0-9]+$'
                 ERROR,
             ],
             'Error Collection - combined multiple violations' => [
@@ -199,13 +199,13 @@ class PropertyNamesTest extends AbstractPHPModelGeneratorTestCase
                     'test' => 1,
                 ],
                 <<<ERROR
-                contains properties with invalid names.
+                contains properties with invalid names
                   - invalid property 'test12345a'
-                    * Value for property name doesn't match pattern ^test[0-9]+$
-                    * Value for property name must not be longer than 8
+                    * Value for 'property name' does not match pattern '^test[0-9]+$'
+                    * Value for 'property name' must not be longer than 8
                   - invalid property 'test'
-                    * Value for property name doesn't match pattern ^test[0-9]+$
-                    * Value for property name must not be shorter than 6
+                    * Value for 'property name' does not match pattern '^test[0-9]+$'
+                    * Value for 'property name' must not be shorter than 6
                 ERROR,
             ],
         ];

--- a/tests/Basic/SchemaDependencyTest.php
+++ b/tests/Basic/SchemaDependencyTest.php
@@ -81,22 +81,22 @@ class SchemaDependencyTest extends AbstractPHPModelGeneratorTestCase
                 'required attribute not provided 1' => [
                     ['credit_card' => 12345],
                     <<<ERROR
-                    Invalid schema which is dependant on credit_card:
-                      - Missing required value for date_of_birth
+                    Invalid schema which is dependant on 'credit_card':
+                      - Missing required value for 'date_of_birth'
                     ERROR,
                 ],
                 'required attribute not provided 2' => [
                     ['credit_card' => 12345, 'billing_address' => '555 Debitors Lane'],
                     <<<ERROR
-                    Invalid schema which is dependant on credit_card:
-                      - Missing required value for date_of_birth
+                    Invalid schema which is dependant on 'credit_card':
+                      - Missing required value for 'date_of_birth'
                     ERROR,
                 ],
                 'invalid data type' => [
                     ['credit_card' => 12345, 'date_of_birth' => false],
                     <<<ERROR
-                    Invalid schema which is dependant on credit_card:
-                      - Invalid type for date_of_birth. Requires string, got boolean
+                    Invalid schema which is dependant on 'credit_card':
+                      - Invalid type for 'date_of_birth': requires 'string', got 'boolean'
                     ERROR,
                 ],
             ],
@@ -150,22 +150,22 @@ class SchemaDependencyTest extends AbstractPHPModelGeneratorTestCase
                 'required attribute not provided 1' => [
                     ['credit_card' => 12345],
                     <<<ERROR
-                    Invalid schema which is dependant on credit_card:
-                      - Missing required value for name
+                    Invalid schema which is dependant on 'credit_card':
+                      - Missing required value for 'name'
                     ERROR,
                 ],
                 'required attribute not provided 2' => [
                     ['credit_card' => 12345, 'age' => 42],
                     <<<ERROR
-                    Invalid schema which is dependant on credit_card:
-                      - Missing required value for name
+                    Invalid schema which is dependant on 'credit_card':
+                      - Missing required value for 'name'
                     ERROR,
                 ],
                 'invalid data type' => [
                     ['credit_card' => 12345, 'name' => false],
                     <<<ERROR
-                    Invalid schema which is dependant on credit_card:
-                      - Invalid type for name. Requires string, got boolean
+                    Invalid schema which is dependant on 'credit_card':
+                      - Invalid type for 'name': requires 'string', got 'boolean'
                     ERROR,
                 ],
             ],
@@ -220,37 +220,37 @@ class SchemaDependencyTest extends AbstractPHPModelGeneratorTestCase
             'required attribute not provided 1' => [
                 ['credit_card' => 12345],
                 <<<ERROR
-                Invalid schema which is dependant on credit_card:
-                  - Invalid value for SchemaDependencyTest_\w+_credit_card_Dependency declined by composition constraint.
-                      Requires to match all composition elements but matched 0 elements.
+                Invalid schema which is dependant on 'credit_card':
+                  - Invalid value for 'SchemaDependencyTest_\w+_credit_card_Dependency' declined by composition constraint
+                      Requires to match all composition elements but matched 0 elements
                       - Composition element #1: Failed
-                        \* Missing required value for name
-                        \* Invalid type for name. Requires string, got NULL
+                        \* Missing required value for 'name'
+                        \* Invalid type for 'name': requires 'string', got 'NULL'
                       - Composition element #2: Failed
-                        \* Missing required value for age
-                        \* Invalid type for age. Requires int, got NULL
+                        \* Missing required value for 'age'
+                        \* Invalid type for 'age': requires 'int', got 'NULL'
                 ERROR,
             ],
             'required attribute not provided 2' => [
                 ['credit_card' => 12345, 'age' => 42],
                 <<<ERROR
-                Invalid schema which is dependant on credit_card:
-                  - Invalid value for SchemaDependencyTest_\w+_credit_card_Dependency declined by composition constraint.
-                      Requires to match all composition elements but matched 1 elements.
+                Invalid schema which is dependant on 'credit_card':
+                  - Invalid value for 'SchemaDependencyTest_\w+_credit_card_Dependency' declined by composition constraint
+                      Requires to match all composition elements but matched 1 elements
                       - Composition element #1: Failed
-                        \* Missing required value for name
-                        \* Invalid type for name. Requires string, got NULL
+                        \* Missing required value for 'name'
+                        \* Invalid type for 'name': requires 'string', got 'NULL'
                       - Composition element #2: Valid
                 ERROR,
             ],
             'invalid data type'                 => [
                 ['credit_card' => 12345, 'name' => false, 'age' => 42],
                 <<<ERROR
-                Invalid schema which is dependant on credit_card:
-                  - Invalid value for SchemaDependencyTest_\w+_credit_card_Dependency declined by composition constraint.
-                      Requires to match all composition elements but matched 1 elements.
+                Invalid schema which is dependant on 'credit_card':
+                  - Invalid value for 'SchemaDependencyTest_\w+_credit_card_Dependency' declined by composition constraint
+                      Requires to match all composition elements but matched 1 elements
                       - Composition element #1: Failed
-                        \* Invalid type for name. Requires string, got boolean
+                        \* Invalid type for 'name': requires 'string', got 'boolean'
                       - Composition element #2: Valid
                 ERROR,
             ],
@@ -323,22 +323,22 @@ class SchemaDependencyTest extends AbstractPHPModelGeneratorTestCase
             'required attribute not provided 1' => [
                 ['credit_card' => 12345],
                 <<<ERROR
-                Invalid schema which is dependant on credit_card:
-                  - Missing required value for billing_address
-                  - Invalid type for billing_address. Requires string, got NULL
-                  - Missing required value for owner
-                  - Invalid type for owner. Requires object, got NULL
+                Invalid schema which is dependant on 'credit_card':
+                  - Missing required value for 'billing_address'
+                  - Invalid type for 'billing_address': requires 'string', got 'NULL'
+                  - Missing required value for 'owner'
+                  - Invalid type for 'owner': requires 'object', got 'NULL'
                 ERROR,
             ],
             'required attribute not provided 2' => [
                 ['credit_card' => 12345, 'owner' => ['age' => 42]],
                 <<<ERROR
-                Invalid schema which is dependant on credit_card:
-                  - Missing required value for billing_address
-                  - Invalid type for billing_address. Requires string, got NULL
-                  - Invalid nested object for property owner:
-                      - Missing required value for name
-                      - Invalid type for name. Requires string, got NULL
+                Invalid schema which is dependant on 'credit_card':
+                  - Missing required value for 'billing_address'
+                  - Invalid type for 'billing_address': requires 'string', got 'NULL'
+                  - Invalid nested object for property 'owner':
+                      - Missing required value for 'name'
+                      - Invalid type for 'name': requires 'string', got 'NULL'
                 ERROR,
             ],
             'invalid data type' => [
@@ -351,9 +351,9 @@ class SchemaDependencyTest extends AbstractPHPModelGeneratorTestCase
                     'billing_address' => '555 Debitors Lane',
                 ],
                 <<<ERROR
-                Invalid schema which is dependant on credit_card:
-                  - Invalid nested object for property owner:
-                      - Invalid type for name. Requires string, got boolean
+                Invalid schema which is dependant on 'credit_card':
+                  - Invalid nested object for property 'owner':
+                      - Invalid type for 'name': requires 'string', got 'boolean'
                 ERROR,
             ],
         ];

--- a/tests/Basic/SchemaDependencyTest.php
+++ b/tests/Basic/SchemaDependencyTest.php
@@ -236,7 +236,7 @@ class SchemaDependencyTest extends AbstractPHPModelGeneratorTestCase
                 <<<ERROR
                 Invalid schema which is dependant on 'credit_card':
                   - Invalid value for 'SchemaDependencyTest_\w+_credit_card_Dependency' declined by composition constraint
-                      Requires to match all composition elements but matched 1 elements
+                      Requires to match all composition elements but matched 1 element
                       - Composition element #1: Failed
                         \* Missing required value for 'name'
                         \* Invalid type for 'name': requires 'string', got 'NULL'
@@ -248,7 +248,7 @@ class SchemaDependencyTest extends AbstractPHPModelGeneratorTestCase
                 <<<ERROR
                 Invalid schema which is dependant on 'credit_card':
                   - Invalid value for 'SchemaDependencyTest_\w+_credit_card_Dependency' declined by composition constraint
-                      Requires to match all composition elements but matched 1 elements
+                      Requires to match all composition elements but matched 1 element
                       - Composition element #1: Failed
                         \* Invalid type for 'name': requires 'string', got 'boolean'
                       - Composition element #2: Valid

--- a/tests/Basic/SchemaHookTest.php
+++ b/tests/Basic/SchemaHookTest.php
@@ -73,7 +73,7 @@ class SchemaHookTest extends AbstractPHPModelGeneratorTestCase
             'Invalid value' => [
                 false,
                 InvalidTypeException::class,
-                'Invalid type for name. Requires string, got boolean',
+                'Invalid type for \'name\': requires \'string\', got \'boolean\'',
             ],
             'Valid value' => [
                 'Hannes',
@@ -163,7 +163,7 @@ class SchemaHookTest extends AbstractPHPModelGeneratorTestCase
             'Invalid value' => [
                 -12,
                 MinimumException::class,
-                'Value for age must not be smaller than 0',
+                'Value for \'age\' must not be smaller than 0',
             ],
             'Valid value' => [
                 12,
@@ -199,7 +199,8 @@ class SchemaHookTest extends AbstractPHPModelGeneratorTestCase
     {
         $this->modifyModelGenerator = static function (ModelGenerator $modelGenerator) use ($schemaHook): void {
             $modelGenerator->addPostProcessor(new class ($schemaHook) extends PostProcessor {
-                public function __construct(private readonly SchemaHookInterface $schemaHook) {}
+                public function __construct(private readonly SchemaHookInterface $schemaHook)
+                {}
 
                 public function process(Schema $schema, GeneratorConfiguration $generatorConfiguration): void
                 {

--- a/tests/Basic/SchemaHookTest.php
+++ b/tests/Basic/SchemaHookTest.php
@@ -73,7 +73,7 @@ class SchemaHookTest extends AbstractPHPModelGeneratorTestCase
             'Invalid value' => [
                 false,
                 InvalidTypeException::class,
-                'Invalid type for \'name\': requires \'string\', got \'boolean\'',
+                "Invalid type for 'name': requires 'string', got 'boolean'",
             ],
             'Valid value' => [
                 'Hannes',
@@ -163,7 +163,7 @@ class SchemaHookTest extends AbstractPHPModelGeneratorTestCase
             'Invalid value' => [
                 -12,
                 MinimumException::class,
-                'Value for \'age\' must not be smaller than 0',
+                "Value for 'age' must not be smaller than 0",
             ],
             'Valid value' => [
                 12,

--- a/tests/ComposedValue/ComposedAllOfTest.php
+++ b/tests/ComposedValue/ComposedAllOfTest.php
@@ -68,8 +68,8 @@ class ComposedAllOfTest extends AbstractPHPModelGeneratorTestCase
     {
         $this->expectException(ValidationException::class);
         $this->expectExceptionMessageMatches(
-            '/^Invalid value for (.*?) declined by composition constraint.\s*' .
-            'Requires to match all composition elements but matched 0 elements.\s*$/',
+            '/^Invalid value for \'(.*?)\' declined by composition constraint\\s*' .
+            'Requires to match all composition elements but matched 0 elements\\s*$/',
         );
 
         $className = $this->generateClassFromFile('ObjectLevelCompositionRequired.json');
@@ -190,10 +190,10 @@ class ComposedAllOfTest extends AbstractPHPModelGeneratorTestCase
     public static function invalidComposedPropertyDataProvider(): array
     {
         return [
-            'one match - int 4' => [4, 'Invalid value for property declined by composition constraint'],
-            'one match - int 11' => [11, 'Invalid value for property declined by composition constraint'],
-            'int -1' => [-1, 'Invalid value for property declined by composition constraint'],
-            'int 20' => [20, 'Invalid value for property declined by composition constraint'],
+            'one match - int 4' => [4, 'Invalid value for \'property\' declined by composition constraint'],
+            'one match - int 11' => [11, 'Invalid value for \'property\' declined by composition constraint'],
+            'int -1' => [-1, 'Invalid value for \'property\' declined by composition constraint'],
+            'int 20' => [20, 'Invalid value for \'property\' declined by composition constraint'],
         ];
     }
 
@@ -241,16 +241,16 @@ class ComposedAllOfTest extends AbstractPHPModelGeneratorTestCase
     public static function invalidExtendedPropertyDataProvider(): array
     {
         return [
-            'one match - int 12' => [12, 'Invalid value for property declined by composition constraint'],
-            'one match - float 12.' => [12., 'Invalid value for property declined by composition constraint'],
-            'one match - int 15' => [15, 'Invalid value for property declined by composition constraint'],
-            'int 13' => [13, 'Invalid value for property declined by composition constraint'],
-            'float 9.9' => [9.9, 'Value for property must not be smaller than 10'],
-            'int 8' => [8, 'Value for property must not be smaller than 10'],
-            'bool' => [true, 'Invalid type for property'],
-            'array' => [[], 'Invalid type for property'],
-            'object' => [new stdClass(), 'Invalid type for property'],
-            'string' => ['', 'Invalid type for property'],
+            'one match - int 12' => [12, 'Invalid value for \'property\' declined by composition constraint'],
+            'one match - float 12.' => [12., 'Invalid value for \'property\' declined by composition constraint'],
+            'one match - int 15' => [15, 'Invalid value for \'property\' declined by composition constraint'],
+            'int 13' => [13, 'Invalid value for \'property\' declined by composition constraint'],
+            'float 9.9' => [9.9, 'Value for \'property\' must not be smaller than 10'],
+            'int 8' => [8, 'Value for \'property\' must not be smaller than 10'],
+            'bool' => [true, 'Invalid type for \'property\''],
+            'array' => [[], 'Invalid type for \'property\''],
+            'object' => [new stdClass(), 'Invalid type for \'property\''],
+            'string' => ['', 'Invalid type for \'property\''],
         ];
     }
 
@@ -285,7 +285,7 @@ class ComposedAllOfTest extends AbstractPHPModelGeneratorTestCase
         mixed $propertyValue,
     ): void {
         $this->expectException(ValidationException::class);
-        $this->expectExceptionMessage('Invalid value for property declined by composition constraint');
+        $this->expectExceptionMessage('Invalid value for \'property\' declined by composition constraint');
 
         $className = $this->generateClassFromFile('ReferencedObjectSchema.json');
 
@@ -313,7 +313,7 @@ class ComposedAllOfTest extends AbstractPHPModelGeneratorTestCase
     public function testNotMatchingObjectPropertyWithReferencedPetSchemaThrowsAnException(mixed $propertyValue): void
     {
         $this->expectException(ValidationException::class);
-        $this->expectExceptionMessage('Invalid value for property declined by composition constraint');
+        $this->expectExceptionMessage('Invalid value for \'property\' declined by composition constraint');
 
         $className = $this->generateClassFromFile('ReferencedObjectSchema.json');
 
@@ -522,29 +522,29 @@ class ComposedAllOfTest extends AbstractPHPModelGeneratorTestCase
             'Exception Collection' => [
                 (new GeneratorConfiguration())->setCollectErrors(true),
                 <<<ERROR
-                declined by composition constraint.
-                  Requires to match all composition elements but matched 1 elements.
+                declined by composition constraint
+                  Requires to match all composition elements but matched 1 elements
                   - Composition element #1: Valid
                   - Composition element #2: Failed
-                    * Value for integerProperty must not be smaller than 1
+                    * Value for 'integerProperty' must not be smaller than 1
                 ERROR,
                 <<<ERROR
-                declined by composition constraint.
-                  Requires to match all composition elements but matched 1 elements.
+                declined by composition constraint
+                  Requires to match all composition elements but matched 1 elements
                   - Composition element #1: Failed
-                    * Value for stringProperty must not be shorter than 2
+                    * Value for 'stringProperty' must not be shorter than 2
                   - Composition element #2: Valid
                 ERROR,
             ],
             'Direct Exception' => [
                 (new GeneratorConfiguration())->setCollectErrors(false),
                 <<<ERROR
-                declined by composition constraint.
-                  Requires to match all composition elements but matched 1 elements.
+                declined by composition constraint
+                  Requires to match all composition elements but matched 1 elements
                 ERROR,
                 <<<ERROR
-                declined by composition constraint.
-                  Requires to match all composition elements but matched 1 elements.
+                declined by composition constraint
+                  Requires to match all composition elements but matched 1 elements
                 ERROR,
             ],
         ];

--- a/tests/ComposedValue/ComposedAllOfTest.php
+++ b/tests/ComposedValue/ComposedAllOfTest.php
@@ -68,7 +68,7 @@ class ComposedAllOfTest extends AbstractPHPModelGeneratorTestCase
     {
         $this->expectException(ValidationException::class);
         $this->expectExceptionMessageMatches(
-            '/^Invalid value for \'(.*?)\' declined by composition constraint\\s*' .
+            "/^Invalid value for '(.*?)' declined by composition constraint\s*" .
             'Requires to match all composition elements but matched 0 elements\\s*$/',
         );
 
@@ -190,10 +190,10 @@ class ComposedAllOfTest extends AbstractPHPModelGeneratorTestCase
     public static function invalidComposedPropertyDataProvider(): array
     {
         return [
-            'one match - int 4' => [4, 'Invalid value for \'property\' declined by composition constraint'],
-            'one match - int 11' => [11, 'Invalid value for \'property\' declined by composition constraint'],
-            'int -1' => [-1, 'Invalid value for \'property\' declined by composition constraint'],
-            'int 20' => [20, 'Invalid value for \'property\' declined by composition constraint'],
+            'one match - int 4' => [4, "Invalid value for 'property' declined by composition constraint"],
+            'one match - int 11' => [11, "Invalid value for 'property' declined by composition constraint"],
+            'int -1' => [-1, "Invalid value for 'property' declined by composition constraint"],
+            'int 20' => [20, "Invalid value for 'property' declined by composition constraint"],
         ];
     }
 
@@ -241,16 +241,16 @@ class ComposedAllOfTest extends AbstractPHPModelGeneratorTestCase
     public static function invalidExtendedPropertyDataProvider(): array
     {
         return [
-            'one match - int 12' => [12, 'Invalid value for \'property\' declined by composition constraint'],
-            'one match - float 12.' => [12., 'Invalid value for \'property\' declined by composition constraint'],
-            'one match - int 15' => [15, 'Invalid value for \'property\' declined by composition constraint'],
-            'int 13' => [13, 'Invalid value for \'property\' declined by composition constraint'],
-            'float 9.9' => [9.9, 'Value for \'property\' must not be smaller than 10'],
-            'int 8' => [8, 'Value for \'property\' must not be smaller than 10'],
-            'bool' => [true, 'Invalid type for \'property\''],
-            'array' => [[], 'Invalid type for \'property\''],
-            'object' => [new stdClass(), 'Invalid type for \'property\''],
-            'string' => ['', 'Invalid type for \'property\''],
+            'one match - int 12' => [12, "Invalid value for 'property' declined by composition constraint"],
+            'one match - float 12.' => [12., "Invalid value for 'property' declined by composition constraint"],
+            'one match - int 15' => [15, "Invalid value for 'property' declined by composition constraint"],
+            'int 13' => [13, "Invalid value for 'property' declined by composition constraint"],
+            'float 9.9' => [9.9, "Value for 'property' must not be smaller than 10"],
+            'int 8' => [8, "Value for 'property' must not be smaller than 10"],
+            'bool' => [true, "Invalid type for 'property'"],
+            'array' => [[], "Invalid type for 'property'"],
+            'object' => [new stdClass(), "Invalid type for 'property'"],
+            'string' => ['', "Invalid type for 'property'"],
         ];
     }
 
@@ -285,7 +285,7 @@ class ComposedAllOfTest extends AbstractPHPModelGeneratorTestCase
         mixed $propertyValue,
     ): void {
         $this->expectException(ValidationException::class);
-        $this->expectExceptionMessage('Invalid value for \'property\' declined by composition constraint');
+        $this->expectExceptionMessage("Invalid value for 'property' declined by composition constraint");
 
         $className = $this->generateClassFromFile('ReferencedObjectSchema.json');
 
@@ -313,7 +313,7 @@ class ComposedAllOfTest extends AbstractPHPModelGeneratorTestCase
     public function testNotMatchingObjectPropertyWithReferencedPetSchemaThrowsAnException(mixed $propertyValue): void
     {
         $this->expectException(ValidationException::class);
-        $this->expectExceptionMessage('Invalid value for \'property\' declined by composition constraint');
+        $this->expectExceptionMessage("Invalid value for 'property' declined by composition constraint");
 
         $className = $this->generateClassFromFile('ReferencedObjectSchema.json');
 
@@ -523,14 +523,14 @@ class ComposedAllOfTest extends AbstractPHPModelGeneratorTestCase
                 (new GeneratorConfiguration())->setCollectErrors(true),
                 <<<ERROR
                 declined by composition constraint
-                  Requires to match all composition elements but matched 1 elements
+                  Requires to match all composition elements but matched 1 element
                   - Composition element #1: Valid
                   - Composition element #2: Failed
                     * Value for 'integerProperty' must not be smaller than 1
                 ERROR,
                 <<<ERROR
                 declined by composition constraint
-                  Requires to match all composition elements but matched 1 elements
+                  Requires to match all composition elements but matched 1 element
                   - Composition element #1: Failed
                     * Value for 'stringProperty' must not be shorter than 2
                   - Composition element #2: Valid
@@ -540,11 +540,11 @@ class ComposedAllOfTest extends AbstractPHPModelGeneratorTestCase
                 (new GeneratorConfiguration())->setCollectErrors(false),
                 <<<ERROR
                 declined by composition constraint
-                  Requires to match all composition elements but matched 1 elements
+                  Requires to match all composition elements but matched 1 element
                 ERROR,
                 <<<ERROR
                 declined by composition constraint
-                  Requires to match all composition elements but matched 1 elements
+                  Requires to match all composition elements but matched 1 element
                 ERROR,
             ],
         ];

--- a/tests/ComposedValue/ComposedAnyOfTest.php
+++ b/tests/ComposedValue/ComposedAnyOfTest.php
@@ -37,8 +37,8 @@ class ComposedAnyOfTest extends AbstractPHPModelGeneratorTestCase
         $this->expectException(ValidationException::class);
         $this->expectExceptionMessage(
             <<<ERROR
-            Invalid value for property declined by composition constraint.
-              Requires to match at least one composition element.
+            Invalid value for 'property' declined by composition constraint
+              Requires to match at least one composition element
             ERROR,
         );
 
@@ -148,8 +148,8 @@ class ComposedAnyOfTest extends AbstractPHPModelGeneratorTestCase
     {
         $this->expectException(ValidationException::class);
         $this->expectExceptionMessageMatches(
-            '/^Invalid value for (.*?) declined by composition constraint.\s*' .
-            'Requires to match at least one composition element.\s*$/',
+            '/^Invalid value for \'(.*?)\' declined by composition constraint\\s*' .
+            'Requires to match at least one composition element\\s*$/',
         );
 
         $className = $this->generateClassFromFile('ObjectLevelCompositionRequired.json');
@@ -236,7 +236,7 @@ class ComposedAnyOfTest extends AbstractPHPModelGeneratorTestCase
     public function testInvalidProvidedAnyOfTypePropertyThrowsAnException(mixed $propertyValue): void
     {
         $this->expectException(ValidationException::class);
-        $this->expectExceptionMessage('Invalid value for property declined by composition constraint');
+        $this->expectExceptionMessage('Invalid value for \'property\' declined by composition constraint');
 
         $className = $this->generateClassFromFile('AnyOfType.json');
 
@@ -280,7 +280,7 @@ class ComposedAnyOfTest extends AbstractPHPModelGeneratorTestCase
     public function testInvalidProvidedRequiredAnyOfTypePropertyThrowsAnException(mixed $propertyValue): void
     {
         $this->expectException(ValidationException::class);
-        $this->expectExceptionMessage('Invalid value for property declined by composition constraint');
+        $this->expectExceptionMessage('Invalid value for \'property\' declined by composition constraint');
 
         $className = $this->generateClassFromFile('AnyOfTypeRequired.json');
 
@@ -340,15 +340,15 @@ class ComposedAnyOfTest extends AbstractPHPModelGeneratorTestCase
         return [
             'int 13' => [
                 13,
-                'Invalid value for property declined by composition constraint',
+                'Invalid value for \'property\' declined by composition constraint',
                 '/properties/property/anyOf',
             ],
-            'float 9.9' => [9.9, 'Value for property must not be smaller than 10', '/properties/property/minimum'],
-            'int 8' => [8, 'Value for property must not be smaller than 10', '/properties/property/minimum'],
-            'bool' => [true, 'Invalid type for property', '/properties/property/type'],
-            'array' => [[], 'Invalid type for property', '/properties/property/type'],
-            'object' => [new stdClass(), 'Invalid type for property', '/properties/property/type'],
-            'string' => ['', 'Invalid type for property', '/properties/property/type'],
+            'float 9.9' => [9.9, 'Value for \'property\' must not be smaller than 10', '/properties/property/minimum'],
+            'int 8' => [8, 'Value for \'property\' must not be smaller than 10', '/properties/property/minimum'],
+            'bool' => [true, 'Invalid type for \'property\'', '/properties/property/type'],
+            'array' => [[], 'Invalid type for \'property\'', '/properties/property/type'],
+            'object' => [new stdClass(), 'Invalid type for \'property\'', '/properties/property/type'],
+            'string' => ['', 'Invalid type for \'property\'', '/properties/property/type'],
         ];
     }
 
@@ -423,7 +423,7 @@ class ComposedAnyOfTest extends AbstractPHPModelGeneratorTestCase
         mixed $propertyValue,
     ): void {
         $this->expectException(ValidationException::class);
-        $this->expectExceptionMessage('Invalid value for property declined by composition constraint');
+        $this->expectExceptionMessage('Invalid value for \'property\' declined by composition constraint');
 
         $className = $this->generateClassFromFile($schema);
 
@@ -456,7 +456,7 @@ class ComposedAnyOfTest extends AbstractPHPModelGeneratorTestCase
         mixed $propertyValue,
     ): void {
         $this->expectException(ValidationException::class);
-        $this->expectExceptionMessage('Invalid value for property declined by composition constraint');
+        $this->expectExceptionMessage('Invalid value for \'property\' declined by composition constraint');
 
         $className = $this->generateClassFromFile($schema);
 
@@ -636,19 +636,19 @@ class ComposedAnyOfTest extends AbstractPHPModelGeneratorTestCase
             'Exception Collection' => [
                 (new GeneratorConfiguration())->setCollectErrors(true),
                 <<<ERROR
-                declined by composition constraint.
-                  Requires to match at least one composition element.
+                declined by composition constraint
+                  Requires to match at least one composition element
                   - Composition element #1: Failed
-                    * Invalid type for stringProperty. Requires string, got NULL
+                    * Invalid type for 'stringProperty': requires 'string', got 'NULL'
                   - Composition element #2: Failed
-                    * Invalid type for integerProperty. Requires int, got NULL
+                    * Invalid type for 'integerProperty': requires 'int', got 'NULL'
                 ERROR,
             ],
             'Direct Exception' => [
                 (new GeneratorConfiguration())->setCollectErrors(false),
                 <<<ERROR
-                declined by composition constraint.
-                  Requires to match at least one composition element.
+                declined by composition constraint
+                  Requires to match at least one composition element
                 ERROR,
             ],
         ];

--- a/tests/ComposedValue/ComposedAnyOfTest.php
+++ b/tests/ComposedValue/ComposedAnyOfTest.php
@@ -148,7 +148,7 @@ class ComposedAnyOfTest extends AbstractPHPModelGeneratorTestCase
     {
         $this->expectException(ValidationException::class);
         $this->expectExceptionMessageMatches(
-            '/^Invalid value for \'(.*?)\' declined by composition constraint\\s*' .
+            "/^Invalid value for '(.*?)' declined by composition constraint\s*" .
             'Requires to match at least one composition element\\s*$/',
         );
 
@@ -236,7 +236,7 @@ class ComposedAnyOfTest extends AbstractPHPModelGeneratorTestCase
     public function testInvalidProvidedAnyOfTypePropertyThrowsAnException(mixed $propertyValue): void
     {
         $this->expectException(ValidationException::class);
-        $this->expectExceptionMessage('Invalid value for \'property\' declined by composition constraint');
+        $this->expectExceptionMessage("Invalid value for 'property' declined by composition constraint");
 
         $className = $this->generateClassFromFile('AnyOfType.json');
 
@@ -280,7 +280,7 @@ class ComposedAnyOfTest extends AbstractPHPModelGeneratorTestCase
     public function testInvalidProvidedRequiredAnyOfTypePropertyThrowsAnException(mixed $propertyValue): void
     {
         $this->expectException(ValidationException::class);
-        $this->expectExceptionMessage('Invalid value for \'property\' declined by composition constraint');
+        $this->expectExceptionMessage("Invalid value for 'property' declined by composition constraint");
 
         $className = $this->generateClassFromFile('AnyOfTypeRequired.json');
 
@@ -340,15 +340,15 @@ class ComposedAnyOfTest extends AbstractPHPModelGeneratorTestCase
         return [
             'int 13' => [
                 13,
-                'Invalid value for \'property\' declined by composition constraint',
+                "Invalid value for 'property' declined by composition constraint",
                 '/properties/property/anyOf',
             ],
-            'float 9.9' => [9.9, 'Value for \'property\' must not be smaller than 10', '/properties/property/minimum'],
-            'int 8' => [8, 'Value for \'property\' must not be smaller than 10', '/properties/property/minimum'],
-            'bool' => [true, 'Invalid type for \'property\'', '/properties/property/type'],
-            'array' => [[], 'Invalid type for \'property\'', '/properties/property/type'],
-            'object' => [new stdClass(), 'Invalid type for \'property\'', '/properties/property/type'],
-            'string' => ['', 'Invalid type for \'property\'', '/properties/property/type'],
+            'float 9.9' => [9.9, "Value for 'property' must not be smaller than 10", '/properties/property/minimum'],
+            'int 8' => [8, "Value for 'property' must not be smaller than 10", '/properties/property/minimum'],
+            'bool' => [true, "Invalid type for 'property'", '/properties/property/type'],
+            'array' => [[], "Invalid type for 'property'", '/properties/property/type'],
+            'object' => [new stdClass(), "Invalid type for 'property'", '/properties/property/type'],
+            'string' => ['', "Invalid type for 'property'", '/properties/property/type'],
         ];
     }
 
@@ -423,7 +423,7 @@ class ComposedAnyOfTest extends AbstractPHPModelGeneratorTestCase
         mixed $propertyValue,
     ): void {
         $this->expectException(ValidationException::class);
-        $this->expectExceptionMessage('Invalid value for \'property\' declined by composition constraint');
+        $this->expectExceptionMessage("Invalid value for 'property' declined by composition constraint");
 
         $className = $this->generateClassFromFile($schema);
 
@@ -456,7 +456,7 @@ class ComposedAnyOfTest extends AbstractPHPModelGeneratorTestCase
         mixed $propertyValue,
     ): void {
         $this->expectException(ValidationException::class);
-        $this->expectExceptionMessage('Invalid value for \'property\' declined by composition constraint');
+        $this->expectExceptionMessage("Invalid value for 'property' declined by composition constraint");
 
         $className = $this->generateClassFromFile($schema);
 

--- a/tests/ComposedValue/ComposedIfTest.php
+++ b/tests/ComposedValue/ComposedIfTest.php
@@ -83,30 +83,30 @@ class ComposedIfTest extends AbstractPHPModelGeneratorTestCase
             'invalid negative' => [
                 -50,
                 <<<ERROR
-                Invalid value for property declined by conditional composition constraint
+                Invalid value for 'property' declined by conditional composition constraint
                   - Condition: Failed
-                    * Value for property must not be smaller than 100
+                    * Value for 'property' must not be smaller than 100
                   - Conditional branch failed:
-                    * Value for property must be a multiple of 30
+                    * Value for 'property' must be a multiple of 30
                 ERROR,
             ],
             'invalid positive else' => [
                 50,
                 <<<ERROR
-                Invalid value for property declined by conditional composition constraint
+                Invalid value for 'property' declined by conditional composition constraint
                   - Condition: Failed
-                    * Value for property must not be smaller than 100
+                    * Value for 'property' must not be smaller than 100
                   - Conditional branch failed:
-                    * Value for property must be a multiple of 30
+                    * Value for 'property' must be a multiple of 30
                 ERROR,
             ],
             'invalid positive then' => [
                 120,
                 <<<ERROR
-                Invalid value for property declined by conditional composition constraint
+                Invalid value for 'property' declined by conditional composition constraint
                   - Condition: Valid
                   - Conditional branch failed:
-                    * Value for property must be a multiple of 50
+                    * Value for 'property' must be a multiple of 50
                 ERROR,
             ],
         ];
@@ -171,7 +171,7 @@ class ComposedIfTest extends AbstractPHPModelGeneratorTestCase
     ): void {
         $this->expectValidationErrorRegExp(
             $configuration,
-            '/(Invalid value for .*? declined by composition constraint|postal_code doesn\'t match pattern .*)/',
+            '/(Invalid value for .*? declined by composition constraint|\'postal_code\' does not match pattern .*)/',
         );
 
         $className = $this->generateClassFromFile($schemaFile, $configuration);

--- a/tests/ComposedValue/ComposedIfTest.php
+++ b/tests/ComposedValue/ComposedIfTest.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 namespace PHPModelGenerator\Tests\ComposedValue;
 
+use PHPModelGenerator\Exception\Arrays\InvalidItemException;
 use PHPModelGenerator\Exception\ComposedValue\ConditionalException;
+use PHPModelGenerator\Exception\ErrorRegistryException;
 use PHPModelGenerator\Exception\FileSystemException;
 use PHPModelGenerator\Exception\RenderException;
 use PHPModelGenerator\Exception\SchemaException;
@@ -195,6 +197,37 @@ class ComposedIfTest extends AbstractPHPModelGeneratorTestCase
                 ],
             )
         );
+    }
+
+    /**
+     * Regression test: when the "then" branch of an if/then applied to an array item fails,
+     * the item's real value must survive. The "then" branch's own decorator resolution may leave
+     * $value as a leftover nested-object-instantiation exception (unlike the "if" branch, which
+     * already restores $originalModelData right after its own check) — that leftover must not
+     * leak out as the reported providedValue, especially since array items are validated by
+     * reference into the original array.
+     *
+     * @throws FileSystemException
+     * @throws RenderException
+     * @throws SchemaException
+     */
+    public function testInvalidConditionalArrayItemPreservesProvidedValueOnThenBranchFailure(): void
+    {
+        $className = $this->generateClassFromFile('ConditionalArrayItem.json', new GeneratorConfiguration());
+
+        $propertyValue = [['kind' => 'metric']];
+
+        try {
+            new $className(['property' => $propertyValue]);
+            $this->fail('Expected exception for invalid conditional array item');
+        } catch (ErrorRegistryException $exception) {
+            $itemException = $exception->getErrors()[0];
+            $this->assertInstanceOf(InvalidItemException::class, $itemException);
+
+            $conditionalException = $itemException->getInvalidItems()[0][0];
+            $this->assertInstanceOf(ConditionalException::class, $conditionalException);
+            $this->assertSame($propertyValue[0], $conditionalException->getProvidedValue());
+        }
     }
 
     public function testIncompleteCompositionThrowsAnException(): void

--- a/tests/ComposedValue/ComposedIfTest.php
+++ b/tests/ComposedValue/ComposedIfTest.php
@@ -171,7 +171,7 @@ class ComposedIfTest extends AbstractPHPModelGeneratorTestCase
     ): void {
         $this->expectValidationErrorRegExp(
             $configuration,
-            '/(Invalid value for .*? declined by composition constraint|\'postal_code\' does not match pattern .*)/',
+            "/(Invalid value for .*? declined by composition constraint|'postal_code' does not match pattern .*)/",
         );
 
         $className = $this->generateClassFromFile($schemaFile, $configuration);

--- a/tests/ComposedValue/ComposedIfThenElseBranchDefaultTest.php
+++ b/tests/ComposedValue/ComposedIfThenElseBranchDefaultTest.php
@@ -142,10 +142,10 @@ class ComposedIfThenElseBranchDefaultTest extends AbstractPHPModelGeneratorTestC
         $this->assertInstanceOf(ConditionalException::class, $caughtException);
         $this->assertMatchesRegularExpression(
             <<<'PATTERN'
-            /^Invalid value for \S+ declined by conditional composition constraint
+            /^Invalid value for '\S+' declined by conditional composition constraint
               - Condition: Valid
               - Conditional branch failed:
-                \* Value for score must not be smaller than 50$/
+                \* Value for 'score' must not be smaller than 50$/
             PATTERN,
             $caughtException->getMessage(),
         );

--- a/tests/ComposedValue/ComposedNotTest.php
+++ b/tests/ComposedValue/ComposedNotTest.php
@@ -31,7 +31,7 @@ class ComposedNotTest extends AbstractPHPModelGeneratorTestCase
         $this->expectExceptionMessage(
             <<<ERROR
             Invalid value for 'property' declined by composition constraint
-              Requires to match none composition element but matched 1 elements
+              Requires to match none composition element but matched 1 element
             ERROR,
         );
 
@@ -109,7 +109,7 @@ class ComposedNotTest extends AbstractPHPModelGeneratorTestCase
             $this->fail('Expected exception for value matching the not branch');
         } catch (ErrorRegistryException | NotException $exception) {
             $this->assertStringContainsString(
-                'Invalid value for \'property\' declined by composition constraint',
+                "Invalid value for 'property' declined by composition constraint",
                 $exception->getMessage(),
             );
 
@@ -145,7 +145,7 @@ class ComposedNotTest extends AbstractPHPModelGeneratorTestCase
     {
         $this->expectValidationError(
             $configuration,
-            'Invalid value for \'property\' declined by composition constraint',
+            "Invalid value for 'property' declined by composition constraint",
         );
 
         $className = $this->generateClassFromFile('NotNull.json', $configuration);
@@ -164,7 +164,7 @@ class ComposedNotTest extends AbstractPHPModelGeneratorTestCase
     ): void {
         $this->expectValidationError(
             $configuration,
-            'Invalid value for \'property\' declined by composition constraint',
+            "Invalid value for 'property' declined by composition constraint",
         );
 
         $className = $this->generateClassFromFile('NotNull.json', $configuration);
@@ -268,15 +268,15 @@ class ComposedNotTest extends AbstractPHPModelGeneratorTestCase
         return self::combineDataProvider(
             self::validationMethodDataProvider(),
             [
-                '10.' => [10., 'Invalid value for \'property\' declined by composition constraint'],
-                '12.' => [12., 'Invalid value for \'property\' declined by composition constraint'],
-                '9.9' => [9.9, 'Value for \'property\' must not be smaller than 10'],
-                '9.' => [9, 'Value for \'property\' must not be smaller than 10'],
-                '8.' => [8, 'Value for \'property\' must not be smaller than 10'],
-                'bool' => [true, 'Invalid type for \'property\''],
-                'array' => [[], 'Invalid type for \'property\''],
-                'object' => [new stdClass(), 'Invalid type for \'property\''],
-                'string' => ['', 'Invalid type for \'property\''],
+                '10.' => [10., "Invalid value for 'property' declined by composition constraint"],
+                '12.' => [12., "Invalid value for 'property' declined by composition constraint"],
+                '9.9' => [9.9, "Value for 'property' must not be smaller than 10"],
+                '9.' => [9, "Value for 'property' must not be smaller than 10"],
+                '8.' => [8, "Value for 'property' must not be smaller than 10"],
+                'bool' => [true, "Invalid type for 'property'"],
+                'array' => [[], "Invalid type for 'property'"],
+                'object' => [new stdClass(), "Invalid type for 'property'"],
+                'string' => ['', "Invalid type for 'property'"],
             ],
         );
     }
@@ -341,7 +341,7 @@ class ComposedNotTest extends AbstractPHPModelGeneratorTestCase
     public function testMatchingObjectPropertyWithReferencedSchemaThrowsAnException(
         GeneratorConfiguration $configuration,
     ): void {
-        $this->expectValidationError($configuration, 'Invalid value for \'person\' declined by composition constraint');
+        $this->expectValidationError($configuration, "Invalid value for 'person' declined by composition constraint");
 
         $className = $this->generateClassFromFile('ReferencedObjectSchema.json', $configuration);
 
@@ -387,7 +387,7 @@ class ComposedNotTest extends AbstractPHPModelGeneratorTestCase
                 (new GeneratorConfiguration())->setCollectErrors(true),
                 <<<ERROR
                 Invalid value for 'property' declined by composition constraint
-                  Requires to match none composition element but matched 1 elements
+                  Requires to match none composition element but matched 1 element
                   - Composition element #1: Valid
                 ERROR,
             ],
@@ -395,7 +395,7 @@ class ComposedNotTest extends AbstractPHPModelGeneratorTestCase
                 (new GeneratorConfiguration())->setCollectErrors(false),
                 <<<ERROR
                 Invalid value for 'property' declined by composition constraint
-                  Requires to match none composition element but matched 1 elements
+                  Requires to match none composition element but matched 1 element
                 ERROR,
             ],
         ];

--- a/tests/ComposedValue/ComposedNotTest.php
+++ b/tests/ComposedValue/ComposedNotTest.php
@@ -30,8 +30,8 @@ class ComposedNotTest extends AbstractPHPModelGeneratorTestCase
         $this->expectException(ValidationException::class);
         $this->expectExceptionMessage(
             <<<ERROR
-            Invalid value for property declined by composition constraint.
-              Requires to match none composition element but matched 1 elements.
+            Invalid value for 'property' declined by composition constraint
+              Requires to match none composition element but matched 1 elements
             ERROR,
         );
 
@@ -109,7 +109,7 @@ class ComposedNotTest extends AbstractPHPModelGeneratorTestCase
             $this->fail('Expected exception for value matching the not branch');
         } catch (ErrorRegistryException | NotException $exception) {
             $this->assertStringContainsString(
-                'Invalid value for property declined by composition constraint',
+                'Invalid value for \'property\' declined by composition constraint',
                 $exception->getMessage(),
             );
 
@@ -143,7 +143,10 @@ class ComposedNotTest extends AbstractPHPModelGeneratorTestCase
     #[DataProvider('validationMethodDataProvider')]
     public function testNotProvidedOptionalNotNullPropertyThrowsAnException(GeneratorConfiguration $configuration): void
     {
-        $this->expectValidationError($configuration, 'Invalid value for property declined by composition constraint');
+        $this->expectValidationError(
+            $configuration,
+            'Invalid value for \'property\' declined by composition constraint',
+        );
 
         $className = $this->generateClassFromFile('NotNull.json', $configuration);
 
@@ -159,7 +162,10 @@ class ComposedNotTest extends AbstractPHPModelGeneratorTestCase
     public function testInvalidProvidedOptionalNotNullPropertyThrowsAnException(
         GeneratorConfiguration $configuration,
     ): void {
-        $this->expectValidationError($configuration, 'Invalid value for property declined by composition constraint');
+        $this->expectValidationError(
+            $configuration,
+            'Invalid value for \'property\' declined by composition constraint',
+        );
 
         $className = $this->generateClassFromFile('NotNull.json', $configuration);
 
@@ -262,15 +268,15 @@ class ComposedNotTest extends AbstractPHPModelGeneratorTestCase
         return self::combineDataProvider(
             self::validationMethodDataProvider(),
             [
-                '10.' => [10., 'Invalid value for property declined by composition constraint'],
-                '12.' => [12., 'Invalid value for property declined by composition constraint'],
-                '9.9' => [9.9, 'Value for property must not be smaller than 10'],
-                '9.' => [9, 'Value for property must not be smaller than 10'],
-                '8.' => [8, 'Value for property must not be smaller than 10'],
-                'bool' => [true, 'Invalid type for property'],
-                'array' => [[], 'Invalid type for property'],
-                'object' => [new stdClass(), 'Invalid type for property'],
-                'string' => ['', 'Invalid type for property'],
+                '10.' => [10., 'Invalid value for \'property\' declined by composition constraint'],
+                '12.' => [12., 'Invalid value for \'property\' declined by composition constraint'],
+                '9.9' => [9.9, 'Value for \'property\' must not be smaller than 10'],
+                '9.' => [9, 'Value for \'property\' must not be smaller than 10'],
+                '8.' => [8, 'Value for \'property\' must not be smaller than 10'],
+                'bool' => [true, 'Invalid type for \'property\''],
+                'array' => [[], 'Invalid type for \'property\''],
+                'object' => [new stdClass(), 'Invalid type for \'property\''],
+                'string' => ['', 'Invalid type for \'property\''],
             ],
         );
     }
@@ -335,7 +341,7 @@ class ComposedNotTest extends AbstractPHPModelGeneratorTestCase
     public function testMatchingObjectPropertyWithReferencedSchemaThrowsAnException(
         GeneratorConfiguration $configuration,
     ): void {
-        $this->expectValidationError($configuration, 'Invalid value for person declined by composition constraint');
+        $this->expectValidationError($configuration, 'Invalid value for \'person\' declined by composition constraint');
 
         $className = $this->generateClassFromFile('ReferencedObjectSchema.json', $configuration);
 
@@ -380,16 +386,16 @@ class ComposedNotTest extends AbstractPHPModelGeneratorTestCase
             'Exception Collection' => [
                 (new GeneratorConfiguration())->setCollectErrors(true),
                 <<<ERROR
-                Invalid value for property declined by composition constraint.
-                  Requires to match none composition element but matched 1 elements.
+                Invalid value for 'property' declined by composition constraint
+                  Requires to match none composition element but matched 1 elements
                   - Composition element #1: Valid
                 ERROR,
             ],
             'Direct Exception' => [
                 (new GeneratorConfiguration())->setCollectErrors(false),
                 <<<ERROR
-                Invalid value for property declined by composition constraint.
-                  Requires to match none composition element but matched 1 elements.
+                Invalid value for 'property' declined by composition constraint
+                  Requires to match none composition element but matched 1 elements
                 ERROR,
             ],
         ];

--- a/tests/ComposedValue/ComposedOneOfTest.php
+++ b/tests/ComposedValue/ComposedOneOfTest.php
@@ -34,8 +34,8 @@ class ComposedOneOfTest extends AbstractPHPModelGeneratorTestCase
         $this->expectException(ValidationException::class);
         $this->expectExceptionMessage(
             <<<ERROR
-            Invalid value for property declined by composition constraint.
-              Requires to match one composition element but matched 0 elements.
+            Invalid value for 'property' declined by composition constraint
+              Requires to match one composition element but matched 0 elements
             ERROR,
         );
 
@@ -108,8 +108,8 @@ class ComposedOneOfTest extends AbstractPHPModelGeneratorTestCase
         $this->expectException(ValidationException::class);
         $this->expectExceptionMessageMatches(
             <<<ERROR
-            /^Invalid value for (.*?) declined by composition constraint.
-              Requires to match one composition element but matched $matchedElements elements.$/
+            /^Invalid value for '(.*?)' declined by composition constraint
+              Requires to match one composition element but matched $matchedElements elements$/
             ERROR,
         );
 
@@ -165,7 +165,7 @@ class ComposedOneOfTest extends AbstractPHPModelGeneratorTestCase
     public function testInvalidProvidedOneOfTypePropertyThrowsAnException(mixed $propertyValue): void
     {
         $this->expectException(ValidationException::class);
-        $this->expectExceptionMessage('Invalid value for property declined by composition constraint');
+        $this->expectExceptionMessage('Invalid value for \'property\' declined by composition constraint');
 
         $className = $this->generateClassFromFile('OneOfType.json');
 
@@ -209,7 +209,7 @@ class ComposedOneOfTest extends AbstractPHPModelGeneratorTestCase
     public function testInvalidProvidedRequiredOneOfTypePropertyThrowsAnException(mixed $propertyValue): void
     {
         $this->expectException(ValidationException::class);
-        $this->expectExceptionMessage('Invalid value for property declined by composition constraint');
+        $this->expectExceptionMessage('Invalid value for \'property\' declined by composition constraint');
 
         $className = $this->generateClassFromFile('OneOfTypeRequired.json');
 
@@ -266,30 +266,30 @@ class ComposedOneOfTest extends AbstractPHPModelGeneratorTestCase
         return [
             'int 10' => [
                 10,
-                'Invalid value for property declined by composition constraint',
+                'Invalid value for \'property\' declined by composition constraint',
                 '/properties/property/oneOf',
             ],
             'int 13' => [
                 13,
-                'Invalid value for property declined by composition constraint',
+                'Invalid value for \'property\' declined by composition constraint',
                 '/properties/property/oneOf',
             ],
             'int 20' => [
                 20,
-                'Invalid value for property declined by composition constraint',
+                'Invalid value for \'property\' declined by composition constraint',
                 '/properties/property/oneOf',
             ],
             'float 10.' => [
                 10.,
-                'Invalid value for property declined by composition constraint',
+                'Invalid value for \'property\' declined by composition constraint',
                 '/properties/property/oneOf',
             ],
-            'float 9.9' => [9.9, 'Value for property must not be smaller than 10', '/properties/property/minimum'],
-            'int 8' => [8, 'Value for property must not be smaller than 10', '/properties/property/minimum'],
-            'bool' => [true, 'Invalid type for property', '/properties/property/type'],
-            'array' => [[], 'Invalid type for property', '/properties/property/type'],
-            'object' => [new stdClass(), 'Invalid type for property', '/properties/property/type'],
-            'string' => ['', 'Invalid type for property', '/properties/property/type'],
+            'float 9.9' => [9.9, 'Value for \'property\' must not be smaller than 10', '/properties/property/minimum'],
+            'int 8' => [8, 'Value for \'property\' must not be smaller than 10', '/properties/property/minimum'],
+            'bool' => [true, 'Invalid type for \'property\'', '/properties/property/type'],
+            'array' => [[], 'Invalid type for \'property\'', '/properties/property/type'],
+            'object' => [new stdClass(), 'Invalid type for \'property\'', '/properties/property/type'],
+            'string' => ['', 'Invalid type for \'property\'', '/properties/property/type'],
         ];
     }
 
@@ -346,7 +346,7 @@ class ComposedOneOfTest extends AbstractPHPModelGeneratorTestCase
         mixed $propertyValue,
     ): void {
         $this->expectException(ValidationException::class);
-        $this->expectExceptionMessage('Invalid value for property declined by composition constraint');
+        $this->expectExceptionMessage('Invalid value for \'property\' declined by composition constraint');
 
         $className = $this->generateClassFromFile($schema);
 
@@ -377,7 +377,7 @@ class ComposedOneOfTest extends AbstractPHPModelGeneratorTestCase
     public function testNotMatchingObjectPropertyWithReferencedPetSchemaThrowsAnException(mixed $propertyValue): void
     {
         $this->expectException(ValidationException::class);
-        $this->expectExceptionMessage('Invalid value for property declined by composition constraint');
+        $this->expectExceptionMessage('Invalid value for \'property\' declined by composition constraint');
 
         $className = $this->generateClassFromFile('ReferencedObjectSchema2.json');
 
@@ -559,29 +559,29 @@ class ComposedOneOfTest extends AbstractPHPModelGeneratorTestCase
             'Exception Collection' => [
                 (new GeneratorConfiguration())->setCollectErrors(true),
                 <<<ERROR
-                declined by composition constraint.
-                  Requires to match one composition element but matched 2 elements.
+                declined by composition constraint
+                  Requires to match one composition element but matched 2 elements
                   - Composition element #1: Valid
                   - Composition element #2: Valid
                 ERROR,
                 <<<ERROR
-                declined by composition constraint.
-                  Requires to match one composition element but matched 0 elements.
+                declined by composition constraint
+                  Requires to match one composition element but matched 0 elements
                   - Composition element #1: Failed
-                    * Invalid type for stringProperty. Requires string, got NULL
+                    * Invalid type for 'stringProperty': requires 'string', got 'NULL'
                   - Composition element #2: Failed
-                    * Invalid type for integerProperty. Requires int, got NULL
+                    * Invalid type for 'integerProperty': requires 'int', got 'NULL'
                 ERROR,
             ],
             'Direct Exception' => [
                 (new GeneratorConfiguration())->setCollectErrors(false),
                 <<<ERROR
-                declined by composition constraint.
-                  Requires to match one composition element but matched 2 elements.
+                declined by composition constraint
+                  Requires to match one composition element but matched 2 elements
                 ERROR,
                 <<<ERROR
-                declined by composition constraint.
-                  Requires to match one composition element but matched 0 elements.
+                declined by composition constraint
+                  Requires to match one composition element but matched 0 elements
                 ERROR,
             ],
         ];

--- a/tests/ComposedValue/ComposedOneOfTest.php
+++ b/tests/ComposedValue/ComposedOneOfTest.php
@@ -165,7 +165,7 @@ class ComposedOneOfTest extends AbstractPHPModelGeneratorTestCase
     public function testInvalidProvidedOneOfTypePropertyThrowsAnException(mixed $propertyValue): void
     {
         $this->expectException(ValidationException::class);
-        $this->expectExceptionMessage('Invalid value for \'property\' declined by composition constraint');
+        $this->expectExceptionMessage("Invalid value for 'property' declined by composition constraint");
 
         $className = $this->generateClassFromFile('OneOfType.json');
 
@@ -209,7 +209,7 @@ class ComposedOneOfTest extends AbstractPHPModelGeneratorTestCase
     public function testInvalidProvidedRequiredOneOfTypePropertyThrowsAnException(mixed $propertyValue): void
     {
         $this->expectException(ValidationException::class);
-        $this->expectExceptionMessage('Invalid value for \'property\' declined by composition constraint');
+        $this->expectExceptionMessage("Invalid value for 'property' declined by composition constraint");
 
         $className = $this->generateClassFromFile('OneOfTypeRequired.json');
 
@@ -266,30 +266,30 @@ class ComposedOneOfTest extends AbstractPHPModelGeneratorTestCase
         return [
             'int 10' => [
                 10,
-                'Invalid value for \'property\' declined by composition constraint',
+                "Invalid value for 'property' declined by composition constraint",
                 '/properties/property/oneOf',
             ],
             'int 13' => [
                 13,
-                'Invalid value for \'property\' declined by composition constraint',
+                "Invalid value for 'property' declined by composition constraint",
                 '/properties/property/oneOf',
             ],
             'int 20' => [
                 20,
-                'Invalid value for \'property\' declined by composition constraint',
+                "Invalid value for 'property' declined by composition constraint",
                 '/properties/property/oneOf',
             ],
             'float 10.' => [
                 10.,
-                'Invalid value for \'property\' declined by composition constraint',
+                "Invalid value for 'property' declined by composition constraint",
                 '/properties/property/oneOf',
             ],
-            'float 9.9' => [9.9, 'Value for \'property\' must not be smaller than 10', '/properties/property/minimum'],
-            'int 8' => [8, 'Value for \'property\' must not be smaller than 10', '/properties/property/minimum'],
-            'bool' => [true, 'Invalid type for \'property\'', '/properties/property/type'],
-            'array' => [[], 'Invalid type for \'property\'', '/properties/property/type'],
-            'object' => [new stdClass(), 'Invalid type for \'property\'', '/properties/property/type'],
-            'string' => ['', 'Invalid type for \'property\'', '/properties/property/type'],
+            'float 9.9' => [9.9, "Value for 'property' must not be smaller than 10", '/properties/property/minimum'],
+            'int 8' => [8, "Value for 'property' must not be smaller than 10", '/properties/property/minimum'],
+            'bool' => [true, "Invalid type for 'property'", '/properties/property/type'],
+            'array' => [[], "Invalid type for 'property'", '/properties/property/type'],
+            'object' => [new stdClass(), "Invalid type for 'property'", '/properties/property/type'],
+            'string' => ['', "Invalid type for 'property'", '/properties/property/type'],
         ];
     }
 
@@ -346,7 +346,7 @@ class ComposedOneOfTest extends AbstractPHPModelGeneratorTestCase
         mixed $propertyValue,
     ): void {
         $this->expectException(ValidationException::class);
-        $this->expectExceptionMessage('Invalid value for \'property\' declined by composition constraint');
+        $this->expectExceptionMessage("Invalid value for 'property' declined by composition constraint");
 
         $className = $this->generateClassFromFile($schema);
 
@@ -377,7 +377,7 @@ class ComposedOneOfTest extends AbstractPHPModelGeneratorTestCase
     public function testNotMatchingObjectPropertyWithReferencedPetSchemaThrowsAnException(mixed $propertyValue): void
     {
         $this->expectException(ValidationException::class);
-        $this->expectExceptionMessage('Invalid value for \'property\' declined by composition constraint');
+        $this->expectExceptionMessage("Invalid value for 'property' declined by composition constraint");
 
         $className = $this->generateClassFromFile('ReferencedObjectSchema2.json');
 

--- a/tests/ComposedValue/ComposedPatternPropertyBranchDefaultTest.php
+++ b/tests/ComposedValue/ComposedPatternPropertyBranchDefaultTest.php
@@ -69,7 +69,7 @@ class ComposedPatternPropertyBranchDefaultTest extends AbstractPHPModelGenerator
     {
         $this->expectValidationError(
             (new GeneratorConfiguration())->setCollectErrors(false),
-            'Value for \'pattern property\' must not be smaller than 1',
+            "Value for 'pattern property' must not be smaller than 1",
         );
 
         $className = $this->generateClassFromFile(

--- a/tests/ComposedValue/ComposedPatternPropertyBranchDefaultTest.php
+++ b/tests/ComposedValue/ComposedPatternPropertyBranchDefaultTest.php
@@ -69,7 +69,7 @@ class ComposedPatternPropertyBranchDefaultTest extends AbstractPHPModelGenerator
     {
         $this->expectValidationError(
             (new GeneratorConfiguration())->setCollectErrors(false),
-            'Value for pattern property must not be smaller than 1',
+            'Value for \'pattern property\' must not be smaller than 1',
         );
 
         $className = $this->generateClassFromFile(

--- a/tests/Draft/DraftExtensibilityTest.php
+++ b/tests/Draft/DraftExtensibilityTest.php
@@ -138,7 +138,7 @@ class DraftExtensibilityTest extends AbstractPHPModelGeneratorTestCase
 
         // Empty string fails (length 0 < 1).
         $this->expectException(ValidationException::class);
-        $this->expectExceptionMessage('Value for \'value\' must not be shorter than 1');
+        $this->expectExceptionMessage("Value for 'value' must not be shorter than 1");
         new $className(['value' => '']);
     }
 
@@ -186,7 +186,7 @@ class DraftExtensibilityTest extends AbstractPHPModelGeneratorTestCase
 
         // 'ab' has length 2 < 3 → validation fails
         $this->expectException(ValidationException::class);
-        $this->expectExceptionMessage('Value for \'value\' must not be shorter than 3');
+        $this->expectExceptionMessage("Value for 'value' must not be shorter than 3");
         new $className(['value' => 'ab']);
     }
 

--- a/tests/Draft/DraftExtensibilityTest.php
+++ b/tests/Draft/DraftExtensibilityTest.php
@@ -138,7 +138,7 @@ class DraftExtensibilityTest extends AbstractPHPModelGeneratorTestCase
 
         // Empty string fails (length 0 < 1).
         $this->expectException(ValidationException::class);
-        $this->expectExceptionMessage('Value for value must not be shorter than 1');
+        $this->expectExceptionMessage('Value for \'value\' must not be shorter than 1');
         new $className(['value' => '']);
     }
 
@@ -186,7 +186,7 @@ class DraftExtensibilityTest extends AbstractPHPModelGeneratorTestCase
 
         // 'ab' has length 2 < 3 → validation fails
         $this->expectException(ValidationException::class);
-        $this->expectExceptionMessage('Value for value must not be shorter than 3');
+        $this->expectExceptionMessage('Value for \'value\' must not be shorter than 3');
         new $className(['value' => 'ab']);
     }
 

--- a/tests/Filter/BuiltInFilterTest.php
+++ b/tests/Filter/BuiltInFilterTest.php
@@ -114,7 +114,7 @@ class BuiltInFilterTest extends AbstractFilterTestCase
     public function testLengthValidationForFilteredValueForInvalidValuesThrowsAnException(string $input): void
     {
         $this->expectException(ValidationException::class);
-        $this->expectExceptionMessage('Value for property must not be shorter than 2');
+        $this->expectExceptionMessage('Value for \'property\' must not be shorter than 2');
 
         $className = $this->generateClassFromFile('TrimAsStringWithLengthValidation.json');
 

--- a/tests/Filter/BuiltInFilterTest.php
+++ b/tests/Filter/BuiltInFilterTest.php
@@ -114,7 +114,7 @@ class BuiltInFilterTest extends AbstractFilterTestCase
     public function testLengthValidationForFilteredValueForInvalidValuesThrowsAnException(string $input): void
     {
         $this->expectException(ValidationException::class);
-        $this->expectExceptionMessage('Value for \'property\' must not be shorter than 2');
+        $this->expectExceptionMessage("Value for 'property' must not be shorter than 2");
 
         $className = $this->generateClassFromFile('TrimAsStringWithLengthValidation.json');
 

--- a/tests/Filter/FilterChainTest.php
+++ b/tests/Filter/FilterChainTest.php
@@ -84,7 +84,7 @@ class FilterChainTest extends AbstractFilterTestCase
     {
         $this->expectException(ErrorRegistryException::class);
         $this->expectExceptionMessage(
-            'Invalid value for property \'filteredProperty\' denied by filter \'exceptionFilter\': ' .
+            "Invalid value for property 'filteredProperty' denied by filter 'exceptionFilter': " .
             'Exception filter called with 12.12.2020',
         );
 
@@ -138,7 +138,7 @@ class FilterChainTest extends AbstractFilterTestCase
     {
         $this->expectException(ErrorRegistryException::class);
         $this->expectExceptionMessage(
-            'Invalid value for property \'filteredProperty\' denied by filter \'dateTime\': ' .
+            "Invalid value for property 'filteredProperty' denied by filter 'dateTime': " .
                 'Invalid Date Time value "Hello"',
         );
 

--- a/tests/Filter/FilterChainTest.php
+++ b/tests/Filter/FilterChainTest.php
@@ -84,7 +84,7 @@ class FilterChainTest extends AbstractFilterTestCase
     {
         $this->expectException(ErrorRegistryException::class);
         $this->expectExceptionMessage(
-            'Invalid value for property filteredProperty denied by filter exceptionFilter: ' .
+            'Invalid value for property \'filteredProperty\' denied by filter \'exceptionFilter\': ' .
             'Exception filter called with 12.12.2020',
         );
 
@@ -138,7 +138,8 @@ class FilterChainTest extends AbstractFilterTestCase
     {
         $this->expectException(ErrorRegistryException::class);
         $this->expectExceptionMessage(
-            'Invalid value for property filteredProperty denied by filter dateTime: Invalid Date Time value "Hello"',
+            'Invalid value for property \'filteredProperty\' denied by filter \'dateTime\': ' .
+                'Invalid Date Time value "Hello"',
         );
 
         $className = $this->generateClassFromFile(

--- a/tests/Filter/FilterCompositionRuntimeTest.php
+++ b/tests/Filter/FilterCompositionRuntimeTest.php
@@ -109,7 +109,7 @@ class FilterCompositionRuntimeTest extends AbstractFilterTestCase
             new $className(['value' => 'hello']);
             $this->fail('Expected PatternException for input "hello"');
         } catch (PatternException $patternException) {
-            $this->assertStringContainsString("doesn't match pattern", $patternException->getMessage());
+            $this->assertStringContainsString("does not match pattern", $patternException->getMessage());
         }
 
         // "-5" would silently become -5 post-transform, causing MinimumException instead.
@@ -118,7 +118,7 @@ class FilterCompositionRuntimeTest extends AbstractFilterTestCase
             new $className(['value' => '-5']);
             $this->fail('Expected PatternException for input "-5"');
         } catch (PatternException $patternException) {
-            $this->assertStringContainsString("doesn't match pattern", $patternException->getMessage());
+            $this->assertStringContainsString("does not match pattern", $patternException->getMessage());
         }
 
         // Valid string input: pattern passes, filter transforms to 42, minimum passes.
@@ -232,11 +232,11 @@ class FilterCompositionRuntimeTest extends AbstractFilterTestCase
             $this->assertContainsOnlyInstancesOf(AllOfException::class, $errors);
             $this->assertStringContainsString(
                 <<<ERROR
-                Invalid value for filteredProperty declined by composition constraint.
-                  Requires to match all composition elements but matched 1 elements.
+                Invalid value for 'filteredProperty' declined by composition constraint
+                  Requires to match all composition elements but matched 1 elements
                   - Composition element #1: Valid
                   - Composition element #2: Failed
-                    * Value for filteredProperty must not be larger than 100
+                    * Value for 'filteredProperty' must not be larger than 100
                 ERROR,
                 $errors[0]->getMessage(),
             );
@@ -254,10 +254,10 @@ class FilterCompositionRuntimeTest extends AbstractFilterTestCase
             $this->assertContainsOnlyInstancesOf(AllOfException::class, $errors);
             $this->assertStringContainsString(
                 <<<ERROR
-                Invalid value for filteredProperty declined by composition constraint.
-                  Requires to match all composition elements but matched 1 elements.
+                Invalid value for 'filteredProperty' declined by composition constraint
+                  Requires to match all composition elements but matched 1 elements
                   - Composition element #1: Failed
-                    * Value for filteredProperty must not be smaller than 0
+                    * Value for 'filteredProperty' must not be smaller than 0
                 ERROR,
                 $errors[0]->getMessage(),
             );
@@ -308,10 +308,10 @@ class FilterCompositionRuntimeTest extends AbstractFilterTestCase
             $this->assertInstanceOf(AllOfException::class, $errors[0]);
             $this->assertStringContainsString(
                 <<<ERROR
-                Invalid value for filteredProperty declined by composition constraint.
-                  Requires to match all composition elements but matched 0 elements.
+                Invalid value for 'filteredProperty' declined by composition constraint
+                  Requires to match all composition elements but matched 0 elements
                   - Composition element #1: Failed
-                    * Invalid type for filteredProperty. Requires string, got integer
+                    * Invalid type for 'filteredProperty': requires 'string', got 'integer'
                 ERROR,
                 $errors[0]->getMessage(),
             );
@@ -323,7 +323,7 @@ class FilterCompositionRuntimeTest extends AbstractFilterTestCase
             // second error silently going missing.
             $this->assertInstanceOf(InvalidFilterValueException::class, $errors[1]);
             $this->assertStringStartsWith(
-                'Invalid value for property filteredProperty denied by filter mixedAcceptDateTimeFilter:',
+                'Invalid value for property \'filteredProperty\' denied by filter \'mixedAcceptDateTimeFilter\':',
                 $errors[1]->getMessage(),
             );
         }
@@ -362,10 +362,10 @@ class FilterCompositionRuntimeTest extends AbstractFilterTestCase
             $this->assertContainsOnlyInstancesOf(AllOfException::class, $errors);
             $this->assertStringContainsString(
                 <<<ERROR
-                Invalid value for filteredProperty declined by composition constraint.
-                  Requires to match all composition elements but matched 0 elements.
+                Invalid value for 'filteredProperty' declined by composition constraint
+                  Requires to match all composition elements but matched 0 elements
                   - Composition element #1: Failed
-                    * Value for filteredProperty must not be shorter than 5
+                    * Value for 'filteredProperty' must not be shorter than 5
                 ERROR,
                 $errors[0]->getMessage(),
             );
@@ -419,10 +419,10 @@ class FilterCompositionRuntimeTest extends AbstractFilterTestCase
             $this->assertContainsOnlyInstancesOf(AllOfException::class, $errors);
             $this->assertStringContainsString(
                 <<<ERROR
-                Invalid value for filteredProperty declined by composition constraint.
-                  Requires to match all composition elements but matched 0 elements.
+                Invalid value for 'filteredProperty' declined by composition constraint
+                  Requires to match all composition elements but matched 0 elements
                   - Composition element #1: Failed
-                    * Value for filteredProperty must not be shorter than 1
+                    * Value for 'filteredProperty' must not be shorter than 1
                 ERROR,
                 $errors[0]->getMessage(),
             );
@@ -440,10 +440,10 @@ class FilterCompositionRuntimeTest extends AbstractFilterTestCase
             $this->assertContainsOnlyInstancesOf(AllOfException::class, $errors);
             $this->assertStringContainsString(
                 <<<ERROR
-                Invalid value for filteredProperty declined by composition constraint.
-                  Requires to match all composition elements but matched 0 elements.
+                Invalid value for 'filteredProperty' declined by composition constraint
+                  Requires to match all composition elements but matched 0 elements
                   - Composition element #1: Failed
-                    * Value for filteredProperty must not be smaller than 0
+                    * Value for 'filteredProperty' must not be smaller than 0
                 ERROR,
                 $errors[0]->getMessage(),
             );
@@ -464,10 +464,10 @@ class FilterCompositionRuntimeTest extends AbstractFilterTestCase
             $this->assertContainsOnlyInstancesOf(AllOfException::class, $errors);
             $this->assertStringContainsString(
                 <<<ERROR
-                Invalid value for filteredProperty declined by composition constraint.
-                  Requires to match all composition elements but matched 0 elements.
+                Invalid value for 'filteredProperty' declined by composition constraint
+                  Requires to match all composition elements but matched 0 elements
                   - Composition element #1: Failed
-                    * Value for filteredProperty must not be smaller than 0
+                    * Value for 'filteredProperty' must not be smaller than 0
                 ERROR,
                 $errors[0]->getMessage(),
             );
@@ -507,10 +507,10 @@ class FilterCompositionRuntimeTest extends AbstractFilterTestCase
             $this->assertContainsOnlyInstancesOf(AllOfException::class, $errors);
             $this->assertStringContainsString(
                 <<<ERROR
-                Invalid value for filteredProperty declined by composition constraint.
-                  Requires to match all composition elements but matched 0 elements.
+                Invalid value for 'filteredProperty' declined by composition constraint
+                  Requires to match all composition elements but matched 0 elements
                   - Composition element #1: Failed
-                    * Value for filteredProperty must not be shorter than 1
+                    * Value for 'filteredProperty' must not be shorter than 1
                 ERROR,
                 $errors[0]->getMessage(),
             );
@@ -528,10 +528,10 @@ class FilterCompositionRuntimeTest extends AbstractFilterTestCase
             $this->assertContainsOnlyInstancesOf(AllOfException::class, $errors);
             $this->assertStringContainsString(
                 <<<ERROR
-                Invalid value for filteredProperty declined by composition constraint.
-                  Requires to match all composition elements but matched 0 elements.
+                Invalid value for 'filteredProperty' declined by composition constraint
+                  Requires to match all composition elements but matched 0 elements
                   - Composition element #1: Failed
-                    * Value for filteredProperty must not be smaller than 0
+                    * Value for 'filteredProperty' must not be smaller than 0
                 ERROR,
                 $errors[0]->getMessage(),
             );
@@ -566,10 +566,10 @@ class FilterCompositionRuntimeTest extends AbstractFilterTestCase
             $this->assertContainsOnlyInstancesOf(AllOfException::class, $errors);
             $this->assertStringContainsString(
                 <<<ERROR
-                Invalid value for filteredProperty declined by composition constraint.
-                  Requires to match all composition elements but matched 0 elements.
+                Invalid value for 'filteredProperty' declined by composition constraint
+                  Requires to match all composition elements but matched 0 elements
                   - Composition element #1: Failed
-                    * Value for filteredProperty must not be shorter than 5
+                    * Value for 'filteredProperty' must not be shorter than 5
                 ERROR,
                 $errors[0]->getMessage(),
             );
@@ -658,12 +658,12 @@ class FilterCompositionRuntimeTest extends AbstractFilterTestCase
             $this->assertContainsOnlyInstancesOf(AnyOfException::class, $errors);
             $this->assertStringContainsString(
                 <<<ERROR
-                Invalid value for filteredProperty declined by composition constraint.
-                  Requires to match at least one composition element.
+                Invalid value for 'filteredProperty' declined by composition constraint
+                  Requires to match at least one composition element
                   - Composition element #1: Failed
-                    * Value for filteredProperty must not be larger than 10
+                    * Value for 'filteredProperty' must not be larger than 10
                   - Composition element #2: Failed
-                    * Value for filteredProperty must not be smaller than 20
+                    * Value for 'filteredProperty' must not be smaller than 20
                 ERROR,
                 $errors[0]->getMessage(),
             );
@@ -707,12 +707,12 @@ class FilterCompositionRuntimeTest extends AbstractFilterTestCase
             $this->assertContainsOnlyInstancesOf(OneOfException::class, $errors);
             $this->assertStringContainsString(
                 <<<ERROR
-                Invalid value for filteredProperty declined by composition constraint.
-                  Requires to match one composition element but matched 0 elements.
+                Invalid value for 'filteredProperty' declined by composition constraint
+                  Requires to match one composition element but matched 0 elements
                   - Composition element #1: Failed
-                    * Value for filteredProperty must not be shorter than 5
+                    * Value for 'filteredProperty' must not be shorter than 5
                   - Composition element #2: Failed
-                    * Value for filteredProperty must not be longer than 3
+                    * Value for 'filteredProperty' must not be longer than 3
                 ERROR,
                 $errors[0]->getMessage(),
             );
@@ -759,12 +759,12 @@ class FilterCompositionRuntimeTest extends AbstractFilterTestCase
             $this->assertContainsOnlyInstancesOf(OneOfException::class, $errors);
             $this->assertStringContainsString(
                 <<<ERROR
-                Invalid value for filteredProperty declined by composition constraint.
-                  Requires to match one composition element but matched 0 elements.
+                Invalid value for 'filteredProperty' declined by composition constraint
+                  Requires to match one composition element but matched 0 elements
                   - Composition element #1: Failed
-                    * Value for filteredProperty must not be larger than 10
+                    * Value for 'filteredProperty' must not be larger than 10
                   - Composition element #2: Failed
-                    * Value for filteredProperty must not be smaller than 20
+                    * Value for 'filteredProperty' must not be smaller than 20
                 ERROR,
                 $errors[0]->getMessage(),
             );
@@ -809,8 +809,8 @@ class FilterCompositionRuntimeTest extends AbstractFilterTestCase
             $this->assertContainsOnlyInstancesOf(NotException::class, $errors);
             $this->assertStringContainsString(
                 <<<ERROR
-                Invalid value for filteredProperty declined by composition constraint.
-                  Requires to match none composition element but matched 1 elements.
+                Invalid value for 'filteredProperty' declined by composition constraint
+                  Requires to match none composition element but matched 1 elements
                   - Composition element #1: Valid
                 ERROR,
                 $errors[0]->getMessage(),
@@ -859,8 +859,8 @@ class FilterCompositionRuntimeTest extends AbstractFilterTestCase
             $this->assertContainsOnlyInstancesOf(NotException::class, $errors);
             $this->assertStringContainsString(
                 <<<ERROR
-                Invalid value for filteredProperty declined by composition constraint.
-                  Requires to match none composition element but matched 1 elements.
+                Invalid value for 'filteredProperty' declined by composition constraint
+                  Requires to match none composition element but matched 1 elements
                   - Composition element #1: Valid
                 ERROR,
                 $errors[0]->getMessage(),
@@ -882,8 +882,8 @@ class FilterCompositionRuntimeTest extends AbstractFilterTestCase
             $this->assertContainsOnlyInstancesOf(NotException::class, $errors);
             $this->assertStringContainsString(
                 <<<ERROR
-                Invalid value for filteredProperty declined by composition constraint.
-                  Requires to match none composition element but matched 1 elements.
+                Invalid value for 'filteredProperty' declined by composition constraint
+                  Requires to match none composition element but matched 1 elements
                   - Composition element #1: Valid
                 ERROR,
                 $errors[0]->getMessage(),
@@ -921,11 +921,11 @@ class FilterCompositionRuntimeTest extends AbstractFilterTestCase
         } catch (ConditionalException $exception) {
             $this->assertStringContainsString(
                 <<<ERROR
-                Invalid value for filteredProperty declined by conditional composition constraint
+                Invalid value for 'filteredProperty' declined by conditional composition constraint
                   - Condition: Failed
-                    * Value for filteredProperty must not be shorter than 8
+                    * Value for 'filteredProperty' must not be shorter than 8
                   - Conditional branch failed:
-                    * Value for filteredProperty must not be shorter than 1
+                    * Value for 'filteredProperty' must not be shorter than 1
                 ERROR,
                 $exception->getMessage(),
             );
@@ -976,10 +976,10 @@ class FilterCompositionRuntimeTest extends AbstractFilterTestCase
         } catch (ConditionalException $exception) {
             $this->assertStringContainsString(
                 <<<ERROR
-                Invalid value for filteredProperty declined by conditional composition constraint
+                Invalid value for 'filteredProperty' declined by conditional composition constraint
                   - Condition: Valid
                   - Conditional branch failed:
-                    * Value for filteredProperty must not be larger than 100
+                    * Value for 'filteredProperty' must not be larger than 100
                 ERROR,
                 $exception->getMessage(),
             );
@@ -995,11 +995,11 @@ class FilterCompositionRuntimeTest extends AbstractFilterTestCase
         } catch (ConditionalException $exception) {
             $this->assertStringContainsString(
                 <<<ERROR
-                Invalid value for filteredProperty declined by conditional composition constraint
+                Invalid value for 'filteredProperty' declined by conditional composition constraint
                   - Condition: Failed
-                    * Value for filteredProperty must not be smaller than 0
+                    * Value for 'filteredProperty' must not be smaller than 0
                   - Conditional branch failed:
-                    * Value for filteredProperty must not be smaller than -100
+                    * Value for 'filteredProperty' must not be smaller than -100
                 ERROR,
                 $exception->getMessage(),
             );
@@ -1042,7 +1042,7 @@ class FilterCompositionRuntimeTest extends AbstractFilterTestCase
             $this->assertNotNull($exception->getThenException());
             $this->assertNull($exception->getElseException());
             $this->assertStringContainsString(
-                'Value for filteredProperty must not be longer than 20',
+                'Value for \'filteredProperty\' must not be longer than 20',
                 $exception->getMessage(),
             );
         }

--- a/tests/Filter/FilterCompositionRuntimeTest.php
+++ b/tests/Filter/FilterCompositionRuntimeTest.php
@@ -233,7 +233,7 @@ class FilterCompositionRuntimeTest extends AbstractFilterTestCase
             $this->assertStringContainsString(
                 <<<ERROR
                 Invalid value for 'filteredProperty' declined by composition constraint
-                  Requires to match all composition elements but matched 1 elements
+                  Requires to match all composition elements but matched 1 element
                   - Composition element #1: Valid
                   - Composition element #2: Failed
                     * Value for 'filteredProperty' must not be larger than 100
@@ -255,7 +255,7 @@ class FilterCompositionRuntimeTest extends AbstractFilterTestCase
             $this->assertStringContainsString(
                 <<<ERROR
                 Invalid value for 'filteredProperty' declined by composition constraint
-                  Requires to match all composition elements but matched 1 elements
+                  Requires to match all composition elements but matched 1 element
                   - Composition element #1: Failed
                     * Value for 'filteredProperty' must not be smaller than 0
                 ERROR,
@@ -323,7 +323,7 @@ class FilterCompositionRuntimeTest extends AbstractFilterTestCase
             // second error silently going missing.
             $this->assertInstanceOf(InvalidFilterValueException::class, $errors[1]);
             $this->assertStringStartsWith(
-                'Invalid value for property \'filteredProperty\' denied by filter \'mixedAcceptDateTimeFilter\':',
+                "Invalid value for property 'filteredProperty' denied by filter 'mixedAcceptDateTimeFilter':",
                 $errors[1]->getMessage(),
             );
         }
@@ -810,7 +810,7 @@ class FilterCompositionRuntimeTest extends AbstractFilterTestCase
             $this->assertStringContainsString(
                 <<<ERROR
                 Invalid value for 'filteredProperty' declined by composition constraint
-                  Requires to match none composition element but matched 1 elements
+                  Requires to match none composition element but matched 1 element
                   - Composition element #1: Valid
                 ERROR,
                 $errors[0]->getMessage(),
@@ -860,7 +860,7 @@ class FilterCompositionRuntimeTest extends AbstractFilterTestCase
             $this->assertStringContainsString(
                 <<<ERROR
                 Invalid value for 'filteredProperty' declined by composition constraint
-                  Requires to match none composition element but matched 1 elements
+                  Requires to match none composition element but matched 1 element
                   - Composition element #1: Valid
                 ERROR,
                 $errors[0]->getMessage(),
@@ -883,7 +883,7 @@ class FilterCompositionRuntimeTest extends AbstractFilterTestCase
             $this->assertStringContainsString(
                 <<<ERROR
                 Invalid value for 'filteredProperty' declined by composition constraint
-                  Requires to match none composition element but matched 1 elements
+                  Requires to match none composition element but matched 1 element
                   - Composition element #1: Valid
                 ERROR,
                 $errors[0]->getMessage(),
@@ -1042,7 +1042,7 @@ class FilterCompositionRuntimeTest extends AbstractFilterTestCase
             $this->assertNotNull($exception->getThenException());
             $this->assertNull($exception->getElseException());
             $this->assertStringContainsString(
-                'Value for \'filteredProperty\' must not be longer than 20',
+                "Value for 'filteredProperty' must not be longer than 20",
                 $exception->getMessage(),
             );
         }

--- a/tests/Filter/FilterCompositionRuntimeTest.php
+++ b/tests/Filter/FilterCompositionRuntimeTest.php
@@ -303,8 +303,9 @@ class FilterCompositionRuntimeTest extends AbstractFilterTestCase
             $this->fail('Expected AllOfException for non-string raw input');
         } catch (ErrorRegistryException $exception) {
             $errors = $exception->getErrors();
-            $this->assertCount(1, $errors);
-            $this->assertContainsOnlyInstancesOf(AllOfException::class, $errors);
+            $this->assertCount(2, $errors);
+
+            $this->assertInstanceOf(AllOfException::class, $errors[0]);
             $this->assertStringContainsString(
                 <<<ERROR
                 Invalid value for filteredProperty declined by composition constraint.
@@ -315,6 +316,16 @@ class FilterCompositionRuntimeTest extends AbstractFilterTestCase
                 $errors[0]->getMessage(),
             );
             $this->assertSame(0, $errors[0]->getSucceededCompositionElements());
+
+            // With the composed-value restoration bug fixed, the filter now correctly receives
+            // the real input (42) instead of a null leftover from the failed composition, and
+            // honestly reports its own failure to parse it as a date/time string, instead of the
+            // second error silently going missing.
+            $this->assertInstanceOf(InvalidFilterValueException::class, $errors[1]);
+            $this->assertStringStartsWith(
+                'Invalid value for property filteredProperty denied by filter mixedAcceptDateTimeFilter:',
+                $errors[1]->getMessage(),
+            );
         }
 
         // Already-constructed DateTime: pre-transform pipeline skipped, accepted as-is.

--- a/tests/Filter/TransformingFilterTest.php
+++ b/tests/Filter/TransformingFilterTest.php
@@ -298,7 +298,9 @@ class TransformingFilterTest extends AbstractFilterTestCase
         );
 
         $this->expectException(\PHPModelGenerator\Exception\ValidationException::class);
-        $this->expectExceptionMessage('Invalid value for filteredProperty declined by enum constraint');
+        $this->expectExceptionMessage(
+            'Value for \'filteredProperty\' must be one of ["2020-12-12","2019-12-12",null], got "1999-12-12"',
+        );
 
         new $className(['filteredProperty' => '1999-12-12']);
     }

--- a/tests/Filter/TransformingFilterTest.php
+++ b/tests/Filter/TransformingFilterTest.php
@@ -153,7 +153,7 @@ class TransformingFilterTest extends AbstractFilterTestCase
             $this->fail('Expected exception for invalid type on a transforming-filtered property');
         } catch (ErrorRegistryException | InvalidTypeException $exception) {
             $this->assertStringContainsString(
-                'Invalid type for \'created\': requires [\'DateTime\', \'string\'], got \'integer\'',
+                "Invalid type for 'created': requires ['DateTime', 'string'], got 'integer'",
                 $exception->getMessage(),
             );
 
@@ -277,7 +277,7 @@ class TransformingFilterTest extends AbstractFilterTestCase
 
         if (!$implicitNull) {
             $this->expectException(ErrorRegistryException::class);
-            $this->expectExceptionMessage('Invalid type for \'value\': requires [\'string\', \'int\'], got \'NULL\'');
+            $this->expectExceptionMessage("Invalid type for 'value': requires ['string', 'int'], got 'NULL'");
             new $fqcn(['value' => null]);
         }
     }

--- a/tests/Filter/TransformingFilterTest.php
+++ b/tests/Filter/TransformingFilterTest.php
@@ -128,8 +128,8 @@ class TransformingFilterTest extends AbstractFilterTestCase
         } catch (ErrorRegistryException $exception) {
             $this->assertSame(
                 <<<ERROR
-                Invalid value for property created denied by filter dateTime: Invalid Date Time value "Hello"
-                Invalid type for name. Requires string, got integer
+                Invalid value for property 'created' denied by filter 'dateTime': Invalid Date Time value "Hello"
+                Invalid type for 'name': requires 'string', got 'integer'
                 ERROR,
                 $exception->getMessage(),
             );
@@ -153,7 +153,7 @@ class TransformingFilterTest extends AbstractFilterTestCase
             $this->fail('Expected exception for invalid type on a transforming-filtered property');
         } catch (ErrorRegistryException | InvalidTypeException $exception) {
             $this->assertStringContainsString(
-                'Invalid type for created. Requires [DateTime, string], got integer',
+                'Invalid type for \'created\': requires [\'DateTime\', \'string\'], got \'integer\'',
                 $exception->getMessage(),
             );
 
@@ -277,7 +277,7 @@ class TransformingFilterTest extends AbstractFilterTestCase
 
         if (!$implicitNull) {
             $this->expectException(ErrorRegistryException::class);
-            $this->expectExceptionMessage('Invalid type for value. Requires [string, int], got NULL');
+            $this->expectExceptionMessage('Invalid type for \'value\': requires [\'string\', \'int\'], got \'NULL\'');
             new $fqcn(['value' => null]);
         }
     }

--- a/tests/Issues/Issue/Issue105Test.php
+++ b/tests/Issues/Issue/Issue105Test.php
@@ -42,7 +42,7 @@ class Issue105Test extends AbstractIssueTestCase
         // passes, "delivery_status" fails its enum check, so allOf requires 2 matches but got 1.
         $this->expectException(InvalidItemException::class);
         $this->expectExceptionMessage(
-            'Requires to match all composition elements but matched 1 elements.',
+            'Requires to match all composition elements but matched 1 elements',
         );
         new $className([
             'by_package' => [

--- a/tests/Issues/Issue/Issue105Test.php
+++ b/tests/Issues/Issue/Issue105Test.php
@@ -13,7 +13,7 @@ class Issue105Test extends AbstractIssueTestCase
 {
     public function testEnumInComposition(): void
     {
-        $this->modifyModelGenerator = static function (ModelGenerator $modelGenerator) : void {
+        $this->modifyModelGenerator = static function (ModelGenerator $modelGenerator): void {
             $modelGenerator->addPostProcessor(new EnumPostProcessor(
                 TEST_BASE_DIR . DIRECTORY_SEPARATOR . 'Enum',
                 'Enum',
@@ -37,8 +37,13 @@ class Issue105Test extends AbstractIssueTestCase
         $this->assertSame('completed', $object->getByPackage()[0]->getDeliveryStatus()->value);
         $this->assertSame(250000, $object->getByPackage()[0]->getImpressions());
 
+        // Composition must not adopt a partially-successful branch's value when the overall
+        // composition fails: only the "impressions" branch (optional, absent here) trivially
+        // passes, "delivery_status" fails its enum check, so allOf requires 2 matches but got 1.
         $this->expectException(InvalidItemException::class);
-        $this->expectExceptionMessage('"invalid" is not a valid backing value for enum');
+        $this->expectExceptionMessage(
+            'Requires to match all composition elements but matched 1 elements.',
+        );
         new $className([
             'by_package' => [
                 [

--- a/tests/Issues/Issue/Issue105Test.php
+++ b/tests/Issues/Issue/Issue105Test.php
@@ -42,7 +42,7 @@ class Issue105Test extends AbstractIssueTestCase
         // passes, "delivery_status" fails its enum check, so allOf requires 2 matches but got 1.
         $this->expectException(InvalidItemException::class);
         $this->expectExceptionMessage(
-            'Requires to match all composition elements but matched 1 elements',
+            'Requires to match all composition elements but matched 1 element',
         );
         new $className([
             'by_package' => [

--- a/tests/Issues/Issue/Issue113Test.php
+++ b/tests/Issues/Issue/Issue113Test.php
@@ -32,7 +32,7 @@ class Issue113Test extends AbstractIssueTestCase
         $className = $this->generateClassFromFile('ifThenWithoutElse.json');
 
         $this->expectException(ConditionalException::class);
-        $this->expectExceptionMessage('Missing required value for \'audiences\'');
+        $this->expectExceptionMessage("Missing required value for 'audiences'");
 
         new $className(['delete_missing' => true]);
     }

--- a/tests/Issues/Issue/Issue113Test.php
+++ b/tests/Issues/Issue/Issue113Test.php
@@ -32,7 +32,7 @@ class Issue113Test extends AbstractIssueTestCase
         $className = $this->generateClassFromFile('ifThenWithoutElse.json');
 
         $this->expectException(ConditionalException::class);
-        $this->expectExceptionMessage('Missing required value for audiences');
+        $this->expectExceptionMessage('Missing required value for \'audiences\'');
 
         new $className(['delete_missing' => true]);
     }

--- a/tests/Issues/Issue/Issue133Test.php
+++ b/tests/Issues/Issue/Issue133Test.php
@@ -157,8 +157,8 @@ class Issue133Test extends AbstractIssueTestCase
         } catch (ValidationException $exception) {
             $this->assertMatchesRegularExpression(
                 <<<'REGEX'
-                /^Invalid value for \S+ declined by composition constraint\.
-                  Requires to match all composition elements but matched 1 elements\.$/m
+                /^Invalid value for '\S+' declined by composition constraint
+                  Requires to match all composition elements but matched 1 elements$/m
                 REGEX,
                 $exception->getMessage(),
             );
@@ -168,8 +168,8 @@ class Issue133Test extends AbstractIssueTestCase
         $this->expectException(ValidationException::class);
         $this->expectExceptionMessageMatches(
             <<<'REGEX'
-            /^Invalid value for \S+ declined by composition constraint\.
-              Requires to match all composition elements but matched 1 elements\.$/m
+            /^Invalid value for '\S+' declined by composition constraint
+              Requires to match all composition elements but matched 1 elements$/m
             REGEX,
         );
         new $className(['name' => str_repeat('a', 65)]);

--- a/tests/Issues/Issue/Issue133Test.php
+++ b/tests/Issues/Issue/Issue133Test.php
@@ -158,7 +158,7 @@ class Issue133Test extends AbstractIssueTestCase
             $this->assertMatchesRegularExpression(
                 <<<'REGEX'
                 /^Invalid value for '\S+' declined by composition constraint
-                  Requires to match all composition elements but matched 1 elements$/m
+                  Requires to match all composition elements but matched 1 element$/m
                 REGEX,
                 $exception->getMessage(),
             );
@@ -169,7 +169,7 @@ class Issue133Test extends AbstractIssueTestCase
         $this->expectExceptionMessageMatches(
             <<<'REGEX'
             /^Invalid value for '\S+' declined by composition constraint
-              Requires to match all composition elements but matched 1 elements$/m
+              Requires to match all composition elements but matched 1 element$/m
             REGEX,
         );
         new $className(['name' => str_repeat('a', 65)]);

--- a/tests/Issues/Issue/Issue77Test.php
+++ b/tests/Issues/Issue/Issue77Test.php
@@ -11,7 +11,10 @@ class Issue77Test extends AbstractIssueTestCase
 {
     public function testCompositionValidatorOnPropertyGeneratesNoDynamicProperty(): void
     {
-        $className = $this->generateClassFromFile('dynamicProperty.json', (new GeneratorConfiguration())->setImmutable(false));
+        $className = $this->generateClassFromFile(
+            'dynamicProperty.json',
+            (new GeneratorConfiguration())->setImmutable(false),
+        );
 
         $object = new $className(['values' => [1, 10, 1000], 'pet' => ['type' => 'dog', 'age' => 0, 'name' => 'Hans']]);
 
@@ -20,7 +23,7 @@ class Issue77Test extends AbstractIssueTestCase
         $this->assertSame(0, $object->getPet()->getAge());
         $this->assertSame('Hans', $object->getPet()->getName());
 
-        $this->expectExceptionMessage('Value for values must not be smaller than 1');
+        $this->expectExceptionMessage('Value for \'values\' must not be smaller than 1');
 
         new $className(['values' => [0]]);
     }

--- a/tests/Issues/Issue/Issue77Test.php
+++ b/tests/Issues/Issue/Issue77Test.php
@@ -20,7 +20,7 @@ class Issue77Test extends AbstractIssueTestCase
         $this->assertSame(0, $object->getPet()->getAge());
         $this->assertSame('Hans', $object->getPet()->getName());
 
-        $this->expectExceptionMessage('Value for item of array values must not be smaller than 1');
+        $this->expectExceptionMessage('Value for values must not be smaller than 1');
 
         new $className(['values' => [0]]);
     }

--- a/tests/Issues/Issue/Issue77Test.php
+++ b/tests/Issues/Issue/Issue77Test.php
@@ -23,7 +23,7 @@ class Issue77Test extends AbstractIssueTestCase
         $this->assertSame(0, $object->getPet()->getAge());
         $this->assertSame('Hans', $object->getPet()->getName());
 
-        $this->expectExceptionMessage('Value for \'values\' must not be smaller than 1');
+        $this->expectExceptionMessage("Value for 'values' must not be smaller than 1");
 
         new $className(['values' => [0]]);
     }

--- a/tests/Objects/AbstractNumericPropertyTestCase.php
+++ b/tests/Objects/AbstractNumericPropertyTestCase.php
@@ -114,7 +114,7 @@ abstract class AbstractNumericPropertyTestCase extends AbstractPHPModelGenerator
             new $className(['property' => $propertyValue]);
             $this->fail('Expected ValidationException for non-multiple value');
         } catch (ValidationException $exception) {
-            $this->assertSame("Value for property must be a multiple of $multipleOf", $exception->getMessage());
+            $this->assertSame("Value for 'property' must be a multiple of $multipleOf", $exception->getMessage());
             $this->assertSame('/properties/property/multipleOf', $exception->getJsonPointer()->pointer);
         }
     }

--- a/tests/Objects/AnyPropertyTest.php
+++ b/tests/Objects/AnyPropertyTest.php
@@ -41,7 +41,7 @@ class AnyPropertyTest extends AbstractPHPModelGeneratorTestCase
     #[DataProvider('validationMethodDataProvider')]
     public function testNotProvidedRequiredAnyPropertyThrowsAnException(GeneratorConfiguration $configuration): void
     {
-        $this->expectValidationError($configuration, 'Missing required value for \'property\'');
+        $this->expectValidationError($configuration, "Missing required value for 'property'");
         $className = $this->generateClassFromFile('RequiredAnyProperty.json', $configuration);
 
         new $className([]);

--- a/tests/Objects/AnyPropertyTest.php
+++ b/tests/Objects/AnyPropertyTest.php
@@ -41,7 +41,7 @@ class AnyPropertyTest extends AbstractPHPModelGeneratorTestCase
     #[DataProvider('validationMethodDataProvider')]
     public function testNotProvidedRequiredAnyPropertyThrowsAnException(GeneratorConfiguration $configuration): void
     {
-        $this->expectValidationError($configuration, 'Missing required value for property');
+        $this->expectValidationError($configuration, 'Missing required value for \'property\'');
         $className = $this->generateClassFromFile('RequiredAnyProperty.json', $configuration);
 
         new $className([]);

--- a/tests/Objects/ArrayPropertyTest.php
+++ b/tests/Objects/ArrayPropertyTest.php
@@ -212,8 +212,8 @@ class ArrayPropertyTest extends AbstractPHPModelGeneratorTestCase
     ): void {
         $this->expectValidationError(
             $configuration,
-            'Invalid type for property. Requires array, got ' .
-                (is_object($propertyValue) ? $propertyValue::class : gettype($propertyValue)),
+            "Invalid type for 'property': requires 'array', got '" .
+                (is_object($propertyValue) ? $propertyValue::class : gettype($propertyValue)) . "'",
         );
 
         $className = $this->generateClassFromFile('ArrayProperty.json', $configuration);
@@ -275,7 +275,7 @@ class ArrayPropertyTest extends AbstractPHPModelGeneratorTestCase
         GeneratorConfiguration $configuration,
         array $propertyValue,
     ): void {
-        $this->expectValidationError($configuration, 'Items of array property are not unique');
+        $this->expectValidationError($configuration, 'Items of array \'property\' are not unique');
 
         $className = $this->generateClassFromFile('ArrayPropertyUnique.json', $configuration);
 
@@ -361,9 +361,9 @@ class ArrayPropertyTest extends AbstractPHPModelGeneratorTestCase
         return self::combineDataProvider(
             self::validationMethodDataProvider(),
             [
-                'Empty array' => [[], 'Array property must not contain less than 2 items'],
-                'Too few array items' => [[1], 'Array property must not contain less than 2 items'],
-                'Too many array items' => [[1, 2, 3 , 4], 'Array property must not contain more than 3 items']
+                'Empty array' => [[], 'Array \'property\' must not contain less than 2 items'],
+                'Too few array items' => [[1], 'Array \'property\' must not contain less than 2 items'],
+                'Too many array items' => [[1, 2, 3 , 4], 'Array \'property\' must not contain more than 3 items']
             ],
         );
     }
@@ -502,114 +502,114 @@ class ArrayPropertyTest extends AbstractPHPModelGeneratorTestCase
                     '"string"',
                     ['a', 'b', 1],
                     <<<ERROR
-                    Invalid items in array property:
+                    Invalid items in array 'property':
                       - invalid item #2
-                        * Invalid type for property. Requires string, got integer
+                        * Invalid type for 'property': requires 'string', got 'integer'
                     ERROR,
                 ],
                 'String array containing null' => [
                     '"string"',
                     ['a', 'b', null],
                     <<<ERROR
-                    Invalid items in array property:
+                    Invalid items in array 'property':
                       - invalid item #2
-                        * Invalid type for property. Requires string, got NULL
+                        * Invalid type for 'property': requires 'string', got 'NULL'
                     ERROR,
                 ],
                 'Int array containing string' => [
                     '"integer"',
                     [1, 2, 3, '4'],
                     <<<ERROR
-                    Invalid items in array property:
+                    Invalid items in array 'property':
                       - invalid item #3
-                        * Invalid type for property. Requires int, got string
+                        * Invalid type for 'property': requires 'int', got 'string'
                     ERROR,
                 ],
                 'Int array containing float' => [
                     '"integer"',
                     [1, 2, 3, 2.5],
                     <<<ERROR
-                    Invalid items in array property:
+                    Invalid items in array 'property':
                       - invalid item #3
-                        * Invalid type for property. Requires int, got double
+                        * Invalid type for 'property': requires 'int', got 'double'
                     ERROR,
                 ],
                 'Number array containing array' => [
                     '"number"',
                     [1, 1.1, 4.5, 6, []],
                     <<<ERROR
-                    Invalid items in array property:
+                    Invalid items in array 'property':
                       - invalid item #4
-                        * Invalid type for property. Requires float, got array
+                        * Invalid type for 'property': requires 'float', got 'array'
                     ERROR,
                 ],
                 'Boolean array containing int' => [
                     '"boolean"',
                     [true, false, true, 3],
                     <<<ERROR
-                    Invalid items in array property:
+                    Invalid items in array 'property':
                       - invalid item #3
-                        * Invalid type for property. Requires bool, got integer
+                        * Invalid type for 'property': requires 'bool', got 'integer'
                     ERROR,
                 ],
                 'Null array containing string' => [
                     '"null"',
                     [null, null, 'null'],
                     <<<ERROR
-                    Invalid items in array property:
+                    Invalid items in array 'property':
                       - invalid item #2
-                        * Invalid type for property. Requires null, got string
+                        * Invalid type for 'property': requires 'null', got 'string'
                     ERROR,
                 ],
                 'Multiple violations' => [
                     '"boolean"',
                     [true, false, true, 3, true, 'true'],
                     <<<ERROR
-                    Invalid items in array property:
+                    Invalid items in array 'property':
                       - invalid item #3
-                        * Invalid type for property. Requires bool, got integer
+                        * Invalid type for 'property': requires 'bool', got 'integer'
                       - invalid item #5
-                        * Invalid type for property. Requires bool, got string
+                        * Invalid type for 'property': requires 'bool', got 'string'
                     ERROR,
                 ],
                 'Nested array containing null' => [
                     '"array","items":{"type":"integer"}',
                     [[1, 2], [], null],
                     <<<ERROR
-                    Invalid items in array property:
+                    Invalid items in array 'property':
                       - invalid item #2
-                        * Invalid type for property. Requires array, got NULL
+                        * Invalid type for 'property': requires 'array', got 'NULL'
                     ERROR,
                 ],
                 'Nested array containing int' => [
                     '"array","items":{"type":"integer"}',
                     [[1, 2], [], 3],
                     <<<ERROR
-                    Invalid items in array property:
+                    Invalid items in array 'property':
                       - invalid item #2
-                        * Invalid type for property. Requires array, got integer
+                        * Invalid type for 'property': requires 'array', got 'integer'
                     ERROR,
                 ],
                 'Nested array inner array containing string' => [
                     '"array","items":{"type":"integer"}',
                     [[1, '2'], [], [3]],
                     <<<ERROR
-                    Invalid items in array property:
+                    Invalid items in array 'property':
                       - invalid item #0
-                        * Invalid items in array property:
+                        * Invalid items in array 'property':
                           - invalid item #1
-                            * Invalid type for property. Requires int, got string
+                            * Invalid type for 'property': requires 'int', got 'string'
                     ERROR,
                 ],
                 'Multi type array containing invalid values' => [
                     '["string", "integer"]',
                     ['a', 1, true, 'true', [], -6],
                     <<<ERROR
-                    Invalid items in array property:
+                    Invalid items in array 'property':
                       - invalid item #2
-                        * Invalid type for property. Requires [string, int], got boolean
+                        * Invalid type for 'property': requires ['string', 'int'], got 'boolean'
                       - invalid item #4
-                        * Invalid type for property. Requires [string, int], got array
+                        * Invalid type for 'property': requires ['string', 'int'], got 'array'
                     ERROR,
                 ],
             ],
@@ -681,7 +681,10 @@ class ArrayPropertyTest extends AbstractPHPModelGeneratorTestCase
         GeneratorConfiguration $configuration,
         array $propertyValue,
     ): void {
-        $this->expectValidationError($configuration, 'No item in array property matches contains constraint');
+        $this->expectValidationError(
+            $configuration,
+            'No item in array \'property\' matches the \'contains\' constraint',
+        );
 
         $className = $this->generateClassFromFile('ArrayPropertyContains.json', $configuration);
 
@@ -808,47 +811,47 @@ class ArrayPropertyTest extends AbstractPHPModelGeneratorTestCase
                     'null' => [
                         [null],
                         <<<ERROR
-                        Invalid items in array property:
+                        Invalid items in array 'property':
                           - invalid item #0
-                            * Invalid type for property. Requires object, got NULL
+                            * Invalid type for 'property': requires 'object', got 'NULL'
                         ERROR,
                     ],
                     'invalid type bool' => [
                         [['name' => 'Hannes'], true],
                         <<<ERROR
-                        Invalid items in array property:
+                        Invalid items in array 'property':
                           - invalid item #1
-                            * Invalid type for property. Requires object, got boolean
+                            * Invalid type for 'property': requires 'object', got 'boolean'
                         ERROR,
                     ],
                     'missing property name' => [
                         [['name' => 'Hannes'], ['age' => 42]],
                         <<<ERROR
-                        Invalid items in array property:
+                        Invalid items in array 'property':
                           - invalid item #1
-                            * Missing required value for name
+                            * Missing required value for 'name'
                         ERROR,
                     ],
                     'invalid type name' => [
                         [['name' => 'Hannes'], ['name' => false, 'age' => 42]],
                         <<<ERROR
-                        Invalid items in array property:
+                        Invalid items in array 'property':
                           - invalid item #1
-                            * Invalid type for name. Requires string, got boolean
+                            * Invalid type for 'name': requires 'string', got 'boolean'
                         ERROR,
                     ],
                     'multiple violations' => [
                         [['name' => false, 'age' => 42], ['name' => 'Frida', 'age' => 'yes'], 5, []],
                         <<<ERROR
-                        Invalid items in array property:
+                        Invalid items in array 'property':
                           - invalid item #0
-                            * Invalid type for name. Requires string, got boolean
+                            * Invalid type for 'name': requires 'string', got 'boolean'
                           - invalid item #1
-                            * Invalid type for age. Requires int, got string
+                            * Invalid type for 'age': requires 'int', got 'string'
                           - invalid item #2
-                            * Invalid type for property. Requires object, got integer
+                            * Invalid type for 'property': requires 'object', got 'integer'
                           - invalid item #3
-                            * Missing required value for name
+                            * Missing required value for 'name'
                         ERROR,
                     ],
                 ],
@@ -868,71 +871,71 @@ class ArrayPropertyTest extends AbstractPHPModelGeneratorTestCase
                     'invalid type bool' => [
                         [['name' => 'Hannes'], true],
                         <<<ERROR
-                        Invalid items in array property:
+                        Invalid items in array 'property':
                           - invalid item #1
-                            * Invalid value for property declined by composition constraint.
-                              Requires to match all composition elements but matched 0 elements.
+                            * Invalid value for 'property' declined by composition constraint
+                              Requires to match all composition elements but matched 0 elements
                               - Composition element #1: Failed
-                                * Invalid type for property. Requires object, got boolean
+                                * Invalid type for 'property': requires 'object', got 'boolean'
                               - Composition element #2: Failed
-                                * Invalid type for property. Requires object, got boolean
+                                * Invalid type for 'property': requires 'object', got 'boolean'
                         ERROR,
                     ],
                     'missing property name' => [
                         [['name' => 'Hannes'], ['age' => 42]],
                         <<<ERROR
-                        Invalid items in array property:
+                        Invalid items in array 'property':
                           - invalid item #1
-                            * Invalid value for property declined by composition constraint.
-                              Requires to match all composition elements but matched 1 elements.
+                            * Invalid value for 'property' declined by composition constraint
+                              Requires to match all composition elements but matched 1 elements
                               - Composition element #1: Failed
-                                * Missing required value for name
-                                * Invalid type for name. Requires string, got NULL
+                                * Missing required value for 'name'
+                                * Invalid type for 'name': requires 'string', got 'NULL'
                               - Composition element #2: Valid
                         ERROR,
                     ],
                     'invalid type name' => [
                         [['name' => 'Hannes'], ['name' => false, 'age' => 42]],
                         <<<ERROR
-                        Invalid items in array property:
+                        Invalid items in array 'property':
                           - invalid item #1
-                            * Invalid value for property declined by composition constraint.
-                              Requires to match all composition elements but matched 1 elements.
+                            * Invalid value for 'property' declined by composition constraint
+                              Requires to match all composition elements but matched 1 elements
                               - Composition element #1: Failed
-                                * Invalid type for name. Requires string, got boolean
+                                * Invalid type for 'name': requires 'string', got 'boolean'
                               - Composition element #2: Valid
                         ERROR,
                     ],
                     'multiple violations' => [
                         [['name' => false, 'age' => 42], ['name' => 'F', 'age' => 'yes'], 5, []],
                         <<<ERROR
-                        Invalid items in array property:
+                        Invalid items in array 'property':
                           - invalid item #0
-                            * Invalid value for property declined by composition constraint.
-                              Requires to match all composition elements but matched 1 elements.
+                            * Invalid value for 'property' declined by composition constraint
+                              Requires to match all composition elements but matched 1 elements
                               - Composition element #1: Failed
-                                * Invalid type for name. Requires string, got boolean
+                                * Invalid type for 'name': requires 'string', got 'boolean'
                               - Composition element #2: Valid
                           - invalid item #1
-                            * Invalid value for property declined by composition constraint.
-                              Requires to match all composition elements but matched 0 elements.
+                            * Invalid value for 'property' declined by composition constraint
+                              Requires to match all composition elements but matched 0 elements
                               - Composition element #1: Failed
-                                * Value for name must not be shorter than 2
+                                * Value for 'name' must not be shorter than 2
                               - Composition element #2: Failed
-                                * Invalid type for age. Requires int, got string
+                                * Invalid type for 'age': requires 'int', got 'string'
                           - invalid item #2
-                            * Invalid value for property declined by composition constraint.
-                              Requires to match all composition elements but matched 0 elements.
+                            * Invalid value for 'property' declined by composition constraint
+                              Requires to match all composition elements but matched 0 elements
                               - Composition element #1: Failed
-                                * Invalid type for property. Requires object, got integer
+                                * Invalid type for 'property': requires 'object', got 'integer'
                               - Composition element #2: Failed
-                                * Invalid type for property. Requires object, got integer
+                                * Invalid type for 'property': requires 'object', got 'integer'
                           - invalid item #3
-                            * Invalid value for property declined by composition constraint.
-                              Requires to match all composition elements but matched 1 elements.
+                            * Invalid value for 'property' declined by composition constraint
+                              Requires to match all composition elements but matched 1 elements
                               - Composition element #1: Failed
-                                * Missing required value for name
-                                * Invalid type for name. Requires string, got NULL
+                                * Missing required value for 'name'
+                                * Invalid type for 'name': requires 'string', got 'NULL'
                               - Composition element #2: Valid
                         ERROR,
                     ],

--- a/tests/Objects/ArrayPropertyTest.php
+++ b/tests/Objects/ArrayPropertyTest.php
@@ -503,7 +503,7 @@ class ArrayPropertyTest extends AbstractPHPModelGeneratorTestCase
                     <<<ERROR
                     Invalid items in array property:
                       - invalid item #2
-                        * Invalid type for item of array property. Requires string, got integer
+                        * Invalid type for property. Requires string, got integer
                     ERROR,
                 ],
                 'String array containing null' => [
@@ -512,7 +512,7 @@ class ArrayPropertyTest extends AbstractPHPModelGeneratorTestCase
                     <<<ERROR
                     Invalid items in array property:
                       - invalid item #2
-                        * Invalid type for item of array property. Requires string, got NULL
+                        * Invalid type for property. Requires string, got NULL
                     ERROR,
                 ],
                 'Int array containing string' => [
@@ -521,7 +521,7 @@ class ArrayPropertyTest extends AbstractPHPModelGeneratorTestCase
                     <<<ERROR
                     Invalid items in array property:
                       - invalid item #3
-                        * Invalid type for item of array property. Requires int, got string
+                        * Invalid type for property. Requires int, got string
                     ERROR,
                 ],
                 'Int array containing float' => [
@@ -530,7 +530,7 @@ class ArrayPropertyTest extends AbstractPHPModelGeneratorTestCase
                     <<<ERROR
                     Invalid items in array property:
                       - invalid item #3
-                        * Invalid type for item of array property. Requires int, got double
+                        * Invalid type for property. Requires int, got double
                     ERROR,
                 ],
                 'Number array containing array' => [
@@ -539,7 +539,7 @@ class ArrayPropertyTest extends AbstractPHPModelGeneratorTestCase
                     <<<ERROR
                     Invalid items in array property:
                       - invalid item #4
-                        * Invalid type for item of array property. Requires float, got array
+                        * Invalid type for property. Requires float, got array
                     ERROR,
                 ],
                 'Boolean array containing int' => [
@@ -548,7 +548,7 @@ class ArrayPropertyTest extends AbstractPHPModelGeneratorTestCase
                     <<<ERROR
                     Invalid items in array property:
                       - invalid item #3
-                        * Invalid type for item of array property. Requires bool, got integer
+                        * Invalid type for property. Requires bool, got integer
                     ERROR,
                 ],
                 'Null array containing string' => [
@@ -557,7 +557,7 @@ class ArrayPropertyTest extends AbstractPHPModelGeneratorTestCase
                     <<<ERROR
                     Invalid items in array property:
                       - invalid item #2
-                        * Invalid type for item of array property. Requires null, got string
+                        * Invalid type for property. Requires null, got string
                     ERROR,
                 ],
                 'Multiple violations' => [
@@ -566,9 +566,9 @@ class ArrayPropertyTest extends AbstractPHPModelGeneratorTestCase
                     <<<ERROR
                     Invalid items in array property:
                       - invalid item #3
-                        * Invalid type for item of array property. Requires bool, got integer
+                        * Invalid type for property. Requires bool, got integer
                       - invalid item #5
-                        * Invalid type for item of array property. Requires bool, got string
+                        * Invalid type for property. Requires bool, got string
                     ERROR,
                 ],
                 'Nested array containing null' => [
@@ -577,7 +577,7 @@ class ArrayPropertyTest extends AbstractPHPModelGeneratorTestCase
                     <<<ERROR
                     Invalid items in array property:
                       - invalid item #2
-                        * Invalid type for item of array property. Requires array, got NULL
+                        * Invalid type for property. Requires array, got NULL
                     ERROR,
                 ],
                 'Nested array containing int' => [
@@ -586,7 +586,7 @@ class ArrayPropertyTest extends AbstractPHPModelGeneratorTestCase
                     <<<ERROR
                     Invalid items in array property:
                       - invalid item #2
-                        * Invalid type for item of array property. Requires array, got integer
+                        * Invalid type for property. Requires array, got integer
                     ERROR,
                 ],
                 'Nested array inner array containing string' => [
@@ -595,9 +595,9 @@ class ArrayPropertyTest extends AbstractPHPModelGeneratorTestCase
                     <<<ERROR
                     Invalid items in array property:
                       - invalid item #0
-                        * Invalid items in array item of array property:
+                        * Invalid items in array property:
                           - invalid item #1
-                            * Invalid type for item of array item of array property. Requires int, got string
+                            * Invalid type for property. Requires int, got string
                     ERROR,
                 ],
                 'Multi type array containing invalid values' => [
@@ -606,13 +606,50 @@ class ArrayPropertyTest extends AbstractPHPModelGeneratorTestCase
                     <<<ERROR
                     Invalid items in array property:
                       - invalid item #2
-                        * Invalid type for item of array property. Requires [string, int], got boolean
+                        * Invalid type for property. Requires [string, int], got boolean
                       - invalid item #4
-                        * Invalid type for item of array property. Requires [string, int], got array
+                        * Invalid type for property. Requires [string, int], got array
                     ERROR,
                 ],
             ],
         );
+    }
+
+    /**
+     * getPropertyName() must return the array's real property name (not a synthetic
+     * "item of array X" description) and getInstancePointer() must resolve to the failing
+     * item's real position within the data, including through nested arrays.
+     *
+     * @throws FileSystemException
+     * @throws RenderException
+     * @throws SchemaException
+     */
+    public function testInvalidTypedArrayItemExposesRealPropertyNameAndInstancePointer(): void
+    {
+        $className = $this->generateClassFromFileTemplate(
+            'ArrayPropertyTyped.json',
+            ['"array","items":{"type":"integer"}'],
+            (new GeneratorConfiguration())->setCollectErrors(false),
+            false,
+        );
+
+        try {
+            new $className(['property' => [[1, 2], [3, 'not an int']]]);
+            $this->fail('Expected ValidationException');
+        } catch (ValidationException $exception) {
+            $this->assertInstanceOf(InvalidItemException::class, $exception);
+            $this->assertSame('property', $exception->getPropertyName());
+            $this->assertSame('/property', $exception->getInstancePointer()->pointer);
+
+            $innerException = $exception->getInvalidItems()[1][0];
+            $this->assertInstanceOf(InvalidItemException::class, $innerException);
+            $this->assertSame('property', $innerException->getPropertyName());
+            $this->assertSame('/property/1', $innerException->getInstancePointer()->pointer);
+
+            $leafException = $innerException->getInvalidItems()[1][0];
+            $this->assertSame('property', $leafException->getPropertyName());
+            $this->assertSame('/property/1/1', $leafException->getInstancePointer()->pointer);
+        }
     }
 
     #[DataProvider('validArrayContainsDataProvider')]
@@ -772,7 +809,7 @@ class ArrayPropertyTest extends AbstractPHPModelGeneratorTestCase
                         <<<ERROR
                         Invalid items in array property:
                           - invalid item #0
-                            * Invalid type for item of array property. Requires object, got NULL
+                            * Invalid type for property. Requires object, got NULL
                         ERROR,
                     ],
                     'invalid type bool' => [
@@ -780,7 +817,7 @@ class ArrayPropertyTest extends AbstractPHPModelGeneratorTestCase
                         <<<ERROR
                         Invalid items in array property:
                           - invalid item #1
-                            * Invalid type for item of array property. Requires object, got boolean
+                            * Invalid type for property. Requires object, got boolean
                         ERROR,
                     ],
                     'missing property name' => [
@@ -808,7 +845,7 @@ class ArrayPropertyTest extends AbstractPHPModelGeneratorTestCase
                           - invalid item #1
                             * Invalid type for age. Requires int, got string
                           - invalid item #2
-                            * Invalid type for item of array property. Requires object, got integer
+                            * Invalid type for property. Requires object, got integer
                           - invalid item #3
                             * Missing required value for name
                         ERROR,
@@ -832,12 +869,12 @@ class ArrayPropertyTest extends AbstractPHPModelGeneratorTestCase
                         <<<ERROR
                         Invalid items in array property:
                           - invalid item #1
-                            * Invalid value for item of array property declined by composition constraint.
+                            * Invalid value for property declined by composition constraint.
                               Requires to match all composition elements but matched 0 elements.
                               - Composition element #1: Failed
-                                * Invalid type for item of array property. Requires object, got boolean
+                                * Invalid type for property. Requires object, got boolean
                               - Composition element #2: Failed
-                                * Invalid type for item of array property. Requires object, got boolean
+                                * Invalid type for property. Requires object, got boolean
                         ERROR,
                     ],
                     'missing property name' => [
@@ -845,7 +882,7 @@ class ArrayPropertyTest extends AbstractPHPModelGeneratorTestCase
                         <<<ERROR
                         Invalid items in array property:
                           - invalid item #1
-                            * Invalid value for item of array property declined by composition constraint.
+                            * Invalid value for property declined by composition constraint.
                               Requires to match all composition elements but matched 1 elements.
                               - Composition element #1: Failed
                                 * Missing required value for name
@@ -858,7 +895,7 @@ class ArrayPropertyTest extends AbstractPHPModelGeneratorTestCase
                         <<<ERROR
                         Invalid items in array property:
                           - invalid item #1
-                            * Invalid value for item of array property declined by composition constraint.
+                            * Invalid value for property declined by composition constraint.
                               Requires to match all composition elements but matched 1 elements.
                               - Composition element #1: Failed
                                 * Invalid type for name. Requires string, got boolean
@@ -870,27 +907,27 @@ class ArrayPropertyTest extends AbstractPHPModelGeneratorTestCase
                         <<<ERROR
                         Invalid items in array property:
                           - invalid item #0
-                            * Invalid value for item of array property declined by composition constraint.
+                            * Invalid value for property declined by composition constraint.
                               Requires to match all composition elements but matched 1 elements.
                               - Composition element #1: Failed
                                 * Invalid type for name. Requires string, got boolean
                               - Composition element #2: Valid
                           - invalid item #1
-                            * Invalid value for item of array property declined by composition constraint.
+                            * Invalid value for property declined by composition constraint.
                               Requires to match all composition elements but matched 0 elements.
                               - Composition element #1: Failed
                                 * Value for name must not be shorter than 2
                               - Composition element #2: Failed
                                 * Invalid type for age. Requires int, got string
                           - invalid item #2
-                            * Invalid value for item of array property declined by composition constraint.
+                            * Invalid value for property declined by composition constraint.
                               Requires to match all composition elements but matched 0 elements.
                               - Composition element #1: Failed
-                                * Invalid type for item of array property. Requires object, got integer
+                                * Invalid type for property. Requires object, got integer
                               - Composition element #2: Failed
-                                * Invalid type for item of array property. Requires object, got integer
+                                * Invalid type for property. Requires object, got integer
                           - invalid item #3
-                            * Invalid value for item of array property declined by composition constraint.
+                            * Invalid value for property declined by composition constraint.
                               Requires to match all composition elements but matched 1 elements.
                               - Composition element #1: Failed
                                 * Missing required value for name

--- a/tests/Objects/ArrayPropertyTest.php
+++ b/tests/Objects/ArrayPropertyTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace PHPModelGenerator\Tests\Objects;
 
 use PHPModelGenerator\Exception\Arrays\InvalidItemException;
+use PHPModelGenerator\Exception\ComposedValue\AllOfException;
 use PHPModelGenerator\Exception\Arrays\MaxItemsException;
 use PHPModelGenerator\Exception\Arrays\MinItemsException;
 use PHPModelGenerator\Exception\ErrorRegistryException;
@@ -938,6 +939,40 @@ class ArrayPropertyTest extends AbstractPHPModelGeneratorTestCase
                 ],
             )
         );
+    }
+
+    /**
+     * Regression test: when a composition applied to an array item fails entirely (no branch
+     * succeeds), the array item's real value must survive. Array items are validated by
+     * reference — each item aliases directly into the array being validated — so a composed-value
+     * validator that adopts an unset/leftover proposed value on total failure doesn't just corrupt
+     * its own reported providedValue; the corruption propagates back into the original array too.
+     *
+     * @throws FileSystemException
+     * @throws RenderException
+     * @throws SchemaException
+     */
+    public function testInvalidCombinedObjectArrayItemPreservesProvidedValueOnTotalCompositionFailure(): void
+    {
+        $className = $this->generateClassFromFile('ArrayPropertyCombinedObject.json', new GeneratorConfiguration());
+
+        $propertyValue = [['name' => 'Hannes'], true];
+
+        try {
+            new $className(['property' => $propertyValue]);
+            $this->fail('Expected exception for invalid object array item');
+        } catch (ErrorRegistryException $exception) {
+            $itemException = $exception->getErrors()[0];
+            $this->assertInstanceOf(InvalidItemException::class, $itemException);
+            // Item #0 validates successfully, so the array reports its instantiated merged
+            // object there; item #1 (true) never validates, so it must survive as the raw
+            // input rather than being corrupted to null by the failed composition.
+            $this->assertSame(true, $itemException->getProvidedValue()[1]);
+
+            $compositionException = $itemException->getInvalidItems()[1][0];
+            $this->assertInstanceOf(AllOfException::class, $compositionException);
+            $this->assertSame(true, $compositionException->getProvidedValue());
+        }
     }
 
     #[DataProvider('validRecursiveArrayDataProvider')]

--- a/tests/Objects/ArrayPropertyTest.php
+++ b/tests/Objects/ArrayPropertyTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace PHPModelGenerator\Tests\Objects;
 
+use Closure;
 use PHPModelGenerator\Exception\Arrays\InvalidItemException;
 use PHPModelGenerator\Exception\ComposedValue\AllOfException;
 use PHPModelGenerator\Exception\Arrays\MaxItemsException;
@@ -16,6 +17,7 @@ use PHPModelGenerator\Exception\SchemaException;
 use PHPModelGenerator\Model\GeneratorConfiguration;
 use PHPModelGenerator\Tests\AbstractPHPModelGeneratorTestCase;
 use stdClass;
+use PHPUnit\Framework\Assert;
 use PHPUnit\Framework\Attributes\DataProvider;
 
 /**
@@ -275,7 +277,7 @@ class ArrayPropertyTest extends AbstractPHPModelGeneratorTestCase
         GeneratorConfiguration $configuration,
         array $propertyValue,
     ): void {
-        $this->expectValidationError($configuration, 'Items of array \'property\' are not unique');
+        $this->expectValidationError($configuration, "Items of array 'property' are not unique");
 
         $className = $this->generateClassFromFile('ArrayPropertyUnique.json', $configuration);
 
@@ -361,9 +363,9 @@ class ArrayPropertyTest extends AbstractPHPModelGeneratorTestCase
         return self::combineDataProvider(
             self::validationMethodDataProvider(),
             [
-                'Empty array' => [[], 'Array \'property\' must not contain less than 2 items'],
-                'Too few array items' => [[1], 'Array \'property\' must not contain less than 2 items'],
-                'Too many array items' => [[1, 2, 3 , 4], 'Array \'property\' must not contain more than 3 items']
+                'Empty array' => [[], "Array 'property' must not contain less than 2 items"],
+                'Too few array items' => [[1], "Array 'property' must not contain less than 2 items"],
+                'Too many array items' => [[1, 2, 3 , 4], "Array 'property' must not contain more than 3 items"]
             ],
         );
     }
@@ -484,13 +486,26 @@ class ArrayPropertyTest extends AbstractPHPModelGeneratorTestCase
         GeneratorConfiguration $configuration,
         string $type,
         array $propertyValue,
-        string $message = '',
+        string $message,
+        ?Closure $extraAssertions = null,
     ): void {
-        $this->expectValidationError($configuration, $message);
-
         $className = $this->generateClassFromFileTemplate('ArrayPropertyTyped.json', [$type], $configuration, false);
 
-        new $className(['property' => $propertyValue]);
+        try {
+            new $className(['property' => $propertyValue]);
+            $this->fail('Expected exception for invalid typed array item');
+        } catch (ErrorRegistryException | InvalidItemException $exception) {
+            $this->assertStringContainsString($message, $exception->getMessage());
+
+            // collectErrors(true) wraps the array item exception in an ErrorRegistryException.
+            $innerException = $exception instanceof ErrorRegistryException
+                ? $exception->getErrors()[0]
+                : $exception;
+
+            if ($extraAssertions) {
+                $extraAssertions($innerException);
+            }
+        }
     }
 
     public static function invalidTypedArrayDataProvider(): array
@@ -600,6 +615,22 @@ class ArrayPropertyTest extends AbstractPHPModelGeneratorTestCase
                           - invalid item #1
                             * Invalid type for 'property': requires 'int', got 'string'
                     ERROR,
+                    function (InvalidItemException $exception): void {
+                        // getPropertyName()/getInstancePointer() must resolve to the array's real
+                        // name and position at every nesting level, not a synthetic "item of array
+                        // X" placeholder.
+                        Assert::assertSame('property', $exception->getPropertyName());
+                        Assert::assertSame('/property', $exception->getInstancePointer()->pointer);
+
+                        $nestedException = $exception->getInvalidItems()[0][0];
+                        Assert::assertInstanceOf(InvalidItemException::class, $nestedException);
+                        Assert::assertSame('property', $nestedException->getPropertyName());
+                        Assert::assertSame('/property/0', $nestedException->getInstancePointer()->pointer);
+
+                        $leafException = $nestedException->getInvalidItems()[1][0];
+                        Assert::assertSame('property', $leafException->getPropertyName());
+                        Assert::assertSame('/property/0/1', $leafException->getInstancePointer()->pointer);
+                    },
                 ],
                 'Multi type array containing invalid values' => [
                     '["string", "integer"]',
@@ -614,43 +645,6 @@ class ArrayPropertyTest extends AbstractPHPModelGeneratorTestCase
                 ],
             ],
         );
-    }
-
-    /**
-     * getPropertyName() must return the array's real property name (not a synthetic
-     * "item of array X" description) and getInstancePointer() must resolve to the failing
-     * item's real position within the data, including through nested arrays.
-     *
-     * @throws FileSystemException
-     * @throws RenderException
-     * @throws SchemaException
-     */
-    public function testInvalidTypedArrayItemExposesRealPropertyNameAndInstancePointer(): void
-    {
-        $className = $this->generateClassFromFileTemplate(
-            'ArrayPropertyTyped.json',
-            ['"array","items":{"type":"integer"}'],
-            (new GeneratorConfiguration())->setCollectErrors(false),
-            false,
-        );
-
-        try {
-            new $className(['property' => [[1, 2], [3, 'not an int']]]);
-            $this->fail('Expected ValidationException');
-        } catch (ValidationException $exception) {
-            $this->assertInstanceOf(InvalidItemException::class, $exception);
-            $this->assertSame('property', $exception->getPropertyName());
-            $this->assertSame('/property', $exception->getInstancePointer()->pointer);
-
-            $innerException = $exception->getInvalidItems()[1][0];
-            $this->assertInstanceOf(InvalidItemException::class, $innerException);
-            $this->assertSame('property', $innerException->getPropertyName());
-            $this->assertSame('/property/1', $innerException->getInstancePointer()->pointer);
-
-            $leafException = $innerException->getInvalidItems()[1][0];
-            $this->assertSame('property', $leafException->getPropertyName());
-            $this->assertSame('/property/1/1', $leafException->getInstancePointer()->pointer);
-        }
     }
 
     #[DataProvider('validArrayContainsDataProvider')]
@@ -683,7 +677,7 @@ class ArrayPropertyTest extends AbstractPHPModelGeneratorTestCase
     ): void {
         $this->expectValidationError(
             $configuration,
-            'No item in array \'property\' matches the \'contains\' constraint',
+            "No item in array 'property' matches the 'contains' constraint",
         );
 
         $className = $this->generateClassFromFile('ArrayPropertyContains.json', $configuration);
@@ -779,6 +773,7 @@ class ArrayPropertyTest extends AbstractPHPModelGeneratorTestCase
         GeneratorConfiguration $configuration,
         array $propertyValue,
         string $message,
+        ?Closure $extraAssertions = null,
     ): void {
         $className = $this->generateClassFromFile($file, $configuration);
 
@@ -795,6 +790,10 @@ class ArrayPropertyTest extends AbstractPHPModelGeneratorTestCase
 
             $this->assertInstanceOf(InvalidItemException::class, $innerException);
             $this->assertSame('/properties/property/items', $innerException->getJsonPointer()->pointer);
+
+            if ($extraAssertions) {
+                $extraAssertions($innerException);
+            }
         }
     }
 
@@ -880,6 +879,30 @@ class ArrayPropertyTest extends AbstractPHPModelGeneratorTestCase
                               - Composition element #2: Failed
                                 * Invalid type for 'property': requires 'object', got 'boolean'
                         ERROR,
+                        function (InvalidItemException $exception): void {
+                            // Regression: when a composition applied to an array item fails
+                            // entirely (no branch succeeds), the array item's real value must
+                            // survive. Array items are validated by reference — each item aliases
+                            // directly into the array being validated — so a composed-value
+                            // validator that adopts an unset/leftover proposed value on total
+                            // failure doesn't just corrupt its own reported providedValue; the
+                            // corruption propagates back into the original array too.
+                            //
+                            // Item #0 validates successfully, so the array reports its
+                            // instantiated merged object there; item #1 (true) never validates, so
+                            // it must survive as the raw input rather than being corrupted to null
+                            // by the failed composition.
+                            Assert::assertSame(true, $exception->getProvidedValue()[1]);
+                            Assert::assertSame('/property', $exception->getInstancePointer()->pointer);
+
+                            $compositionException = $exception->getInvalidItems()[1][0];
+                            Assert::assertInstanceOf(AllOfException::class, $compositionException);
+                            Assert::assertSame(true, $compositionException->getProvidedValue());
+                            Assert::assertSame(
+                                '/property/1',
+                                $compositionException->getInstancePointer()->pointer,
+                            );
+                        },
                     ],
                     'missing property name' => [
                         [['name' => 'Hannes'], ['age' => 42]],
@@ -887,7 +910,7 @@ class ArrayPropertyTest extends AbstractPHPModelGeneratorTestCase
                         Invalid items in array 'property':
                           - invalid item #1
                             * Invalid value for 'property' declined by composition constraint
-                              Requires to match all composition elements but matched 1 elements
+                              Requires to match all composition elements but matched 1 element
                               - Composition element #1: Failed
                                 * Missing required value for 'name'
                                 * Invalid type for 'name': requires 'string', got 'NULL'
@@ -900,7 +923,7 @@ class ArrayPropertyTest extends AbstractPHPModelGeneratorTestCase
                         Invalid items in array 'property':
                           - invalid item #1
                             * Invalid value for 'property' declined by composition constraint
-                              Requires to match all composition elements but matched 1 elements
+                              Requires to match all composition elements but matched 1 element
                               - Composition element #1: Failed
                                 * Invalid type for 'name': requires 'string', got 'boolean'
                               - Composition element #2: Valid
@@ -912,7 +935,7 @@ class ArrayPropertyTest extends AbstractPHPModelGeneratorTestCase
                         Invalid items in array 'property':
                           - invalid item #0
                             * Invalid value for 'property' declined by composition constraint
-                              Requires to match all composition elements but matched 1 elements
+                              Requires to match all composition elements but matched 1 element
                               - Composition element #1: Failed
                                 * Invalid type for 'name': requires 'string', got 'boolean'
                               - Composition element #2: Valid
@@ -932,7 +955,7 @@ class ArrayPropertyTest extends AbstractPHPModelGeneratorTestCase
                                 * Invalid type for 'property': requires 'object', got 'integer'
                           - invalid item #3
                             * Invalid value for 'property' declined by composition constraint
-                              Requires to match all composition elements but matched 1 elements
+                              Requires to match all composition elements but matched 1 element
                               - Composition element #1: Failed
                                 * Missing required value for 'name'
                                 * Invalid type for 'name': requires 'string', got 'NULL'
@@ -942,40 +965,6 @@ class ArrayPropertyTest extends AbstractPHPModelGeneratorTestCase
                 ],
             )
         );
-    }
-
-    /**
-     * Regression test: when a composition applied to an array item fails entirely (no branch
-     * succeeds), the array item's real value must survive. Array items are validated by
-     * reference — each item aliases directly into the array being validated — so a composed-value
-     * validator that adopts an unset/leftover proposed value on total failure doesn't just corrupt
-     * its own reported providedValue; the corruption propagates back into the original array too.
-     *
-     * @throws FileSystemException
-     * @throws RenderException
-     * @throws SchemaException
-     */
-    public function testInvalidCombinedObjectArrayItemPreservesProvidedValueOnTotalCompositionFailure(): void
-    {
-        $className = $this->generateClassFromFile('ArrayPropertyCombinedObject.json', new GeneratorConfiguration());
-
-        $propertyValue = [['name' => 'Hannes'], true];
-
-        try {
-            new $className(['property' => $propertyValue]);
-            $this->fail('Expected exception for invalid object array item');
-        } catch (ErrorRegistryException $exception) {
-            $itemException = $exception->getErrors()[0];
-            $this->assertInstanceOf(InvalidItemException::class, $itemException);
-            // Item #0 validates successfully, so the array reports its instantiated merged
-            // object there; item #1 (true) never validates, so it must survive as the raw
-            // input rather than being corrupted to null by the failed composition.
-            $this->assertSame(true, $itemException->getProvidedValue()[1]);
-
-            $compositionException = $itemException->getInvalidItems()[1][0];
-            $this->assertInstanceOf(AllOfException::class, $compositionException);
-            $this->assertSame(true, $compositionException->getProvidedValue());
-        }
     }
 
     #[DataProvider('validRecursiveArrayDataProvider')]

--- a/tests/Objects/BooleanPropertyTest.php
+++ b/tests/Objects/BooleanPropertyTest.php
@@ -56,7 +56,7 @@ class BooleanPropertyTest extends AbstractPHPModelGeneratorTestCase
             'null' => [null],
         ];
     }
-    
+
     /**
      * @throws FileSystemException
      * @throws RenderException
@@ -67,8 +67,8 @@ class BooleanPropertyTest extends AbstractPHPModelGeneratorTestCase
     {
         $this->expectException(ValidationException::class);
         $this->expectExceptionMessage(
-            'Invalid type for property. Requires bool, got ' .
-                (is_object($propertyValue) ? $propertyValue::class : gettype($propertyValue)),
+            "Invalid type for 'property': requires 'bool', got '" .
+                (is_object($propertyValue) ? $propertyValue::class : gettype($propertyValue)) . "'",
         );
 
         $className = $this->generateClassFromFile('BooleanProperty.json');

--- a/tests/Objects/ConstPropertyTest.php
+++ b/tests/Objects/ConstPropertyTest.php
@@ -169,7 +169,11 @@ class ConstPropertyTest extends AbstractPHPModelGeneratorTestCase
             $this->fail('Expected ValidationException');
         } catch (ValidationException $exception) {
             $this->assertSame(
-                'Invalid value for stringProperty declined by const constraint',
+                sprintf(
+                    "Value for 'stringProperty' must be %s, got %s",
+                    json_encode('MyConstValue'),
+                    json_encode($propertyValue),
+                ),
                 $exception->getMessage(),
             );
             $this->assertSame(
@@ -330,11 +334,11 @@ class ConstPropertyTest extends AbstractPHPModelGeneratorTestCase
         return self::combineDataProvider(
             self::implicitNullDataProvider(),
             [
-                ['blue', 'green', 'Invalid value for requiredProperty declined by const constraint'],
-                ['blue', null, 'Invalid value for requiredProperty declined by const constraint'],
-                ['red', 'blue', 'Invalid value for optionalProperty declined by const constraint'],
-                ['red', '0', 'Invalid value for optionalProperty declined by const constraint'],
-                ['red', '', 'Invalid value for optionalProperty declined by const constraint'],
+                ['blue', 'green', 'Value for \'requiredProperty\' must be "red", got "blue"'],
+                ['blue', null, 'Value for \'requiredProperty\' must be "red", got "blue"'],
+                ['red', 'blue', 'Value for \'optionalProperty\' must be "green", got "blue"'],
+                ['red', '0', 'Value for \'optionalProperty\' must be "green", got "0"'],
+                ['red', '', 'Value for \'optionalProperty\' must be "green", got ""'],
             ],
         );
     }
@@ -384,7 +388,7 @@ class ConstPropertyTest extends AbstractPHPModelGeneratorTestCase
     public function testInvalidConstAdditionalPropertiesThrowsAnException(array $value): void
     {
         $this->expectException(InvalidAdditionalPropertiesException::class);
-        $this->expectExceptionMessageMatches('/Invalid value for additional property declined by const constraint/');
+        $this->expectExceptionMessageMatches('/Value for \'additional property\' must be "red", got /');
 
         $className = $this->generateClassFromFile('AdditionalPropertiesConst.json');
 
@@ -424,7 +428,7 @@ class ConstPropertyTest extends AbstractPHPModelGeneratorTestCase
     public function testInvalidConstPatternPropertiesThrowsAnException(array $value): void
     {
         $this->expectException(InvalidPatternPropertiesException::class);
-        $this->expectExceptionMessageMatches('/Invalid value for pattern property declined by const constraint/');
+        $this->expectExceptionMessageMatches('/Value for \'pattern property\' must be "red", got /');
 
         $className = $this->generateClassFromFile('PatternPropertiesConst.json');
 

--- a/tests/Objects/ConstPropertyTest.php
+++ b/tests/Objects/ConstPropertyTest.php
@@ -147,7 +147,7 @@ class ConstPropertyTest extends AbstractPHPModelGeneratorTestCase
     public function testNotMatchingOneOfPropertyThrowsAnException(): void
     {
         $this->expectException(OneOfException::class);
-        $this->expectExceptionMessage('Invalid value for property declined by composition constraint');
+        $this->expectExceptionMessage('Invalid value for \'property\' declined by composition constraint');
 
         $className = $this->generateClassFromFile('OneOfConstProperty.json');
 
@@ -297,7 +297,7 @@ class ConstPropertyTest extends AbstractPHPModelGeneratorTestCase
     public function testNotProvidedRequiredPropertyThrowsAnException(): void
     {
         $this->expectException(RequiredValueException::class);
-        $this->expectExceptionMessage('Missing required value for requiredProperty');
+        $this->expectExceptionMessage('Missing required value for \'requiredProperty\'');
 
         $className = $this->generateClassFromFile('RequiredAndOptionalConstProperties.json');
 
@@ -459,7 +459,7 @@ class ConstPropertyTest extends AbstractPHPModelGeneratorTestCase
     public function testInvalidConstArrayContainsThrowsAnException(array $value): void
     {
         $this->expectException(ContainsException::class);
-        $this->expectExceptionMessage('No item in array property matches contains constraint');
+        $this->expectExceptionMessage('No item in array \'property\' matches the \'contains\' constraint');
 
         $className = $this->generateClassFromFile('ArrayContainsConst.json');
 

--- a/tests/Objects/ConstPropertyTest.php
+++ b/tests/Objects/ConstPropertyTest.php
@@ -147,7 +147,7 @@ class ConstPropertyTest extends AbstractPHPModelGeneratorTestCase
     public function testNotMatchingOneOfPropertyThrowsAnException(): void
     {
         $this->expectException(OneOfException::class);
-        $this->expectExceptionMessage('Invalid value for \'property\' declined by composition constraint');
+        $this->expectExceptionMessage("Invalid value for 'property' declined by composition constraint");
 
         $className = $this->generateClassFromFile('OneOfConstProperty.json');
 
@@ -297,7 +297,7 @@ class ConstPropertyTest extends AbstractPHPModelGeneratorTestCase
     public function testNotProvidedRequiredPropertyThrowsAnException(): void
     {
         $this->expectException(RequiredValueException::class);
-        $this->expectExceptionMessage('Missing required value for \'requiredProperty\'');
+        $this->expectExceptionMessage("Missing required value for 'requiredProperty'");
 
         $className = $this->generateClassFromFile('RequiredAndOptionalConstProperties.json');
 
@@ -459,7 +459,7 @@ class ConstPropertyTest extends AbstractPHPModelGeneratorTestCase
     public function testInvalidConstArrayContainsThrowsAnException(array $value): void
     {
         $this->expectException(ContainsException::class);
-        $this->expectExceptionMessage('No item in array \'property\' matches the \'contains\' constraint');
+        $this->expectExceptionMessage("No item in array 'property' matches the 'contains' constraint");
 
         $className = $this->generateClassFromFile('ArrayContainsConst.json');
 

--- a/tests/Objects/ConstPropertyTest.php
+++ b/tests/Objects/ConstPropertyTest.php
@@ -162,12 +162,21 @@ class ConstPropertyTest extends AbstractPHPModelGeneratorTestCase
     #[DataProvider('invalidPropertyDataProvider')]
     public function testNotMatchingProvidedDataThrowsAnException(mixed $propertyValue): void
     {
-        $this->expectException(ValidationException::class);
-        $this->expectExceptionMessage('Invalid value for stringProperty declined by const constraint');
-
         $className = $this->generateClassFromFile('ConstProperty.json', null, false, false);
 
-        new $className(['stringProperty' => $propertyValue]);
+        try {
+            new $className(['stringProperty' => $propertyValue]);
+            $this->fail('Expected ValidationException');
+        } catch (ValidationException $exception) {
+            $this->assertSame(
+                'Invalid value for stringProperty declined by const constraint',
+                $exception->getMessage(),
+            );
+            $this->assertSame(
+                '/properties/stringProperty/const',
+                $exception->getJsonPointer()->pointer,
+            );
+        }
     }
 
     public static function invalidPropertyDataProvider(): array

--- a/tests/Objects/EnumPropertyTest.php
+++ b/tests/Objects/EnumPropertyTest.php
@@ -125,8 +125,8 @@ class EnumPropertyTest extends AbstractPHPModelGeneratorTestCase
     {
         $this->expectException(ValidationException::class);
         $this->expectExceptionMessage(
-            'Invalid type for property. Requires string, got ' .
-                (is_object($propertyValue) ? $propertyValue::class : gettype($propertyValue)),
+            "Invalid type for 'property': requires 'string', got '" .
+                (is_object($propertyValue) ? $propertyValue::class : gettype($propertyValue)) . "'",
         );
 
         $className = $this->generateEnumClass('string', static::ENUM_STRING);
@@ -153,7 +153,7 @@ class EnumPropertyTest extends AbstractPHPModelGeneratorTestCase
     public function testNotProvidedValueForRequiredEnumThrowsAnException(): void
     {
         $this->expectException(ValidationException::class);
-        $this->expectExceptionMessage("Missing required value for property");
+        $this->expectExceptionMessage("Missing required value for 'property'");
 
         $className = $this->generateEnumClass('string', static::ENUM_STRING, true);
 
@@ -168,7 +168,7 @@ class EnumPropertyTest extends AbstractPHPModelGeneratorTestCase
     public function testNullProvidedForRequiredEnumThrowsAnException(): void
     {
         $this->expectException(ValidationException::class);
-        $this->expectExceptionMessage("Invalid type for property. Requires string, got NULL");
+        $this->expectExceptionMessage("Invalid type for 'property': requires 'string', got 'NULL'");
 
         $className = $this->generateEnumClass('string', static::ENUM_STRING, true);
 
@@ -310,7 +310,7 @@ class EnumPropertyTest extends AbstractPHPModelGeneratorTestCase
     public function testNotProvidedEnumItemInRequiredUntypedEnumThrowsAnException(bool $implicitNull): void
     {
         $this->expectException(ValidationException::class);
-        $this->expectExceptionMessage('Missing required value for property');
+        $this->expectExceptionMessage('Missing required value for \'property\'');
 
         $className = $this->generateClassFromFile('RequiredUntypedEnumProperty.json', null, false, $implicitNull);
 

--- a/tests/Objects/EnumPropertyTest.php
+++ b/tests/Objects/EnumPropertyTest.php
@@ -71,7 +71,7 @@ class EnumPropertyTest extends AbstractPHPModelGeneratorTestCase
     public function testNullWithoutImplicitNullThrowsAnException(): void
     {
         $this->expectException(ValidationException::class);
-        $this->expectExceptionMessage('Invalid value for property declined by enum constraint');
+        $this->expectExceptionMessage('Value for \'property\' must be one of ["red","green"], got null');
 
         $className = $this->generateClassFromFile('TypedEnumProperty.json', null, false, false);
 
@@ -94,7 +94,14 @@ class EnumPropertyTest extends AbstractPHPModelGeneratorTestCase
             new $className(['property' => $propertyValue]);
             $this->fail('Expected EnumException');
         } catch (EnumException $exception) {
-            $this->assertSame('Invalid value for property declined by enum constraint', $exception->getMessage());
+            $this->assertSame(
+                sprintf(
+                    "Value for 'property' must be one of %s, got %s",
+                    json_encode([...static::ENUM_STRING, null]),
+                    json_encode($propertyValue),
+                ),
+                $exception->getMessage(),
+            );
             $this->assertSame('/properties/property/enum', $exception->getJsonPointer()->pointer);
         }
     }
@@ -254,7 +261,7 @@ class EnumPropertyTest extends AbstractPHPModelGeneratorTestCase
     public function testNullInUntypedEnumWithoutImplicitNullThrowsAnException(): void
     {
         $this->expectException(ValidationException::class);
-        $this->expectExceptionMessage('Invalid value for property declined by enum constraint');
+        $this->expectExceptionMessage('Value for \'property\' must be one of ["red",0,10], got null');
 
         $className = $this->generateClassFromFile('UntypedEnumProperty.json', null, false, false);
 
@@ -270,7 +277,12 @@ class EnumPropertyTest extends AbstractPHPModelGeneratorTestCase
     public function testInvalidItemInUntypedEnumThrowsAnException(mixed $propertyValue): void
     {
         $this->expectException(ValidationException::class);
-        $this->expectExceptionMessage('Invalid value for property declined by enum constraint');
+        $this->expectExceptionMessage(
+            sprintf(
+                "Value for 'property' must be one of [\"red\",0,10,null], got %s",
+                json_encode($propertyValue),
+            ),
+        );
 
         $className = $this->generateClassFromFile('UntypedEnumProperty.json');
 
@@ -382,7 +394,7 @@ class EnumPropertyTest extends AbstractPHPModelGeneratorTestCase
     public function testNullProvidedEnumItemInRequiredUntypedEnumThrowsAnException(bool $implicitNull): void
     {
         $this->expectException(ValidationException::class);
-        $this->expectExceptionMessage('Invalid value for property declined by enum constraint');
+        $this->expectExceptionMessage('Value for \'property\' must be one of ["red",10], got null');
 
         $className = $this->generateClassFromFile('RequiredUntypedEnumProperty.json', null, false, $implicitNull);
 

--- a/tests/Objects/EnumPropertyTest.php
+++ b/tests/Objects/EnumPropertyTest.php
@@ -310,7 +310,7 @@ class EnumPropertyTest extends AbstractPHPModelGeneratorTestCase
     public function testNotProvidedEnumItemInRequiredUntypedEnumThrowsAnException(bool $implicitNull): void
     {
         $this->expectException(ValidationException::class);
-        $this->expectExceptionMessage('Missing required value for \'property\'');
+        $this->expectExceptionMessage("Missing required value for 'property'");
 
         $className = $this->generateClassFromFile('RequiredUntypedEnumProperty.json', null, false, $implicitNull);
 

--- a/tests/Objects/IntegerPropertyTest.php
+++ b/tests/Objects/IntegerPropertyTest.php
@@ -140,8 +140,8 @@ class IntegerPropertyTest extends AbstractNumericPropertyTestCase
     public static function invalidRangeDataProvider(): iterable
     {
         return [
-            'Too large number' => [2, 'Value for \'property\' must not be larger than 1', 'maximum'],
-            'Too small number' => [-2, 'Value for \'property\' must not be smaller than -1', 'minimum'],
+            'Too large number' => [2, "Value for 'property' must not be larger than 1", 'maximum'],
+            'Too small number' => [-2, "Value for 'property' must not be smaller than -1", 'minimum'],
         ];
     }
 
@@ -158,10 +158,10 @@ class IntegerPropertyTest extends AbstractNumericPropertyTestCase
     public static function invalidExclusiveRangeDataProvider(): iterable
     {
         return [
-            'Too large number 1' => [2, 'Value for \'property\' must be smaller than 1', 'exclusiveMaximum'],
-            'Too large number 2' => [1, 'Value for \'property\' must be smaller than 1', 'exclusiveMaximum'],
-            'Too small number 1' => [-1, 'Value for \'property\' must be larger than -1', 'exclusiveMinimum'],
-            'Too small number 2' => [-2, 'Value for \'property\' must be larger than -1', 'exclusiveMinimum'],
+            'Too large number 1' => [2, "Value for 'property' must be smaller than 1", 'exclusiveMaximum'],
+            'Too large number 2' => [1, "Value for 'property' must be smaller than 1", 'exclusiveMaximum'],
+            'Too small number 1' => [-1, "Value for 'property' must be larger than -1", 'exclusiveMinimum'],
+            'Too small number 2' => [-2, "Value for 'property' must be larger than -1", 'exclusiveMinimum'],
         ];
     }
 }

--- a/tests/Objects/IntegerPropertyTest.php
+++ b/tests/Objects/IntegerPropertyTest.php
@@ -67,8 +67,8 @@ class IntegerPropertyTest extends AbstractNumericPropertyTestCase
     {
         $this->expectException(ValidationException::class);
         $this->expectExceptionMessage(
-            'Invalid type for property. Requires int, got ' .
-                (is_object($propertyValue) ? $propertyValue::class : gettype($propertyValue)),
+            "Invalid type for 'property': requires 'int', got '" .
+                (is_object($propertyValue) ? $propertyValue::class : gettype($propertyValue)) . "'",
         );
 
         $className = $this->generateClassFromFile('IntegerProperty.json');
@@ -140,8 +140,8 @@ class IntegerPropertyTest extends AbstractNumericPropertyTestCase
     public static function invalidRangeDataProvider(): iterable
     {
         return [
-            'Too large number' => [2, 'Value for property must not be larger than 1', 'maximum'],
-            'Too small number' => [-2, 'Value for property must not be smaller than -1', 'minimum'],
+            'Too large number' => [2, 'Value for \'property\' must not be larger than 1', 'maximum'],
+            'Too small number' => [-2, 'Value for \'property\' must not be smaller than -1', 'minimum'],
         ];
     }
 
@@ -158,10 +158,10 @@ class IntegerPropertyTest extends AbstractNumericPropertyTestCase
     public static function invalidExclusiveRangeDataProvider(): iterable
     {
         return [
-            'Too large number 1' => [2, 'Value for property must be smaller than 1', 'exclusiveMaximum'],
-            'Too large number 2' => [1, 'Value for property must be smaller than 1', 'exclusiveMaximum'],
-            'Too small number 1' => [-1, 'Value for property must be larger than -1', 'exclusiveMinimum'],
-            'Too small number 2' => [-2, 'Value for property must be larger than -1', 'exclusiveMinimum'],
+            'Too large number 1' => [2, 'Value for \'property\' must be smaller than 1', 'exclusiveMaximum'],
+            'Too large number 2' => [1, 'Value for \'property\' must be smaller than 1', 'exclusiveMaximum'],
+            'Too small number 1' => [-1, 'Value for \'property\' must be larger than -1', 'exclusiveMinimum'],
+            'Too small number 2' => [-2, 'Value for \'property\' must be larger than -1', 'exclusiveMinimum'],
         ];
     }
 }

--- a/tests/Objects/MultiTypePropertyTest.php
+++ b/tests/Objects/MultiTypePropertyTest.php
@@ -156,17 +156,17 @@ class MultiTypePropertyTest extends AbstractPHPModelGeneratorTestCase
         return [
             'Bool' => [
                 true,
-                'Invalid type for \'property\': requires [\'float\', \'string\', \'array\'], got \'boolean\'',
+                "Invalid type for 'property': requires ['float', 'string', 'array'], got 'boolean'",
             ],
             'Object' => [
                 new stdClass(),
-                'Invalid type for \'property\': requires [\'float\', \'string\', \'array\'], got \'stdClass\'',
+                "Invalid type for 'property': requires ['float', 'string', 'array'], got 'stdClass'",
             ],
-            'Invalid int' => [9, 'Value for \'property\' must not be smaller than 10'],
-            'zero' => [0, 'Value for \'property\' must not be smaller than 10'],
-            'Invalid float' => [9.9, 'Value for \'property\' must not be smaller than 10'],
-            'Invalid string' => ['ABC', 'Value for \'property\' must not be shorter than 4'],
-            'Array with too few items' => [['Hello'], 'Array \'property\' must not contain less than 2 items'],
+            'Invalid int' => [9, "Value for 'property' must not be smaller than 10"],
+            'zero' => [0, "Value for 'property' must not be smaller than 10"],
+            'Invalid float' => [9.9, "Value for 'property' must not be smaller than 10"],
+            'Invalid string' => ['ABC', "Value for 'property' must not be shorter than 4"],
+            'Array with too few items' => [['Hello'], "Array 'property' must not contain less than 2 items"],
             'Array with invalid items' => [
                 ['Hello', 123],
                 <<<ERROR
@@ -285,7 +285,7 @@ class MultiTypePropertyTest extends AbstractPHPModelGeneratorTestCase
             'int' => [
                 1,
                 InvalidTypeException::class,
-                'Invalid type for \'property\': requires [\'string\', \'array\'], got \'integer\'',
+                "Invalid type for 'property': requires ['string', 'array'], got 'integer'",
             ],
             'invalid item in array' => [
                 ['Test1', 1],
@@ -299,7 +299,7 @@ class MultiTypePropertyTest extends AbstractPHPModelGeneratorTestCase
             'invalid array length' => [
                 [],
                 MinItemsException::class,
-                'Array \'property\' must not contain less than 2 items',
+                "Array 'property' must not contain less than 2 items",
             ],
             'invalid item in nested array' => [
                 ['Test1', [3, 'Test3']],

--- a/tests/Objects/MultiTypePropertyTest.php
+++ b/tests/Objects/MultiTypePropertyTest.php
@@ -166,7 +166,7 @@ class MultiTypePropertyTest extends AbstractPHPModelGeneratorTestCase
                 <<<ERROR
                 Invalid items in array property:
                   - invalid item #1
-                    * Invalid type for item of array property. Requires string, got integer
+                    * Invalid type for property. Requires string, got integer
                 ERROR,
             ]
         ];
@@ -287,7 +287,7 @@ class MultiTypePropertyTest extends AbstractPHPModelGeneratorTestCase
                 <<<ERROR
                 Invalid items in array property:
                   - invalid item #1
-                    * Invalid type for item of array property. Requires [string, array], got integer
+                    * Invalid type for property. Requires [string, array], got integer
                 ERROR,
             ],
             'invalid array length' => [
@@ -303,7 +303,7 @@ class MultiTypePropertyTest extends AbstractPHPModelGeneratorTestCase
                   - invalid item #1
                     * Invalid items in array property:
                       - invalid item #0
-                        * Invalid type for item of array property. Requires [string, array], got integer
+                        * Invalid type for property. Requires [string, array], got integer
                 ERROR,
             ],
             'invalid array length in nested array' => [
@@ -312,7 +312,7 @@ class MultiTypePropertyTest extends AbstractPHPModelGeneratorTestCase
                 <<<ERROR
                 Invalid items in array property:
                   - invalid item #1
-                    * Array item of array property must not contain less than 2 items
+                    * Array property must not contain less than 2 items
                 ERROR,
             ],
         ];

--- a/tests/Objects/MultiTypePropertyTest.php
+++ b/tests/Objects/MultiTypePropertyTest.php
@@ -154,19 +154,25 @@ class MultiTypePropertyTest extends AbstractPHPModelGeneratorTestCase
     public static function invalidValueDataProvider(): array
     {
         return [
-            'Bool' => [true, 'Invalid type for property. Requires [float, string, array], got boolean'],
-            'Object' => [new stdClass(), 'Invalid type for property. Requires [float, string, array], got stdClass'],
-            'Invalid int' => [9, 'Value for property must not be smaller than 10'],
-            'zero' => [0, 'Value for property must not be smaller than 10'],
-            'Invalid float' => [9.9, 'Value for property must not be smaller than 10'],
-            'Invalid string' => ['ABC', 'Value for property must not be shorter than 4'],
-            'Array with too few items' => [['Hello'], 'Array property must not contain less than 2 items'],
+            'Bool' => [
+                true,
+                'Invalid type for \'property\': requires [\'float\', \'string\', \'array\'], got \'boolean\'',
+            ],
+            'Object' => [
+                new stdClass(),
+                'Invalid type for \'property\': requires [\'float\', \'string\', \'array\'], got \'stdClass\'',
+            ],
+            'Invalid int' => [9, 'Value for \'property\' must not be smaller than 10'],
+            'zero' => [0, 'Value for \'property\' must not be smaller than 10'],
+            'Invalid float' => [9.9, 'Value for \'property\' must not be smaller than 10'],
+            'Invalid string' => ['ABC', 'Value for \'property\' must not be shorter than 4'],
+            'Array with too few items' => [['Hello'], 'Array \'property\' must not contain less than 2 items'],
             'Array with invalid items' => [
                 ['Hello', 123],
                 <<<ERROR
-                Invalid items in array property:
+                Invalid items in array 'property':
                   - invalid item #1
-                    * Invalid type for property. Requires string, got integer
+                    * Invalid type for 'property': requires 'string', got 'integer'
                 ERROR,
             ]
         ];
@@ -226,15 +232,15 @@ class MultiTypePropertyTest extends AbstractPHPModelGeneratorTestCase
             'invalid type' => [
                 ['name' => 42],
                 <<<ERROR
-                Invalid nested object for property property:
-                  - Invalid type for name. Requires string, got integer
+                Invalid nested object for property 'property':
+                  - Invalid type for 'name': requires 'string', got 'integer'
                 ERROR,
             ],
             'invalid additional property' => [
                 ['name' => 'Hans', 'age' => 42],
                 <<<ERROR
-                Invalid nested object for property property:
-                  - Provided JSON for MultiTypePropertyTest_\w+ contains not allowed additional properties \[age\]
+                Invalid nested object for property 'property':
+                  - Provided JSON for 'MultiTypePropertyTest_\w+' contains not allowed additional properties \['age'\]
                 ERROR,
             ],
         ];
@@ -279,40 +285,40 @@ class MultiTypePropertyTest extends AbstractPHPModelGeneratorTestCase
             'int' => [
                 1,
                 InvalidTypeException::class,
-                'Invalid type for property. Requires [string, array], got integer',
+                'Invalid type for \'property\': requires [\'string\', \'array\'], got \'integer\'',
             ],
             'invalid item in array' => [
                 ['Test1', 1],
                 InvalidItemException::class,
                 <<<ERROR
-                Invalid items in array property:
+                Invalid items in array 'property':
                   - invalid item #1
-                    * Invalid type for property. Requires [string, array], got integer
+                    * Invalid type for 'property': requires ['string', 'array'], got 'integer'
                 ERROR,
             ],
             'invalid array length' => [
                 [],
                 MinItemsException::class,
-                'Array property must not contain less than 2 items',
+                'Array \'property\' must not contain less than 2 items',
             ],
             'invalid item in nested array' => [
                 ['Test1', [3, 'Test3']],
                 InvalidItemException::class,
                 <<<ERROR
-                Invalid items in array property:
+                Invalid items in array 'property':
                   - invalid item #1
-                    * Invalid items in array property:
+                    * Invalid items in array 'property':
                       - invalid item #0
-                        * Invalid type for property. Requires [string, array], got integer
+                        * Invalid type for 'property': requires ['string', 'array'], got 'integer'
                 ERROR,
             ],
             'invalid array length in nested array' => [
                 ['Test1', []],
                 InvalidItemException::class,
                 <<<ERROR
-                Invalid items in array property:
+                Invalid items in array 'property':
                   - invalid item #1
-                    * Array property must not contain less than 2 items
+                    * Array 'property' must not contain less than 2 items
                 ERROR,
             ],
         ];

--- a/tests/Objects/NullPropertyTest.php
+++ b/tests/Objects/NullPropertyTest.php
@@ -55,8 +55,8 @@ class NullPropertyTest extends AbstractPHPModelGeneratorTestCase
     {
         $this->expectException(ValidationException::class);
         $this->expectExceptionMessage(
-            'Invalid type for property. Requires null, got ' .
-                (is_object($propertyValue) ? $propertyValue::class : gettype($propertyValue)),
+            "Invalid type for 'property': requires 'null', got '" .
+                (is_object($propertyValue) ? $propertyValue::class : gettype($propertyValue)) . "'",
         );
 
         $className = $this->generateClassFromFile('NullProperty.json');

--- a/tests/Objects/NumberPropertyTest.php
+++ b/tests/Objects/NumberPropertyTest.php
@@ -178,10 +178,10 @@ class NumberPropertyTest extends AbstractNumericPropertyTestCase
     public static function invalidRangeDataProvider(): iterable
     {
         return [
-            'Too large number int' => [2, 'Value for \'property\' must not be larger than 1.6', 'maximum'],
-            'Too large number float' => [1.7, 'Value for \'property\' must not be larger than 1.6', 'maximum'],
-            'Too small number int' => [-2, 'Value for \'property\' must not be smaller than -1.6', 'minimum'],
-            'Too small number float' => [-1.7, 'Value for \'property\' must not be smaller than -1.6', 'minimum'],
+            'Too large number int' => [2, "Value for 'property' must not be larger than 1.6", 'maximum'],
+            'Too large number float' => [1.7, "Value for 'property' must not be larger than 1.6", 'maximum'],
+            'Too small number int' => [-2, "Value for 'property' must not be smaller than -1.6", 'minimum'],
+            'Too small number float' => [-1.7, "Value for 'property' must not be smaller than -1.6", 'minimum'],
         ];
     }
     #[\Override]
@@ -202,12 +202,12 @@ class NumberPropertyTest extends AbstractNumericPropertyTestCase
     public static function invalidExclusiveRangeDataProvider(): iterable
     {
         return [
-            'Too large number int' => [2, 'Value for \'property\' must be smaller than 1.6', 'exclusiveMaximum'],
-            'Too large number float 1' => [1.6, 'Value for \'property\' must be smaller than 1.6', 'exclusiveMaximum'],
-            'Too large number float 2' => [1.9, 'Value for \'property\' must be smaller than 1.6', 'exclusiveMaximum'],
-            'Too small number int' => [-2, 'Value for \'property\' must be larger than -1.6', 'exclusiveMinimum'],
-            'Too small number float 1' => [-1.6, 'Value for \'property\' must be larger than -1.6', 'exclusiveMinimum'],
-            'Too small number float 2' => [-1.9, 'Value for \'property\' must be larger than -1.6', 'exclusiveMinimum'],
+            'Too large number int' => [2, "Value for 'property' must be smaller than 1.6", 'exclusiveMaximum'],
+            'Too large number float 1' => [1.6, "Value for 'property' must be smaller than 1.6", 'exclusiveMaximum'],
+            'Too large number float 2' => [1.9, "Value for 'property' must be smaller than 1.6", 'exclusiveMaximum'],
+            'Too small number int' => [-2, "Value for 'property' must be larger than -1.6", 'exclusiveMinimum'],
+            'Too small number float 1' => [-1.6, "Value for 'property' must be larger than -1.6", 'exclusiveMinimum'],
+            'Too small number float 2' => [-1.9, "Value for 'property' must be larger than -1.6", 'exclusiveMinimum'],
         ];
     }
 }

--- a/tests/Objects/NumberPropertyTest.php
+++ b/tests/Objects/NumberPropertyTest.php
@@ -83,8 +83,8 @@ class NumberPropertyTest extends AbstractNumericPropertyTestCase
     {
         $this->expectException(ValidationException::class);
         $this->expectExceptionMessage(
-            'Invalid type for property. Requires float, got ' .
-                (is_object($propertyValue) ? $propertyValue::class : gettype($propertyValue)),
+            "Invalid type for 'property': requires 'float', got '" .
+                (is_object($propertyValue) ? $propertyValue::class : gettype($propertyValue)) . "'",
         );
 
         $className = $this->generateClassFromFile('NumberProperty.json');
@@ -178,10 +178,10 @@ class NumberPropertyTest extends AbstractNumericPropertyTestCase
     public static function invalidRangeDataProvider(): iterable
     {
         return [
-            'Too large number int' => [2, 'Value for property must not be larger than 1.6', 'maximum'],
-            'Too large number float' => [1.7, 'Value for property must not be larger than 1.6', 'maximum'],
-            'Too small number int' => [-2, 'Value for property must not be smaller than -1.6', 'minimum'],
-            'Too small number float' => [-1.7, 'Value for property must not be smaller than -1.6', 'minimum'],
+            'Too large number int' => [2, 'Value for \'property\' must not be larger than 1.6', 'maximum'],
+            'Too large number float' => [1.7, 'Value for \'property\' must not be larger than 1.6', 'maximum'],
+            'Too small number int' => [-2, 'Value for \'property\' must not be smaller than -1.6', 'minimum'],
+            'Too small number float' => [-1.7, 'Value for \'property\' must not be smaller than -1.6', 'minimum'],
         ];
     }
     #[\Override]
@@ -202,12 +202,12 @@ class NumberPropertyTest extends AbstractNumericPropertyTestCase
     public static function invalidExclusiveRangeDataProvider(): iterable
     {
         return [
-            'Too large number int' => [2, 'Value for property must be smaller than 1.6', 'exclusiveMaximum'],
-            'Too large number float 1' => [1.6, 'Value for property must be smaller than 1.6', 'exclusiveMaximum'],
-            'Too large number float 2' => [1.9, 'Value for property must be smaller than 1.6', 'exclusiveMaximum'],
-            'Too small number int' => [-2, 'Value for property must be larger than -1.6', 'exclusiveMinimum'],
-            'Too small number float 1' => [-1.6, 'Value for property must be larger than -1.6', 'exclusiveMinimum'],
-            'Too small number float 2' => [-1.9, 'Value for property must be larger than -1.6', 'exclusiveMinimum'],
+            'Too large number int' => [2, 'Value for \'property\' must be smaller than 1.6', 'exclusiveMaximum'],
+            'Too large number float 1' => [1.6, 'Value for \'property\' must be smaller than 1.6', 'exclusiveMaximum'],
+            'Too large number float 2' => [1.9, 'Value for \'property\' must be smaller than 1.6', 'exclusiveMaximum'],
+            'Too small number int' => [-2, 'Value for \'property\' must be larger than -1.6', 'exclusiveMinimum'],
+            'Too small number float 1' => [-1.6, 'Value for \'property\' must be larger than -1.6', 'exclusiveMinimum'],
+            'Too small number float 2' => [-1.9, 'Value for \'property\' must be larger than -1.6', 'exclusiveMinimum'],
         ];
     }
 }

--- a/tests/Objects/ObjectPropertyTest.php
+++ b/tests/Objects/ObjectPropertyTest.php
@@ -65,7 +65,9 @@ class ObjectPropertyTest extends AbstractPHPModelGeneratorTestCase
     public function testInvalidPropertyTypeThrowsAnException(mixed $propertyValue): void
     {
         $this->expectException(ValidationException::class);
-        $this->expectExceptionMessage('Invalid type for property. Requires object, got ' . gettype($propertyValue));
+        $this->expectExceptionMessage(
+            "Invalid type for 'property': requires 'object', got '" . gettype($propertyValue) . "'",
+        );
 
         $className = $this->generateClassFromFile('ObjectProperty.json');
 
@@ -96,7 +98,7 @@ class ObjectPropertyTest extends AbstractPHPModelGeneratorTestCase
             $this->fail('Expected InvalidInstanceOfException');
         } catch (InvalidInstanceOfException $exception) {
             $this->assertMatchesRegularExpression(
-                '/Invalid class for property. Requires ObjectPropertyTest_.*, got stdClass/',
+                '/Invalid class for \'property\': requires \'ObjectPropertyTest_.*\', got \'stdClass\'/',
                 $exception->getMessage(),
             );
             $this->assertSame('/properties/property/type', $exception->getJsonPointer()->pointer);
@@ -166,17 +168,17 @@ class ObjectPropertyTest extends AbstractPHPModelGeneratorTestCase
             'Missing required property' => [
                 ['age' => 42, 'alive' => true],
                 ValidationException::class,
-                'Missing required value for name'
+                'Missing required value for \'name\''
             ],
             'Too few arguments' => [
                 ['name' => 'Hannes'],
                 ValidationException::class,
-                'Provided object for ObjectPropertyTest_(.*) must not contain less than 2 properties'
+                'Provided object for \'ObjectPropertyTest_(.*)\' must not contain less than 2 properties'
             ],
             'Too many arguments' => [
                 ['name' => 'Hannes', 'age' => 42, 'alive' => true, 'children' => 3],
                 ValidationException::class,
-                'Provided object for ObjectPropertyTest_(.*) must not contain more than 3 properties'
+                'Provided object for \'ObjectPropertyTest_(.*)\' must not contain more than 3 properties'
             ],
         ];
     }

--- a/tests/Objects/ObjectPropertyTest.php
+++ b/tests/Objects/ObjectPropertyTest.php
@@ -98,7 +98,7 @@ class ObjectPropertyTest extends AbstractPHPModelGeneratorTestCase
             $this->fail('Expected InvalidInstanceOfException');
         } catch (InvalidInstanceOfException $exception) {
             $this->assertMatchesRegularExpression(
-                '/Invalid class for \'property\': requires \'ObjectPropertyTest_.*\', got \'stdClass\'/',
+                "/Invalid class for 'property': requires 'ObjectPropertyTest_.*', got 'stdClass'/",
                 $exception->getMessage(),
             );
             $this->assertSame('/properties/property/type', $exception->getJsonPointer()->pointer);
@@ -168,17 +168,17 @@ class ObjectPropertyTest extends AbstractPHPModelGeneratorTestCase
             'Missing required property' => [
                 ['age' => 42, 'alive' => true],
                 ValidationException::class,
-                'Missing required value for \'name\''
+                "Missing required value for 'name'"
             ],
             'Too few arguments' => [
                 ['name' => 'Hannes'],
                 ValidationException::class,
-                'Provided object for \'ObjectPropertyTest_(.*)\' must not contain less than 2 properties'
+                "Provided object for 'ObjectPropertyTest_(.*)' must not contain less than 2 properties"
             ],
             'Too many arguments' => [
                 ['name' => 'Hannes', 'age' => 42, 'alive' => true, 'children' => 3],
                 ValidationException::class,
-                'Provided object for \'ObjectPropertyTest_(.*)\' must not contain more than 3 properties'
+                "Provided object for 'ObjectPropertyTest_(.*)' must not contain more than 3 properties"
             ],
         ];
     }

--- a/tests/Objects/ReferencePropertyTest.php
+++ b/tests/Objects/ReferencePropertyTest.php
@@ -142,7 +142,7 @@ class ReferencePropertyTest extends AbstractPHPModelGeneratorTestCase
         $this->expectException(ValidationException::class);
         if ($propertyValue instanceof stdClass) {
             $this->expectExceptionMessageMatches(
-                '/Invalid class for \'person\': requires \'ReferencePropertyTest_.*\', got \'stdClass\'/',
+                "/Invalid class for 'person': requires 'ReferencePropertyTest_.*', got 'stdClass'/",
             );
         } else {
             $this->expectExceptionMessage(
@@ -249,13 +249,13 @@ class ReferencePropertyTest extends AbstractPHPModelGeneratorTestCase
         return self::combineDataProvider(
             static::intReferenceProvider(),
             [
-                'bool' => [true, 'Invalid type for \'year\''],
-                'float' => [0.92, 'Invalid type for \'year\''],
-                'array' => [[2], 'Invalid type for \'year\''],
-                'object' => [new stdClass(), 'Invalid type for \'year\''],
-                'string' => ['1', 'Invalid type for \'year\''],
-                'int too low' => [1899, 'Value for \'year\' must not be smaller than 1900'],
-                'int too high' => [2001, 'Value for \'year\' must not be larger than 2000'],
+                'bool' => [true, "Invalid type for 'year'"],
+                'float' => [0.92, "Invalid type for 'year'"],
+                'array' => [[2], "Invalid type for 'year'"],
+                'object' => [new stdClass(), "Invalid type for 'year'"],
+                'string' => ['1', "Invalid type for 'year'"],
+                'int too low' => [1899, "Value for 'year' must not be smaller than 1900"],
+                'int too high' => [2001, "Value for 'year' must not be larger than 2000"],
             ],
         );
     }
@@ -456,7 +456,7 @@ class ReferencePropertyTest extends AbstractPHPModelGeneratorTestCase
     public function testRecursivePathRefWithInvalidTypeThrowsException(string $schemaFile): void
     {
         $this->expectException(ValidationException::class);
-        $this->expectExceptionMessage('Invalid type for \'root\': requires \'object\', got \'integer\'');
+        $this->expectExceptionMessage("Invalid type for 'root': requires 'object', got 'integer'");
 
         $className = $this->generateClassFromFile($schemaFile);
         new $className(['root' => 42]);
@@ -519,7 +519,7 @@ class ReferencePropertyTest extends AbstractPHPModelGeneratorTestCase
     public function testDefsObjectRefInvalidTypeThrowsException(string $reference): void
     {
         $this->expectException(ValidationException::class);
-        $this->expectExceptionMessage('Invalid type for \'person\': requires \'object\', got \'integer\'');
+        $this->expectExceptionMessage("Invalid type for 'person': requires 'object', got 'integer'");
 
         $className = $this->generateClassFromFileTemplate('DefsObjectReference.json', [$reference]);
         new $className(['person' => 42]);
@@ -920,7 +920,7 @@ class ReferencePropertyTest extends AbstractPHPModelGeneratorTestCase
     public function testBaseRefToInBaseDirFileEnforcesRequiredProperty(): void
     {
         $this->expectException(ValidationException::class);
-        $this->expectExceptionMessage('Missing required value for \'street\'');
+        $this->expectExceptionMessage("Missing required value for 'street'");
 
         $namespace = 'T5BaseDirBaseRefRequired';
         $this->generateDirectory('BaseDirBaseRef', $this->directoryConfig($namespace));
@@ -1040,11 +1040,11 @@ class ReferencePropertyTest extends AbstractPHPModelGeneratorTestCase
     public static function invalidValuesForMultiplePropertiesWithIdenticalReferenceDataProvider(): array
     {
         return [
-            'Invalid value for \'personA\'' => [
+            "Invalid value for 'personA'" => [
                 ['personA' => 10],
-                'Invalid type for \'personA\': requires \'object\', got \'integer\'',
+                "Invalid type for 'personA': requires 'object', got 'integer'",
             ],
-            'Invalid value for \'both persons\'' => [
+            "Invalid value for 'both persons'" => [
                 ['personA' => 10, 'personB' => false],
                 <<<ERROR
                 Invalid type for 'personA': requires 'object', got 'integer'

--- a/tests/Objects/ReferencePropertyTest.php
+++ b/tests/Objects/ReferencePropertyTest.php
@@ -142,10 +142,12 @@ class ReferencePropertyTest extends AbstractPHPModelGeneratorTestCase
         $this->expectException(ValidationException::class);
         if ($propertyValue instanceof stdClass) {
             $this->expectExceptionMessageMatches(
-                '/Invalid class for person. Requires ReferencePropertyTest_.*, got stdClass/',
+                '/Invalid class for \'person\': requires \'ReferencePropertyTest_.*\', got \'stdClass\'/',
             );
         } else {
-            $this->expectExceptionMessage('Invalid type for person. Requires object, got ' . gettype($propertyValue));
+            $this->expectExceptionMessage(
+                "Invalid type for 'person': requires 'object', got '" . gettype($propertyValue) . "'",
+            );
         }
 
         $className = $this->generateClassFromFileTemplate('ObjectReference.json', [$reference]);
@@ -247,13 +249,13 @@ class ReferencePropertyTest extends AbstractPHPModelGeneratorTestCase
         return self::combineDataProvider(
             static::intReferenceProvider(),
             [
-                'bool' => [true, 'Invalid type for year'],
-                'float' => [0.92, 'Invalid type for year'],
-                'array' => [[2], 'Invalid type for year'],
-                'object' => [new stdClass(), 'Invalid type for year'],
-                'string' => ['1', 'Invalid type for year'],
-                'int too low' => [1899, 'Value for year must not be smaller than 1900'],
-                'int too high' => [2001, 'Value for year must not be larger than 2000'],
+                'bool' => [true, 'Invalid type for \'year\''],
+                'float' => [0.92, 'Invalid type for \'year\''],
+                'array' => [[2], 'Invalid type for \'year\''],
+                'object' => [new stdClass(), 'Invalid type for \'year\''],
+                'string' => ['1', 'Invalid type for \'year\''],
+                'int too low' => [1899, 'Value for \'year\' must not be smaller than 1900'],
+                'int too high' => [2001, 'Value for \'year\' must not be larger than 2000'],
             ],
         );
     }
@@ -454,7 +456,7 @@ class ReferencePropertyTest extends AbstractPHPModelGeneratorTestCase
     public function testRecursivePathRefWithInvalidTypeThrowsException(string $schemaFile): void
     {
         $this->expectException(ValidationException::class);
-        $this->expectExceptionMessage('Invalid type for root. Requires object, got integer');
+        $this->expectExceptionMessage('Invalid type for \'root\': requires \'object\', got \'integer\'');
 
         $className = $this->generateClassFromFile($schemaFile);
         new $className(['root' => 42]);
@@ -517,7 +519,7 @@ class ReferencePropertyTest extends AbstractPHPModelGeneratorTestCase
     public function testDefsObjectRefInvalidTypeThrowsException(string $reference): void
     {
         $this->expectException(ValidationException::class);
-        $this->expectExceptionMessage('Invalid type for person. Requires object, got integer');
+        $this->expectExceptionMessage('Invalid type for \'person\': requires \'object\', got \'integer\'');
 
         $className = $this->generateClassFromFileTemplate('DefsObjectReference.json', [$reference]);
         new $className(['person' => 42]);
@@ -918,7 +920,7 @@ class ReferencePropertyTest extends AbstractPHPModelGeneratorTestCase
     public function testBaseRefToInBaseDirFileEnforcesRequiredProperty(): void
     {
         $this->expectException(ValidationException::class);
-        $this->expectExceptionMessage('Missing required value for street');
+        $this->expectExceptionMessage('Missing required value for \'street\'');
 
         $namespace = 'T5BaseDirBaseRefRequired';
         $this->generateDirectory('BaseDirBaseRef', $this->directoryConfig($namespace));
@@ -1038,32 +1040,32 @@ class ReferencePropertyTest extends AbstractPHPModelGeneratorTestCase
     public static function invalidValuesForMultiplePropertiesWithIdenticalReferenceDataProvider(): array
     {
         return [
-            'Invalid value for personA' => [
+            'Invalid value for \'personA\'' => [
                 ['personA' => 10],
-                'Invalid type for personA. Requires object, got integer',
+                'Invalid type for \'personA\': requires \'object\', got \'integer\'',
             ],
-            'Invalid value for both persons' => [
+            'Invalid value for \'both persons\'' => [
                 ['personA' => 10, 'personB' => false],
                 <<<ERROR
-                Invalid type for personA. Requires object, got integer
-                Invalid type for personB. Requires object, got boolean
+                Invalid type for 'personA': requires 'object', got 'integer'
+                Invalid type for 'personB': requires 'object', got 'boolean'
                 ERROR,
             ],
             'Invalid names for personB' => [
                 ['personA' => ['name' => 'A'], 'personB' => ['name' => 10]],
                 <<<ERROR
-                Invalid nested object for property personA:
-                  - Value for name must not be shorter than 3
-                Invalid nested object for property personB:
-                  - Invalid type for name. Requires string, got integer
+                Invalid nested object for property 'personA':
+                  - Value for 'name' must not be shorter than 3
+                Invalid nested object for property 'personB':
+                  - Invalid type for 'name': requires 'string', got 'integer'
                 ERROR,
             ],
             'Combined top level validation error and nested error' => [
                 ['personA' => ['name' => 'A'], 'personB' => 10],
                 <<<ERROR
-                Invalid nested object for property personA:
-                  - Value for name must not be shorter than 3
-                Invalid type for personB. Requires object, got integer
+                Invalid nested object for property 'personA':
+                  - Value for 'name' must not be shorter than 3
+                Invalid type for 'personB': requires 'object', got 'integer'
                 ERROR,
             ],
         ];

--- a/tests/Objects/RequiredPropertyTest.php
+++ b/tests/Objects/RequiredPropertyTest.php
@@ -72,7 +72,7 @@ class RequiredPropertyTest extends AbstractPHPModelGeneratorTestCase
     public function testNotProvidedRequiredPropertyThrowsAnException(bool $implicitNull, string $file): void
     {
         $this->expectException(ErrorRegistryException::class);
-        $this->expectExceptionMessageMatches("/Missing required value for property/");
+        $this->expectExceptionMessageMatches("/Missing required value for 'property'/");
 
         $className = $this->generateClassFromFile(
             $file,
@@ -131,7 +131,7 @@ class RequiredPropertyTest extends AbstractPHPModelGeneratorTestCase
     public function testNullProvidedForRequiredPropertyThrowsAnException(bool $implicitNull, string $schemaFile): void
     {
         $this->expectException(ErrorRegistryException::class);
-        $this->expectExceptionMessageMatches("/Invalid type for property/");
+        $this->expectExceptionMessageMatches("/Invalid type for 'property'/");
 
         $className = $this->generateClassFromFile(
             $schemaFile,

--- a/tests/Objects/StringPropertyTest.php
+++ b/tests/Objects/StringPropertyTest.php
@@ -164,17 +164,17 @@ class StringPropertyTest extends AbstractPHPModelGeneratorTestCase
             [
                 'Empty string' => [
                     '',
-                    'Value for \'property\' must not be shorter than 2',
+                    "Value for 'property' must not be shorter than 2",
                     '/properties/property/minLength',
                 ],
                 'Too short string' => [
                     '1',
-                    'Value for \'property\' must not be shorter than 2',
+                    "Value for 'property' must not be shorter than 2",
                     '/properties/property/minLength',
                 ],
                 'Too long string' => [
                     'Some Text',
-                    'Value for \'property\' must not be longer than 8',
+                    "Value for 'property' must not be longer than 8",
                     '/properties/property/maxLength',
                 ],
             ],
@@ -224,7 +224,7 @@ class StringPropertyTest extends AbstractPHPModelGeneratorTestCase
                     '[0-9]{4}-[0-9]{2}-[0-9]{2}',
                     'Contains a Date 2018-12-12 and something else'
                 ],
-                'Regex escape test' => ['^\\\\\\\\/\'$', '\\/\''],
+                'Regex escape test' => ['^\\\\\\\\/\'$', "\/'"],
             ],
         );
     }
@@ -252,7 +252,7 @@ class StringPropertyTest extends AbstractPHPModelGeneratorTestCase
         return self::combineDataProvider(
             self::validationMethodDataProvider(),
             [
-                'String starts with' => ['^The', 'This Test doesn\'t start with The'],
+                'String starts with' => ['^The', "This Test doesn't start with The"],
                 'No spaces in string' => ['^[^\\s]+$', 'This String Contains Spaces'],
                 'A formatted date' => ['^[0-9]{4}-[0-9]{2}-[0-9]{2}$', '12.12.2018'],
                 'A formatted date inside a text' => [
@@ -286,7 +286,7 @@ class StringPropertyTest extends AbstractPHPModelGeneratorTestCase
     public function testInvalidStringFormatCheck(string $value): void
     {
         $this->expectException(ErrorRegistryException::class);
-        $this->expectExceptionMessage('Value for \'property\' must match the format \'onlyNumbers\'');
+        $this->expectExceptionMessage("Value for 'property' must match the format 'onlyNumbers'");
 
         $className = $this->generateClassFromFile(
             'StringPropertyFormat.json',

--- a/tests/Objects/StringPropertyTest.php
+++ b/tests/Objects/StringPropertyTest.php
@@ -76,8 +76,8 @@ class StringPropertyTest extends AbstractPHPModelGeneratorTestCase
     ): void {
         $this->expectValidationError(
             $configuration,
-            'Invalid type for property. Requires string, got ' .
-                (is_object($propertyValue) ? $propertyValue::class : gettype($propertyValue)),
+            "Invalid type for 'property': requires 'string', got '" .
+                (is_object($propertyValue) ? $propertyValue::class : gettype($propertyValue)) . "'",
         );
 
         $className = $this->generateClassFromFile('StringProperty.json', $configuration);
@@ -164,17 +164,17 @@ class StringPropertyTest extends AbstractPHPModelGeneratorTestCase
             [
                 'Empty string' => [
                     '',
-                    'Value for property must not be shorter than 2',
+                    'Value for \'property\' must not be shorter than 2',
                     '/properties/property/minLength',
                 ],
                 'Too short string' => [
                     '1',
-                    'Value for property must not be shorter than 2',
+                    'Value for \'property\' must not be shorter than 2',
                     '/properties/property/minLength',
                 ],
                 'Too long string' => [
                     'Some Text',
-                    'Value for property must not be longer than 8',
+                    'Value for \'property\' must not be longer than 8',
                     '/properties/property/maxLength',
                 ],
             ],
@@ -240,7 +240,7 @@ class StringPropertyTest extends AbstractPHPModelGeneratorTestCase
         string $pattern,
         string $propertyValue,
     ): void {
-        $this->expectValidationError($configuration, "Value for property doesn't match pattern $pattern");
+        $this->expectValidationError($configuration, "Value for 'property' does not match pattern '$pattern'");
 
         $className = $this->generateClassFromFileTemplate('StringPropertyPattern.json', [$pattern], $configuration);
 
@@ -286,7 +286,7 @@ class StringPropertyTest extends AbstractPHPModelGeneratorTestCase
     public function testInvalidStringFormatCheck(string $value): void
     {
         $this->expectException(ErrorRegistryException::class);
-        $this->expectExceptionMessage('Value for property must match the format onlyNumbers');
+        $this->expectExceptionMessage('Value for \'property\' must match the format \'onlyNumbers\'');
 
         $className = $this->generateClassFromFile(
             'StringPropertyFormat.json',

--- a/tests/Objects/TupleArrayPropertyTest.php
+++ b/tests/Objects/TupleArrayPropertyTest.php
@@ -95,7 +95,7 @@ class TupleArrayPropertyTest extends AbstractPHPModelGeneratorTestCase
     ): void {
         $this->expectValidationError(
             $configuration,
-            'Tuple array property contains not allowed additional items. Expected 3 items, got 4',
+            'Tuple array \'property\' contains not allowed additional items: expected 3 items, got 4',
         );
 
         $className = $this->generateClassFromFile('TupleArrayNoAdditionalItems.json', $configuration);
@@ -124,7 +124,7 @@ class TupleArrayPropertyTest extends AbstractPHPModelGeneratorTestCase
                 'not all elements invalid type' => [
                     [400, ''],
                     <<<ERROR
-                    Invalid tuple item in array property:
+                    Invalid tuple item in array 'property':
                       - invalid tuple #2
                         * Value for 'tuple item #1 of array property' must be one of ["Street","Avenue","Boulevard"], got ""
                     ERROR,
@@ -132,24 +132,24 @@ class TupleArrayPropertyTest extends AbstractPHPModelGeneratorTestCase
                 'invalid type' => [
                     ['400', 'Avenue', ['name' => 'Hans', 'age' => 42]],
                     <<<ERROR
-                    Invalid tuple item in array property:
+                    Invalid tuple item in array 'property':
                       - invalid tuple #1
-                        * Invalid type for tuple item #0 of array property. Requires int, got string
+                        * Invalid type for 'tuple item #0 of array property': requires 'int', got 'string'
                     ERROR,
                 ],
                 'Too small number' => [
                     [2, 'Boulevard', ['name' => 'Hans', 'age' => 42]],
                     <<<ERROR
-                    Invalid tuple item in array property:
+                    Invalid tuple item in array 'property':
                       - invalid tuple #1
-                        * Value for tuple item #0 of array property must not be smaller than 3
+                        * Value for 'tuple item #0 of array property' must not be smaller than 3
                     ERROR
 
                 ],
                 'invalid enum value' => [
                     [400, 'Way', ['name' => 'Hans', 'age' => 42]],
                     <<<ERROR
-                    Invalid tuple item in array property:
+                    Invalid tuple item in array 'property':
                       - invalid tuple #2
                         * Value for 'tuple item #1 of array property' must be one of ["Street","Avenue","Boulevard"], got "Way"
                     ERROR
@@ -158,37 +158,37 @@ class TupleArrayPropertyTest extends AbstractPHPModelGeneratorTestCase
                 'Missing required field in nested object' => [
                     [400, 'Street', ['age' => 42]],
                     <<<ERROR
-                    Invalid tuple item in array property:
+                    Invalid tuple item in array 'property':
                       - invalid tuple #3
-                        * Missing required value for name
+                        * Missing required value for 'name'
                     ERROR,
                 ],
                 'Invalid type in nested object' => [
                     [400, 'Street', ['name' => 'Hans', 'age' => true]],
                     <<<ERROR
-                    Invalid tuple item in array property:
+                    Invalid tuple item in array 'property':
                       - invalid tuple #3
-                        * Invalid type for age. Requires int, got boolean
+                        * Invalid type for 'age': requires 'int', got 'boolean'
                     ERROR,
                 ],
                 'Invalid order' => [
                     [['name' => 'Hans', 'age' => 42], 'Street', 400],
                     <<<ERROR
-                    Invalid tuple item in array property:
+                    Invalid tuple item in array 'property':
                       - invalid tuple #1
-                        * Invalid type for tuple item #0 of array property. Requires int, got array
+                        * Invalid type for 'tuple item #0 of array property': requires 'int', got 'array'
                       - invalid tuple #3
-                        * Invalid type for tuple item #2 of array property. Requires object, got integer
+                        * Invalid type for 'tuple item #2 of array property': requires 'object', got 'integer'
                     ERROR,
                 ],
                 'null values' => [
                     [null, null, ['name' => 'Hans', 'age' => 42]],
                     <<<ERROR
-                    Invalid tuple item in array property:
+                    Invalid tuple item in array 'property':
                       - invalid tuple #1
-                        * Invalid type for tuple item #0 of array property. Requires int, got NULL
+                        * Invalid type for 'tuple item #0 of array property': requires 'int', got 'NULL'
                       - invalid tuple #2
-                        * Invalid type for tuple item #1 of array property. Requires string, got NULL
+                        * Invalid type for 'tuple item #1 of array property': requires 'string', got 'NULL'
                     ERROR,
                 ],
             ],
@@ -240,7 +240,7 @@ class TupleArrayPropertyTest extends AbstractPHPModelGeneratorTestCase
     public static function invalidAdditionalItemsDataProvider(): array
     {
         $exception = <<<ERROR
-        Tuple array property contains invalid additional items.
+        Tuple array 'property' contains invalid additional items
           - invalid additional item '2'
             * %s
         ERROR;
@@ -250,38 +250,38 @@ class TupleArrayPropertyTest extends AbstractPHPModelGeneratorTestCase
             [
                 'invalid type for additional item (null)' => [
                     [3, 'Avenue', null],
-                    sprintf($exception, 'Invalid type for additional item. Requires string, got NULL')
+                    sprintf($exception, 'Invalid type for \'additional item\': requires \'string\', got \'NULL\'')
                 ],
                 'invalid type for additional item (int)' => [
                     [3, 'Avenue', 0],
-                    sprintf($exception, 'Invalid type for additional item. Requires string, got int')
+                    sprintf($exception, 'Invalid type for \'additional item\': requires \'string\', got \'integer\'')
                 ],
                 'invalid type for additional item (float)' => [
                     [3, 'Avenue', 0.2],
-                    sprintf($exception, 'Invalid type for additional item. Requires string, got double')
+                    sprintf($exception, 'Invalid type for \'additional item\': requires \'string\', got \'double\'')
                 ],
                 'invalid type for additional item (bool)' => [
                     [3, 'Avenue', false],
-                    sprintf($exception, 'Invalid type for additional item. Requires string, got bool')
+                    sprintf($exception, 'Invalid type for \'additional item\': requires \'string\', got \'boolean\'')
                 ],
                 'invalid type for additional item (object)' => [
                     [3, 'Avenue', new stdClass()],
-                    sprintf($exception, 'Invalid type for additional item. Requires string, got stdClass')
+                    sprintf($exception, 'Invalid type for \'additional item\': requires \'string\', got \'stdClass\'')
                 ],
                 'invalid type for additional item (array)' => [
                     [3, 'Avenue', [1, 2]],
-                    sprintf($exception, 'Invalid type for additional item. Requires string, got array')
+                    sprintf($exception, 'Invalid type for \'additional item\': requires \'string\', got \'array\'')
                 ],
                 'Multiple violations' => [
                     [3, 'Avenue', 0, 'asx', null, 'ADC', false],
                     <<<ERROR
-                    Tuple array property contains invalid additional items.
+                    Tuple array 'property' contains invalid additional items
                       - invalid additional item '2'
-                        * Invalid type for additional item. Requires string, got integer
+                        * Invalid type for 'additional item': requires 'string', got 'integer'
                       - invalid additional item '4'
-                        * Invalid type for additional item. Requires string, got NULL
+                        * Invalid type for 'additional item': requires 'string', got 'NULL'
                       - invalid additional item '6'
-                        * Invalid type for additional item. Requires string, got boolean
+                        * Invalid type for 'additional item': requires 'string', got 'boolean'
                     ERROR,
                 ],
             ],
@@ -345,7 +345,7 @@ class TupleArrayPropertyTest extends AbstractPHPModelGeneratorTestCase
     public static function invalidObjectAdditionalItemsDataProvider(): array
     {
         $exception = <<<ERROR
-        Tuple array property contains invalid additional items.
+        Tuple array 'property' contains invalid additional items
           - invalid additional item '2'
             * %s
         ERROR;
@@ -355,23 +355,23 @@ class TupleArrayPropertyTest extends AbstractPHPModelGeneratorTestCase
             [
                 'invalid type for additional item (null)' => [
                     [3, 'Avenue', null],
-                    sprintf($exception, 'Invalid type for additional item. Requires object, got NULL')
+                    sprintf($exception, 'Invalid type for \'additional item\': requires \'object\', got \'NULL\'')
                 ],
                 'invalid type for additional item (int)' => [
                     [3, 'Avenue', 12],
-                    sprintf($exception, 'Invalid type for additional item. Requires object, got int')
+                    sprintf($exception, 'Invalid type for \'additional item\': requires \'object\', got \'integer\'')
                 ],
                 'Missing required name' => [
                     [3, 'Avenue', ['age' => 42], ['name' => 'Hans']],
-                    sprintf($exception, 'Missing required value for name')
+                    sprintf($exception, 'Missing required value for \'name\'')
                 ],
-                'Invalid type for name' => [
+                'Invalid type for \'name\'' => [
                     [3, 'Avenue', ['name' => 42], ['name' => 'Hans']],
-                    sprintf($exception, 'Invalid type for name. Requires string, got integer')
+                    sprintf($exception, 'Invalid type for \'name\': requires \'string\', got \'integer\'')
                 ],
-                'Invalid type for age' => [
+                'Invalid type for \'age\'' => [
                     [3, 'Avenue', ['name' => 'Frida', 'age' => true], ['name' => 'Hans']],
-                    sprintf($exception, 'Invalid type for age. Requires int, got bool')
+                    sprintf($exception, 'Invalid type for \'age\': requires \'int\', got \'boolean\'')
                 ],
                 'Multiple violations' => [
                     [
@@ -382,11 +382,11 @@ class TupleArrayPropertyTest extends AbstractPHPModelGeneratorTestCase
                         ['name' => 'Jens', 'age' => false]
                     ],
                     <<<ERROR
-                    Tuple array property contains invalid additional items.
+                    Tuple array 'property' contains invalid additional items
                       - invalid additional item '2'
-                        * Invalid type for name. Requires string, got integer
+                        * Invalid type for 'name': requires 'string', got 'integer'
                       - invalid additional item '4'
-                        * Invalid type for age. Requires int, got boolean
+                        * Invalid type for 'age': requires 'int', got 'boolean'
                     ERROR,
                 ],
             ],

--- a/tests/Objects/TupleArrayPropertyTest.php
+++ b/tests/Objects/TupleArrayPropertyTest.php
@@ -126,7 +126,7 @@ class TupleArrayPropertyTest extends AbstractPHPModelGeneratorTestCase
                     <<<ERROR
                     Invalid tuple item in array property:
                       - invalid tuple #2
-                        * Invalid value for tuple item #1 of array property declined by enum constraint
+                        * Value for 'tuple item #1 of array property' must be one of ["Street","Avenue","Boulevard"], got ""
                     ERROR,
                 ],
                 'invalid type' => [
@@ -151,7 +151,7 @@ class TupleArrayPropertyTest extends AbstractPHPModelGeneratorTestCase
                     <<<ERROR
                     Invalid tuple item in array property:
                       - invalid tuple #2
-                        * Invalid value for tuple item #1 of array property declined by enum constraint
+                        * Value for 'tuple item #1 of array property' must be one of ["Street","Avenue","Boulevard"], got "Way"
                     ERROR
 
                 ],

--- a/tests/Objects/TupleArrayPropertyTest.php
+++ b/tests/Objects/TupleArrayPropertyTest.php
@@ -95,7 +95,7 @@ class TupleArrayPropertyTest extends AbstractPHPModelGeneratorTestCase
     ): void {
         $this->expectValidationError(
             $configuration,
-            'Tuple array \'property\' contains not allowed additional items: expected 3 items, got 4',
+            "Tuple array 'property' contains not allowed additional items: expected 3 items, got 4",
         );
 
         $className = $this->generateClassFromFile('TupleArrayNoAdditionalItems.json', $configuration);
@@ -250,27 +250,27 @@ class TupleArrayPropertyTest extends AbstractPHPModelGeneratorTestCase
             [
                 'invalid type for additional item (null)' => [
                     [3, 'Avenue', null],
-                    sprintf($exception, 'Invalid type for \'additional item\': requires \'string\', got \'NULL\'')
+                    sprintf($exception, "Invalid type for 'additional item': requires 'string', got 'NULL'")
                 ],
                 'invalid type for additional item (int)' => [
                     [3, 'Avenue', 0],
-                    sprintf($exception, 'Invalid type for \'additional item\': requires \'string\', got \'integer\'')
+                    sprintf($exception, "Invalid type for 'additional item': requires 'string', got 'integer'")
                 ],
                 'invalid type for additional item (float)' => [
                     [3, 'Avenue', 0.2],
-                    sprintf($exception, 'Invalid type for \'additional item\': requires \'string\', got \'double\'')
+                    sprintf($exception, "Invalid type for 'additional item': requires 'string', got 'double'")
                 ],
                 'invalid type for additional item (bool)' => [
                     [3, 'Avenue', false],
-                    sprintf($exception, 'Invalid type for \'additional item\': requires \'string\', got \'boolean\'')
+                    sprintf($exception, "Invalid type for 'additional item': requires 'string', got 'boolean'")
                 ],
                 'invalid type for additional item (object)' => [
                     [3, 'Avenue', new stdClass()],
-                    sprintf($exception, 'Invalid type for \'additional item\': requires \'string\', got \'stdClass\'')
+                    sprintf($exception, "Invalid type for 'additional item': requires 'string', got 'stdClass'")
                 ],
                 'invalid type for additional item (array)' => [
                     [3, 'Avenue', [1, 2]],
-                    sprintf($exception, 'Invalid type for \'additional item\': requires \'string\', got \'array\'')
+                    sprintf($exception, "Invalid type for 'additional item': requires 'string', got 'array'")
                 ],
                 'Multiple violations' => [
                     [3, 'Avenue', 0, 'asx', null, 'ADC', false],
@@ -355,23 +355,23 @@ class TupleArrayPropertyTest extends AbstractPHPModelGeneratorTestCase
             [
                 'invalid type for additional item (null)' => [
                     [3, 'Avenue', null],
-                    sprintf($exception, 'Invalid type for \'additional item\': requires \'object\', got \'NULL\'')
+                    sprintf($exception, "Invalid type for 'additional item': requires 'object', got 'NULL'")
                 ],
                 'invalid type for additional item (int)' => [
                     [3, 'Avenue', 12],
-                    sprintf($exception, 'Invalid type for \'additional item\': requires \'object\', got \'integer\'')
+                    sprintf($exception, "Invalid type for 'additional item': requires 'object', got 'integer'")
                 ],
                 'Missing required name' => [
                     [3, 'Avenue', ['age' => 42], ['name' => 'Hans']],
-                    sprintf($exception, 'Missing required value for \'name\'')
+                    sprintf($exception, "Missing required value for 'name'")
                 ],
-                'Invalid type for \'name\'' => [
+                "Invalid type for 'name'" => [
                     [3, 'Avenue', ['name' => 42], ['name' => 'Hans']],
-                    sprintf($exception, 'Invalid type for \'name\': requires \'string\', got \'integer\'')
+                    sprintf($exception, "Invalid type for 'name': requires 'string', got 'integer'")
                 ],
-                'Invalid type for \'age\'' => [
+                "Invalid type for 'age'" => [
                     [3, 'Avenue', ['name' => 'Frida', 'age' => true], ['name' => 'Hans']],
-                    sprintf($exception, 'Invalid type for \'age\': requires \'int\', got \'boolean\'')
+                    sprintf($exception, "Invalid type for 'age': requires 'int', got 'boolean'")
                 ],
                 'Multiple violations' => [
                     [

--- a/tests/PostProcessor/AdditionalPropertiesAccessorPostProcessorTest.php
+++ b/tests/PostProcessor/AdditionalPropertiesAccessorPostProcessorTest.php
@@ -262,7 +262,7 @@ class AdditionalPropertiesAccessorPostProcessorTest extends AbstractPHPModelGene
         return [
             'regular object property' => [
                 RegularPropertyAsAdditionalPropertyException::class,
-                "Couldn't add regular property name as additional property to object ",
+                "Could not add regular property 'name' as an additional property of object '",
                 'add',
                 ['name' => 'Hannes'],
                 '/properties/name',
@@ -290,7 +290,7 @@ class AdditionalPropertiesAccessorPostProcessorTest extends AbstractPHPModelGene
             ],
             'Invalid property value' => [
                 InvalidAdditionalPropertiesException::class,
-                "Value for additional property must not be longer than 15",
+                "Value for 'additional property' must not be longer than 15",
                 'add',
                 ['property2' => 'My much too long property value will fail the validation'],
                 '/additionalProperties',

--- a/tests/PostProcessor/BuilderClassPostProcessorTest.php
+++ b/tests/PostProcessor/BuilderClassPostProcessorTest.php
@@ -113,8 +113,8 @@ class BuilderClassPostProcessorTest extends AbstractPHPModelGeneratorTestCase
         $this->expectValidationErrorRegExp(
             $configuration,
             [
-                '/Value for name must not be shorter than 5/',
-                '/Value for age must not be smaller than 0/'
+                '/Value for \'name\' must not be shorter than 5/',
+                '/Value for \'age\' must not be smaller than 0/'
             ],
         );
 

--- a/tests/PostProcessor/BuilderClassPostProcessorTest.php
+++ b/tests/PostProcessor/BuilderClassPostProcessorTest.php
@@ -113,8 +113,8 @@ class BuilderClassPostProcessorTest extends AbstractPHPModelGeneratorTestCase
         $this->expectValidationErrorRegExp(
             $configuration,
             [
-                '/Value for \'name\' must not be shorter than 5/',
-                '/Value for \'age\' must not be smaller than 0/'
+                "/Value for 'name' must not be shorter than 5/",
+                "/Value for 'age' must not be smaller than 0/"
             ],
         );
 

--- a/tests/PostProcessor/EnumPostProcessorTest.php
+++ b/tests/PostProcessor/EnumPostProcessorTest.php
@@ -109,7 +109,8 @@ class EnumPostProcessorTest extends AbstractPHPModelGeneratorTestCase
 
         $this->expectException(InvalidTypeException::class);
         $this->expectExceptionMessageMatches(
-            '/Invalid type for property\. Requires EnumPostProcessorTest_.*Property, got PHPModelGenerator\\\\Tests\\\\PostProcessor\\\\IntEnum/',
+            '/Invalid type for \'property\': requires \'EnumPostProcessorTest_.*Property\', ' .
+                'got \'PHPModelGenerator\\\\Tests\\\\PostProcessor\\\\IntEnum\'/',
         );
 
         new $className(['property' => IntEnum::A]);
@@ -499,7 +500,7 @@ class EnumPostProcessorTest extends AbstractPHPModelGeneratorTestCase
         $className = $this->generateClassFromFile('EnumPropertyRequired.json');
 
         $this->expectException(RequiredValueException::class);
-        $this->expectExceptionMessage('Missing required value for property');
+        $this->expectExceptionMessage('Missing required value for \'property\'');
 
         new $className();
     }

--- a/tests/PostProcessor/EnumPostProcessorTest.php
+++ b/tests/PostProcessor/EnumPostProcessorTest.php
@@ -86,7 +86,7 @@ class EnumPostProcessorTest extends AbstractPHPModelGeneratorTestCase
         );
 
         $this->expectException(EnumException::class);
-        $this->expectExceptionMessage('Invalid value for property declined by enum constraint');
+        $this->expectExceptionMessage('Value for \'property\' must be one of ["hans","dieter",null], got "Meier"');
         $object->setProperty('Meier');
     }
 
@@ -96,7 +96,7 @@ class EnumPostProcessorTest extends AbstractPHPModelGeneratorTestCase
         $className = $this->generateClassFromFileTemplate('EnumProperty.json', ['["Hans", "Dieter"]'], null, false);
 
         $this->expectException(EnumException::class);
-        $this->expectExceptionMessage('Invalid value for property declined by enum constraint');
+        $this->expectExceptionMessage('Value for \'property\' must be one of ["Hans","Dieter",null], got "Meier"');
 
         new $className(['property' => 'Meier']);
     }
@@ -286,7 +286,7 @@ class EnumPostProcessorTest extends AbstractPHPModelGeneratorTestCase
         );
 
         $this->expectException(EnumException::class);
-        $this->expectExceptionMessage('Invalid value for property declined by enum constraint');
+        $this->expectExceptionMessage('Value for \'property\' must be one of [10,100,null], got 1');
         $object->setProperty(1);
     }
 
@@ -350,7 +350,7 @@ class EnumPostProcessorTest extends AbstractPHPModelGeneratorTestCase
         $this->assertNull($enum::tryFrom('Dieter'));
 
         $this->expectException(EnumException::class);
-        $this->expectExceptionMessage('Invalid value for property declined by enum constraint');
+        $this->expectExceptionMessage('Value for \'property\' must be one of ["Hans",100,true,60.5,null], got 1');
         $object->setProperty(1);
     }
 
@@ -627,7 +627,7 @@ class EnumPostProcessorTest extends AbstractPHPModelGeneratorTestCase
 
         $builder->setProperty('Meier');
         $this->expectException(EnumException::class);
-        $this->expectExceptionMessage('Invalid value for property declined by enum constraint');
+        $this->expectExceptionMessage('Value for \'property\' must be one of ["hans","dieter",null], got "Meier"');
         $builder->validate();
     }
 

--- a/tests/PostProcessor/EnumPostProcessorTest.php
+++ b/tests/PostProcessor/EnumPostProcessorTest.php
@@ -109,8 +109,8 @@ class EnumPostProcessorTest extends AbstractPHPModelGeneratorTestCase
 
         $this->expectException(InvalidTypeException::class);
         $this->expectExceptionMessageMatches(
-            '/Invalid type for \'property\': requires \'EnumPostProcessorTest_.*Property\', ' .
-                'got \'PHPModelGenerator\\\\Tests\\\\PostProcessor\\\\IntEnum\'/',
+            "/Invalid type for 'property': requires 'EnumPostProcessorTest_.*Property', " .
+                "got 'PHPModelGenerator\\\\Tests\\\\PostProcessor\\\\IntEnum'/",
         );
 
         new $className(['property' => IntEnum::A]);
@@ -287,7 +287,7 @@ class EnumPostProcessorTest extends AbstractPHPModelGeneratorTestCase
         );
 
         $this->expectException(EnumException::class);
-        $this->expectExceptionMessage('Value for \'property\' must be one of [10,100,null], got 1');
+        $this->expectExceptionMessage("Value for 'property' must be one of [10,100,null], got 1");
         $object->setProperty(1);
     }
 
@@ -500,7 +500,7 @@ class EnumPostProcessorTest extends AbstractPHPModelGeneratorTestCase
         $className = $this->generateClassFromFile('EnumPropertyRequired.json');
 
         $this->expectException(RequiredValueException::class);
-        $this->expectExceptionMessage('Missing required value for \'property\'');
+        $this->expectExceptionMessage("Missing required value for 'property'");
 
         new $className();
     }

--- a/tests/PostProcessor/PatternPropertiesAccessorPostProcessorTest.php
+++ b/tests/PostProcessor/PatternPropertiesAccessorPostProcessorTest.php
@@ -179,18 +179,18 @@ class PatternPropertiesAccessorPostProcessorTest extends AbstractPHPModelGenerat
                     'a0',
                     'Hello',
                     <<<ERROR
-                    Provided JSON for PatternPropertiesAccessorPostProcessorTest.* contains invalid pattern properties.
+                    Provided JSON for 'PatternPropertiesAccessorPostProcessorTest.*' contains invalid pattern properties
                       - invalid property 'a0' matching pattern '\^a'
-                        \* Invalid type for pattern property. Requires int, got string
+                        \* Invalid type for 'pattern property': requires 'int', got 'string'
                     ERROR,
                 ],
                 'invalid type for string properties' => [
                     'b0',
                     100,
                     <<<ERROR
-                    Provided JSON for PatternPropertiesAccessorPostProcessorTest.* contains invalid pattern properties.
+                    Provided JSON for 'PatternPropertiesAccessorPostProcessorTest.*' contains invalid pattern properties
                       - invalid property 'b0' matching pattern '\^b'
-                        \* Invalid type for pattern property. Requires string, got int
+                        \* Invalid type for 'pattern property': requires 'string', got 'integer'
                     ERROR,
                 ],
             ],
@@ -377,25 +377,25 @@ class PatternPropertiesAccessorPostProcessorTest extends AbstractPHPModelGenerat
             'value declined by property constraint' => [
                 'alpha',
                 0,
-                'Value for alpha must not be smaller than 10'
+                'Value for \'alpha\' must not be smaller than 10'
             ],
             'value declined by pattern property constraint' => [
                 'alpha',
                 15,
                 <<<ERROR
-                Provided JSON for PatternPropertiesAccessorPostProcessorTest.* contains invalid pattern properties.
+                Provided JSON for 'PatternPropertiesAccessorPostProcessorTest.*' contains invalid pattern properties
                   - invalid property 'alpha' matching pattern '\^a'
-                    \* Value for pattern property must be a multiple of 10
+                    \* Value for 'pattern property' must be a multiple of 10
                 ERROR,
             ],
             'Value declined by property and pattern property constraint' => [
                 'alpha',
                 5,
                 <<<ERROR
-                Provided JSON for PatternPropertiesAccessorPostProcessorTest.* contains invalid pattern properties.
+                Provided JSON for 'PatternPropertiesAccessorPostProcessorTest.*' contains invalid pattern properties
                   - invalid property 'alpha' matching pattern '\^a'
-                    \* Value for pattern property must be a multiple of 10
-                Value for alpha must not be smaller than 10
+                    \* Value for 'pattern property' must be a multiple of 10
+                Value for 'alpha' must not be smaller than 10
                 ERROR,
             ],
         ];
@@ -482,7 +482,7 @@ class PatternPropertiesAccessorPostProcessorTest extends AbstractPHPModelGenerat
 
         $this->expectException(AdditionalPropertiesException::class);
         $this->expectExceptionMessageMatches(
-            '/Provided JSON for .* contains not allowed additional properties \[b1\]/',
+            '/Provided JSON for .* contains not allowed additional properties \[\'b1\'\]/',
         );
 
         $object->populate(['a0' => 'Hello', 'b1' => 'not allowed']);

--- a/tests/PostProcessor/PatternPropertiesAccessorPostProcessorTest.php
+++ b/tests/PostProcessor/PatternPropertiesAccessorPostProcessorTest.php
@@ -377,7 +377,7 @@ class PatternPropertiesAccessorPostProcessorTest extends AbstractPHPModelGenerat
             'value declined by property constraint' => [
                 'alpha',
                 0,
-                'Value for \'alpha\' must not be smaller than 10'
+                "Value for 'alpha' must not be smaller than 10"
             ],
             'value declined by pattern property constraint' => [
                 'alpha',
@@ -482,7 +482,7 @@ class PatternPropertiesAccessorPostProcessorTest extends AbstractPHPModelGenerat
 
         $this->expectException(AdditionalPropertiesException::class);
         $this->expectExceptionMessageMatches(
-            '/Provided JSON for .* contains not allowed additional properties \[\'b1\'\]/',
+            "/Provided JSON for .* contains not allowed additional properties \['b1'\]/",
         );
 
         $object->populate(['a0' => 'Hello', 'b1' => 'not allowed']);

--- a/tests/PostProcessor/PopulatePostProcessorTest.php
+++ b/tests/PostProcessor/PopulatePostProcessorTest.php
@@ -99,7 +99,7 @@ class PopulatePostProcessorTest extends AbstractPHPModelGeneratorTestCase
 
         if (!$implicitNull) {
             $this->expectException(InvalidTypeException::class);
-            $this->expectExceptionMessage('Invalid type for age. Requires int, got NULL');
+            $this->expectExceptionMessage('Invalid type for \'age\': requires \'int\', got \'NULL\'');
         }
 
         $object->populate(['age' => null]);
@@ -120,7 +120,7 @@ class PopulatePostProcessorTest extends AbstractPHPModelGeneratorTestCase
         $this->assertSame('Hannes', $object->getName());
 
         $this->expectException(InvalidTypeException::class);
-        $this->expectExceptionMessage('Invalid type for name. Requires string, got NULL');
+        $this->expectExceptionMessage('Invalid type for \'name\': requires \'string\', got \'NULL\'');
 
         $object->populate(['name' => null]);
     }
@@ -160,43 +160,43 @@ class PopulatePostProcessorTest extends AbstractPHPModelGeneratorTestCase
                 ['name' => 'Anne-Marie', 'age' => false],
                 false,
                 PatternException::class,
-                "Value for name doesn't match pattern ^[a-zA-Z]*$"
+                "Value for 'name' does not match pattern '^[a-zA-Z]*$'"
             ],
             'No error collection - first value ok second invalid' => [
                 ['name' => 'Hannes', 'age' => false],
                 false,
                 InvalidTypeException::class,
-                "Invalid type for age. Requires int, got boolean"
+                "Invalid type for 'age': requires 'int', got 'boolean'"
             ],
             'Error collection - first value ok second invalid' => [
                 ['name' => 'Hannes', 'age' => false],
                 true,
                 ErrorRegistryException::class,
-                "Invalid type for age. Requires int, got boolean"
+                "Invalid type for 'age': requires 'int', got 'boolean'"
             ],
             'Error collection - multiple violations' => [
                 ['name' => 'Anne-Marie', 'age' => false],
                 true,
                 ErrorRegistryException::class,
-                "Value for name doesn't match pattern ^[a-zA-Z]*$
-Value for name must not be longer than 8
-Invalid type for age. Requires int, got boolean"
+                "Value for 'name' does not match pattern '^[a-zA-Z]*$'
+Value for 'name' must not be longer than 8
+Invalid type for 'age': requires 'int', got 'boolean'"
             ],
             'Invalid additional property' => [
                 ['numeric' => 9],
                 false,
                 InvalidAdditionalPropertiesException::class,
-                "contains invalid additional properties.
+                "contains invalid additional properties
   - invalid additional property 'numeric'
-    * Invalid type for additional property. Requires string, got integer"
+    * Invalid type for 'additional property': requires 'string', got 'integer'"
             ],
             'Invalid additional property name' => [
                 ['invalid name' => 'Hi'],
                 false,
                 InvalidPropertyNamesException::class,
-                "contains properties with invalid names.
+                "contains properties with invalid names
   - invalid property 'invalid name'
-    * Value for property name doesn't match pattern ^[a-zA-Z]*$"
+    * Value for 'property name' does not match pattern '^[a-zA-Z]*$'"
             ],
             'Too many properties' => [
                 ['additional' => 'Hi', 'another' => 'Ho'],
@@ -245,8 +245,7 @@ Invalid type for age. Requires int, got boolean"
         ?string $expectedException,
         ?string $expectedExceptionMessage,
         array $populateValues,
-    ): void
-    {
+    ): void {
         $this->modifyModelGenerator = static function (ModelGenerator $modelGenerator): void {
             $modelGenerator->addPostProcessor(new PopulatePostProcessor());
             $modelGenerator->addPostProcessor(new class () extends PostProcessor {
@@ -288,7 +287,7 @@ Invalid type for age. Requires int, got boolean"
             ],
             'update not hooked value invalid' => [
                 InvalidTypeException::class,
-                'Invalid type for name. Requires string, got boolean',
+                'Invalid type for \'name\': requires \'string\', got \'boolean\'',
                 ['name' => false],
             ],
             'update hooked value not changed' => [
@@ -303,7 +302,7 @@ Invalid type for age. Requires int, got boolean"
             ],
             'update hooked value invalid' => [
                 InvalidTypeException::class,
-                'Invalid type for age. Requires int, got boolean',
+                'Invalid type for \'age\': requires \'int\', got \'boolean\'',
                 ['age' => false],
             ],
         ];
@@ -378,29 +377,29 @@ Invalid type for age. Requires int, got boolean"
             'Exception Collection' => [
                 (new GeneratorConfiguration())->setCollectErrors(true),
                 <<<ERROR
-                declined by composition constraint.
-                  Requires to match one composition element but matched 2 elements.
+                declined by composition constraint
+                  Requires to match one composition element but matched 2 elements
                   - Composition element #1: Valid
                   - Composition element #2: Valid
                 ERROR,
                 <<<ERROR
-                declined by composition constraint.
-                  Requires to match one composition element but matched 0 elements.
+                declined by composition constraint
+                  Requires to match one composition element but matched 0 elements
                   - Composition element #1: Failed
-                    * Invalid type for stringProperty. Requires string, got integer
+                    * Invalid type for 'stringProperty': requires 'string', got 'integer'
                   - Composition element #2: Failed
-                    * Invalid type for integerProperty. Requires int, got NULL
+                    * Invalid type for 'integerProperty': requires 'int', got 'NULL'
                 ERROR,
             ],
             'Direct Exception' => [
                 (new GeneratorConfiguration())->setCollectErrors(false),
                 <<<ERROR
-                declined by composition constraint.
-                  Requires to match one composition element but matched 2 elements.
+                declined by composition constraint
+                  Requires to match one composition element but matched 2 elements
                 ERROR,
                 <<<ERROR
-                declined by composition constraint.
-                  Requires to match one composition element but matched 0 elements.
+                declined by composition constraint
+                  Requires to match one composition element but matched 0 elements
                 ERROR,
             ],
         ];

--- a/tests/PostProcessor/PopulatePostProcessorTest.php
+++ b/tests/PostProcessor/PopulatePostProcessorTest.php
@@ -99,7 +99,7 @@ class PopulatePostProcessorTest extends AbstractPHPModelGeneratorTestCase
 
         if (!$implicitNull) {
             $this->expectException(InvalidTypeException::class);
-            $this->expectExceptionMessage('Invalid type for \'age\': requires \'int\', got \'NULL\'');
+            $this->expectExceptionMessage("Invalid type for 'age': requires 'int', got 'NULL'");
         }
 
         $object->populate(['age' => null]);
@@ -120,7 +120,7 @@ class PopulatePostProcessorTest extends AbstractPHPModelGeneratorTestCase
         $this->assertSame('Hannes', $object->getName());
 
         $this->expectException(InvalidTypeException::class);
-        $this->expectExceptionMessage('Invalid type for \'name\': requires \'string\', got \'NULL\'');
+        $this->expectExceptionMessage("Invalid type for 'name': requires 'string', got 'NULL'");
 
         $object->populate(['name' => null]);
     }
@@ -178,25 +178,31 @@ class PopulatePostProcessorTest extends AbstractPHPModelGeneratorTestCase
                 ['name' => 'Anne-Marie', 'age' => false],
                 true,
                 ErrorRegistryException::class,
-                "Value for 'name' does not match pattern '^[a-zA-Z]*$'
-Value for 'name' must not be longer than 8
-Invalid type for 'age': requires 'int', got 'boolean'"
+                <<<ERROR
+                Value for 'name' does not match pattern '^[a-zA-Z]*$'
+                Value for 'name' must not be longer than 8
+                Invalid type for 'age': requires 'int', got 'boolean'
+                ERROR,
             ],
             'Invalid additional property' => [
                 ['numeric' => 9],
                 false,
                 InvalidAdditionalPropertiesException::class,
-                "contains invalid additional properties
-  - invalid additional property 'numeric'
-    * Invalid type for 'additional property': requires 'string', got 'integer'"
+                <<<ERROR
+                contains invalid additional properties
+                  - invalid additional property 'numeric'
+                    * Invalid type for 'additional property': requires 'string', got 'integer'
+                ERROR,
             ],
             'Invalid additional property name' => [
                 ['invalid name' => 'Hi'],
                 false,
                 InvalidPropertyNamesException::class,
-                "contains properties with invalid names
-  - invalid property 'invalid name'
-    * Value for 'property name' does not match pattern '^[a-zA-Z]*$'"
+                <<<ERROR
+                contains properties with invalid names
+                  - invalid property 'invalid name'
+                    * Value for 'property name' does not match pattern '^[a-zA-Z]*$'
+                ERROR,
             ],
             'Too many properties' => [
                 ['additional' => 'Hi', 'another' => 'Ho'],
@@ -287,7 +293,7 @@ Invalid type for 'age': requires 'int', got 'boolean'"
             ],
             'update not hooked value invalid' => [
                 InvalidTypeException::class,
-                'Invalid type for \'name\': requires \'string\', got \'boolean\'',
+                "Invalid type for 'name': requires 'string', got 'boolean'",
                 ['name' => false],
             ],
             'update hooked value not changed' => [
@@ -302,7 +308,7 @@ Invalid type for 'age': requires 'int', got 'boolean'"
             ],
             'update hooked value invalid' => [
                 InvalidTypeException::class,
-                'Invalid type for \'age\': requires \'int\', got \'boolean\'',
+                "Invalid type for 'age': requires 'int', got 'boolean'",
                 ['age' => false],
             ],
         ];

--- a/tests/Schema/ComposedIfTest/ConditionalArrayItem.json
+++ b/tests/Schema/ComposedIfTest/ConditionalArrayItem.json
@@ -1,0 +1,32 @@
+{
+  "type": "object",
+  "properties": {
+    "property": {
+      "type": "array",
+      "items": {
+        "if": {
+          "type": "object",
+          "properties": {
+            "kind": {
+              "const": "metric"
+            }
+          },
+          "required": [
+            "kind"
+          ]
+        },
+        "then": {
+          "type": "object",
+          "properties": {
+            "value": {
+              "type": "integer"
+            }
+          },
+          "required": [
+            "value"
+          ]
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Part of the validation-error-message readability work tracked in [issue #131](https://github.com/wol-soft/php-json-schema-model-generator/issues/131).

- `ConstModifier` was the only Draft modifier that added a validator without calling `withJsonPointer(...)`, so `InvalidConstException::getJsonPointer()` always returned an empty pointer while every other constraint — including the sibling `EnumException` for the same `const`/`enum` keyword family — correctly resolved to its schema location. Now calls `->withJsonPointer($propertySchema->getPointer() . '/const')`, matching every other modifier/factory.
- Array-item validators (`ArrayItemValidator`, `ContainsValidatorFactory`) built the literal string `"item of array X"` and used it as the item property's own name, so every exception thrown for an array item's own value carried that description in `getPropertyName()` and in message text, instead of the array's real key. It also doubled as an internal sentinel that `isRequired()` and `PropertyFactory`'s required-validator logic string-matched on. Both call sites now pass the array's real name plus an explicit `isArrayItem` flag through `PropertyFactory::create()` (threaded through its internal call graph the same way `$required` already is), replacing the string-sentinel checks. `Property`/`PropertyProxy` expose `isArrayItem()`/`setArrayItem()` alongside the existing `isRequired()`-style flags.
- Updated every test and doc example asserting the old enum/const `"declined by ... constraint"` wording to match the companion production-library message rewrite (see below).
- Fixed two data-corruption bugs found while adding instance-pointer test coverage for array items nested inside compositions/conditionals: `ComposedItem.phptpl` (allOf/anyOf/oneOf) and `ConditionalComposedItem.phptpl` (if/then/else) both validate through a `&$value` reference shared with the caller (e.g. the enclosing array item), and both unconditionally overwrote that reference with a partially-built/leftover result even when the composition or branch had failed. That corrupted value then leaked into the resulting exception's `getProvidedValue()` and into any sibling validators still to run. Both templates now only ever expose the transformed value on success, restoring the original input on failure. See "Bug fixes" below for details.

**Breaking changes, deliberate**: exception message text and `getPropertyName()` for array items change (e.g. `"item of array goals"` → `"goals"`); enum/const message text becomes self-descriptive. Existing tests asserting the old wording are updated.

## Companion PR

The position information lost by dropping the synthetic array-item name is restored via a new `getInstancePointer()` on `ValidationException` (an RFC 6901 pointer into the *data*, alongside the existing schema-pointing `getJsonPointer()`), and the enum/const message rewrite itself, both added in the companion production-library PR: `wol-soft/php-json-schema-model-generator-production#19`.

**This repo's new test `ArrayPropertyTest::testInvalidTypedArrayItemExposesRealPropertyNameAndInstancePointer` depends on that production PR being merged** — `composer.json` already points at `dev-master` for the production package, so once #19 merges there this test passes with no further change here. Until then it fails in isolation (`getInstancePointer()` doesn't exist on the currently-released production library).

## Bug fixes: data corruption in composition/conditional validators on failure

Found while manually reproducing the instance-pointer scenario for a composition failing inside an array item — the reported `getProvidedValue()` for the nested exception was a corrupted leftover instead of the real input.

- **`ComposedItem.phptpl` (allOf/anyOf/oneOf)**: reassignment of the by-reference `$value` to the last attempted merged/instantiated result was gated only on `is_object($proposedValue)`, never on whether the composition actually succeeded. Fixed by computing `$compositionSatisfied` up front and only exposing the merged/transformed value on success; on failure, `$value` is explicitly reset to the original input.
- **`ConditionalComposedItem.phptpl` (if/then/else)**: the "if" branch already resets `$value` to the original input right after its own check, but a failed then/else branch didn't — it could leave `$value` as a leftover object from a failed nested-instantiation attempt. Fixed by resetting `$value` to the original input whenever the then/else branch failed, without touching the success path (still needed for `hasModifiedValuesMethod` and for a successfully-instantiated branch object to be the correct resulting value).

Two existing tests were asserting on symptoms of these bugs rather than correct behavior, and were updated rather than reverted-around (per this repo's guidance to fix real bugs a test exposes, not narrow the test):
- `Issue105Test::testEnumInComposition` was asserting a native PHP `ValueError` message that had been leaking through from a partially-built merged object on failure; now asserts the correct, clean `AllOfException` message.
- `FilterCompositionRuntimeTest::testAllOfPropertyWithMixedAcceptTransformingFilter` was asserting only 1 error, because the old bug corrupted `$value` to `null` after a failed composition and silently suppressed the downstream transforming filter's own error; now asserts both errors (composition + filter).

New regression tests added: `ArrayPropertyTest::testInvalidCombinedObjectArrayItemPreservesProvidedValueOnTotalCompositionFailure` and `ComposedIfTest::testInvalidConditionalArrayItemPreservesProvidedValueOnThenBranchFailure` (new fixture `tests/Schema/ComposedIfTest/ConditionalArrayItem.json`), each asserting the nested exception's `getProvidedValue()` is the real originally-provided value.

These fixes are entirely within this repo's templates; no production-repo changes were needed for them.

## Wording pass: consistent quoting, no trailing periods

Companion change to the production-library wording pass: quote every interpolated property name, nested key, pattern, filter token, and type name in exception messages so identifiers read distinctly from surrounding prose, and drop trailing periods from message headers that introduce a nested bullet list. Fixes the same grammar issues as the production repo (contraction, article, colon-vs-period splice) plus this repo's own `UnknownPatternPropertyException` message built inline in the generated `PatternPropertiesCompanion` companion class.

Also fixes a gap found while auditing docs for stale wording: `InvalidItemException`'s "Invalid items in array X:" header was never quoted in the initial production-repo sweep (see production PR #19).

Updates every test asserting exact or partial production-library message text, and audits `docs/source/` for hardcoded example exception text affected by this wording change (and, where found in the same files, by the still-unfixed "item of array X" staleness from the array-item-naming change above — fixed in the same pass rather than deferred twice).

## Test plan

- [x] Full suite passes against a local build of the companion production PR (2865 tests).
- [x] No phpcs violations in changed files.
- [ ] Full suite will show failing tests (the instance-pointer integration test, plus every test asserting the old enum/const message text) until the companion production PR merges — expected, not a regression.
