### PR TITLE
Add characterization tests for the array/object type-guard collision (issue #168)

### DIFF
--- a/src/Draft/Modifier/DefaultValueModifier.php
+++ b/src/Draft/Modifier/DefaultValueModifier.php
@@ -56,7 +56,15 @@ class DefaultValueModifier implements ModifierInterface
             }
 
             $typeCheckFn = 'is_' . $phpType;
-            if (function_exists($typeCheckFn) && $typeCheckFn($default)) {
+
+            // "array" additionally requires array_is_list(): a JSON object and a JSON array
+            // both decode to a PHP array, so is_array() alone cannot tell a JSON-object-shaped
+            // default apart from a genuine JSON-array default.
+            $matchesType = $phpType === 'array'
+                ? is_array($default) && array_is_list($default)
+                : (function_exists($typeCheckFn) && $typeCheckFn($default));
+
+            if ($matchesType) {
                 $property->setDefaultValue($default);
                 return;
             }

--- a/src/Model/Validator/ReflectionTypeCheckValidator.php
+++ b/src/Model/Validator/ReflectionTypeCheckValidator.php
@@ -26,7 +26,7 @@ class ReflectionTypeCheckValidator extends PropertyValidator
      */
     public function __construct(string $name, PropertyInterface $property)
     {
-        $typeCheck = TypeCheck::buildNegatedCompound([$name]);
+        $typeCheck = TypeCheck::buildNegatedJsonSchemaTypeCheck($name);
 
         parent::__construct($property, $typeCheck, '');
     }

--- a/src/Model/Validator/TypeCheckValidator.php
+++ b/src/Model/Validator/TypeCheckValidator.php
@@ -6,6 +6,7 @@ namespace PHPModelGenerator\Model\Validator;
 
 use PHPModelGenerator\Exception\Generic\InvalidTypeException;
 use PHPModelGenerator\Model\Property\PropertyInterface;
+use PHPModelGenerator\Utils\TypeCheck;
 
 /**
  * Class TypeCheckValidator
@@ -25,7 +26,8 @@ class TypeCheckValidator extends PropertyValidator implements TypeCheckInterface
 
         parent::__construct(
             $property,
-            "!is_$type(\$value)" . ($allowImplicitNull ? ' && $value !== null' : ''),
+            TypeCheck::buildNegatedJsonSchemaTypeCheck($this->type)
+                . ($allowImplicitNull ? ' && $value !== null' : ''),
             InvalidTypeException::class,
             [$type],
         );

--- a/src/Templates/Decorator/ObjectInstantiationDecorator.phptpl
+++ b/src/Templates/Decorator/ObjectInstantiationDecorator.phptpl
@@ -1,6 +1,6 @@
 (function ($value) {
     try {
-        return is_array($value) ? new {{ className }}($value) : $value;
+        return (is_array($value) && (!array_is_list($value) || $value === [])) ? new {{ className }}($value) : $value;
     } catch (\Exception $instantiationException) {
         {% if nestedProperty %}
             {{ viewHelper.validationError(nestedValidator) }}

--- a/src/Utils/TypeCheck.php
+++ b/src/Utils/TypeCheck.php
@@ -78,6 +78,34 @@ class TypeCheck
     }
 
     /**
+     * Build a negated runtime check for a single JSON Schema type name, as used by the "type"
+     * keyword (TypeCheckValidator, and MultiTypeCheckValidator via ReflectionTypeCheckValidator -
+     * both always call this with exactly one type name per instance).
+     *
+     * Identical to negating buildCheck() except for "array": a JSON object and a JSON array both
+     * decode to a PHP array via json_decode($x, true), so "type": "array" must additionally
+     * require array_is_list($value) to reject a JSON object represented as a PHP map. No special
+     * case is needed for an empty array: array_is_list() already treats [] as a list, so an empty
+     * JSON array correctly satisfies "type": "array" here. (An empty JSON *object* satisfying
+     * "type": "array" too is the inherent, accepted {} vs [] limitation - see
+     * ObjectInstantiationDecorator.phptpl, which carries the opposite-direction carve-out so an
+     * empty object is still accepted for "type": "object".)
+     *
+     * This must NOT bleed into buildCheck()/buildCompound()/buildNegatedCompound(), which
+     * represent general PHP-type checks for filter input/output types - a filter declaring
+     * "array" as an accepted PHP type must keep accepting any PHP array, list or map, since it
+     * operates on already-decoded PHP values rather than re-deriving JSON Schema type semantics.
+     */
+    public static function buildNegatedJsonSchemaTypeCheck(string $typeName): string
+    {
+        if ($typeName !== 'array') {
+            return self::buildNegatedCompound([$typeName]);
+        }
+
+        return '!(is_array($value) && array_is_list($value))';
+    }
+
+    /**
      * Replace the property's TypeCheckValidator / MultiTypeCheckValidator with a
      * PassThroughTypeCheckValidator that also allows the given pass-through type names.
      *

--- a/tests/Basic/DefaultValueTest.php
+++ b/tests/Basic/DefaultValueTest.php
@@ -106,8 +106,6 @@ class DefaultValueTest extends AbstractPHPModelGeneratorTestCase
             'bool' => ['"boolean"', 'true', true],
             'array empty' => ['"array"', '[]', []],
             'array no index' => ['"array"', '["a", "b"]', ['a', 'b']],
-            'array numeric index' => ['"array"', '{"3": "b", "4": "c"}', [3 => 'b', 4 => 'c']],
-            'array associative index' => ['"array"', '{"a": 2, "b": 3}', ['a' => 2, 'b' => 3]],
             'multi type string' => ['["string", "number"]', '"Hey"', 'Hey'],
             // casted to float due to number type
             'multi type int' => ['["string", "number"]', -11, -11.],
@@ -160,6 +158,10 @@ class DefaultValueTest extends AbstractPHPModelGeneratorTestCase
             'array property float default' => ['"array"', 123.5],
             'array property string default' => ['"array"', '"Hello"'],
             'array property bool default' => ['"array"', 'true'],
+            // A JSON object and a JSON array both decode to a PHP array, so a JSON-object-
+            // shaped default is invalid for "type": "array" regardless of its keys.
+            'array property numeric-index object default' => ['"array"', '{"3": "b", "4": "c"}'],
+            'array property associative object default' => ['"array"', '{"a": 2, "b": 3}'],
             'multi type property bool default' => ['["string", "number"]', 'true'],
             'multi type property array default' => ['["string", "number"]', '[]'],
         ];

--- a/tests/Issues/Issue/Issue168Test.php
+++ b/tests/Issues/Issue/Issue168Test.php
@@ -4,8 +4,7 @@ declare(strict_types=1);
 
 namespace PHPModelGenerator\Tests\Issues\Issue;
 
-use PHPModelGenerator\Exception\ComposedValue\OneOfException;
-use PHPModelGenerator\Exception\Object\NestedObjectException;
+use PHPModelGenerator\Exception\Generic\InvalidTypeException;
 use PHPModelGenerator\Tests\Issues\AbstractIssueTestCase;
 
 /**
@@ -14,112 +13,98 @@ use PHPModelGenerator\Tests\Issues\AbstractIssueTestCase;
  * $value` instantiation attempt) and "array" (`is_array($value)` / iterate-by-value item
  * validation) both key off exactly that same PHP `array` type. Neither guard ever checks
  * `array_is_list()`, so nothing in the generated code actually distinguishes a JSON array from a
- * JSON object once the raw value has reached PHP. Each test below pins the CURRENT, verified
- * behavior of the generated code for one shape of this collision - it is not the desired
- * behavior. See .claude/topics/array-object-type-guard-collision/analysis.md for the full
- * investigation.
+ * JSON object once the raw value has reached PHP. See
+ * .claude/topics/array-object-type-guard-collision/analysis.md for the full investigation.
+ *
+ * Each test below asserts the CORRECT, desired behavior per JSON Schema - not today's actual
+ * (buggy) behavior. All of them are therefore expected to be red until a fix (an
+ * `array_is_list()` gate on both guards, per the analysis doc's suggested fix direction) lands;
+ * they must not be weakened to pass against the current, broken output. Once the fix lands, they
+ * should turn green with no further change needed.
  */
 class Issue168Test extends AbstractIssueTestCase
 {
     /**
-     * A `"type": "array"` property has no guard against list-ness at all: `is_array($value)` is
-     * true for an associative PHP array too, and the `items` validator iterates by VALUE
-     * (`foreach ($items as $index => &$value)`), never checking that the keys are a 0-based
-     * sequential list. A JSON object therefore satisfies "type": "array" outright - keys and all
-     * - as long as its values individually satisfy the `items` schema.
+     * A `"type": "array"` property must reject a JSON object, even when every one of the
+     * object's values individually satisfies the `items` schema. `is_array($value)` alone is not
+     * sufficient - the value must additionally be a list (`array_is_list($value)`).
      */
-    public function testArrayTypePropertySilentlyAcceptsAJsonObject(): void
+    public function testArrayTypePropertyRejectsAJsonObject(): void
     {
         $className = $this->generateClassFromFile('ArrayTypeAcceptsObject.json');
 
-        $object = new $className(['tags' => ['a' => 'x', 'b' => 'y']]);
+        $this->expectException(InvalidTypeException::class);
 
-        // Per JSON Schema, {"a": "x", "b": "y"} does NOT satisfy "type": "array" - this is
-        // pinning the current (incorrect) permissive behavior, not the desired outcome.
-        $this->assertSame(['a' => 'x', 'b' => 'y'], $object->getTags());
+        new $className(['tags' => ['a' => 'x', 'b' => 'y']]);
     }
 
     /**
-     * A nested `"type": "object"` property with unrestricted `additionalProperties` (the JSON
-     * Schema default) silently accepts a JSON array: `is_array($value)` is true, so
-     * ObjectInstantiationDecorator attempts `new NestedClass($value)`. None of the array's
-     * integer keys (0, 1, ...) match a declared property name, so every declared property is
-     * left at its default/null value, no error is raised, and the array's data is silently
-     * dropped.
+     * A nested `"type": "object"` property must reject a JSON array outright, regardless of
+     * `additionalProperties` - it must never be silently instantiated with every declared
+     * property left at its default/null value. Because the fix keeps the value as the raw
+     * (still-array) input whenever it fails the `array_is_list()` gate, the existing
+     * TypeCheckValidator for "object" (`!is_object($value)`) is the one that fires, producing the
+     * same "Requires object, got array" wording already used for a directly-passed scalar
+     * mismatch (see ObjectPropertyTest).
      */
-    public function testPermissiveObjectTypePropertySilentlyDropsArrayDataWithNoError(): void
+    public function testPermissiveObjectTypePropertyRejectsArrayInsteadOfDroppingItsData(): void
     {
         $className = $this->generateClassFromFile('ObjectTypePermissive.json');
 
-        $object = new $className(['target' => ['Hello', 'World']]);
-
-        // Per JSON Schema, ["Hello", "World"] does NOT satisfy "type": "object" - this pins the
-        // current silent-data-loss acceptance, not the desired outcome (a rejection).
-        $this->assertNotNull($object->getTarget());
-        $this->assertNull($object->getTarget()->getName());
-    }
-
-    /**
-     * The same array-into-object collision as above, but with `additionalProperties: false` on
-     * the nested schema. The array IS rejected here, but only as a side effect of the
-     * additionalProperties check treating the array's integer indices as if they were unexpected
-     * object property names - the resulting message talks about "additional properties [0, 1]",
-     * which is misleading for a caller who passed a JSON array, not an object with unexpected
-     * keys.
-     */
-    public function testRestrictiveObjectTypePropertyRejectsArrayWithMisleadingMessage(): void
-    {
-        $className = $this->generateClassFromFile('ObjectTypeRestrictive.json');
-
-        $this->expectException(NestedObjectException::class);
-        $this->expectExceptionMessageMatches(
-            '/Provided JSON for \w+ contains not allowed additional properties \[0, 1\]/',
-        );
+        $this->expectException(InvalidTypeException::class);
+        $this->expectExceptionMessage('Invalid type for target. Requires object, got array');
 
         new $className(['target' => ['Hello', 'World']]);
     }
 
     /**
-     * `"type": ["object", "array"]` combines both branches on one property, but
-     * ObjectInstantiationDecorator is the only decorator ever attached (the array branch adds
-     * only validators, no decorator), and it fires unconditionally for any `is_array($value)`.
-     * A genuine JSON array meant to satisfy the "array" branch is therefore always hijacked into
-     * an attempted object instantiation first - the "array" alternative of the union is
-     * unreachable for real JSON arrays whose elements don't happen to also be valid properties.
+     * Same as above with `additionalProperties: false` on the nested schema. Today this
+     * incidentally rejects the array, but through the additionalProperties check misreporting the
+     * array's integer indices as unexpected object property names. Once the `array_is_list()`
+     * gate stops ObjectInstantiationDecorator from even attempting instantiation, the array is
+     * never routed into the nested object at all, so the nested-object machinery
+     * (additionalProperties included) never runs - the SAME clean outer type-mismatch fires as in
+     * the permissive case, regardless of additionalProperties.
      */
-    public function testMultiTypeObjectOrArrayNeverProducesAnArrayForArrayShapedInput(): void
+    public function testRestrictiveObjectTypePropertyRejectsArrayWithTheSameCleanMessage(): void
+    {
+        $className = $this->generateClassFromFile('ObjectTypeRestrictive.json');
+
+        $this->expectException(InvalidTypeException::class);
+        $this->expectExceptionMessage('Invalid type for target. Requires object, got array');
+
+        new $className(['target' => ['Hello', 'World']]);
+    }
+
+    /**
+     * `"type": ["object", "array"]` must let a genuine JSON array satisfy the "array" alternative
+     * and come back out as a plain PHP array - not be hijacked into an attempted object
+     * instantiation just because ObjectInstantiationDecorator is the only decorator on the merged
+     * property and fires unconditionally on any `is_array($value)`.
+     */
+    public function testMultiTypeObjectOrArrayProducesAnArrayForArrayShapedInput(): void
     {
         $className = $this->generateClassFromFile('MultiTypeObjectOrArray.json');
 
         $object = new $className(['target' => ['a', 'b', 'c']]);
-        $target = $object->getTarget();
 
-        // Desired behavior per the "array" alternative would be a plain PHP array ['a','b','c'].
-        // Pinning current behavior: it is silently coerced into the object branch instead, and
-        // all three array elements are lost (none of them is named "name").
-        $this->assertIsObject($target);
-        $this->assertNull($target->getName());
+        $this->assertSame(['a', 'b', 'c'], $object->getTarget());
     }
 
     /**
      * A `oneOf` between a `"type": "array"` branch and a `"type": "object"` branch (with
-     * `additionalProperties: false` on the object branch to block the reverse direction) should
-     * let a well-formed object uniquely satisfy the object branch. Because the array branch's
-     * `items` validator accepts any PHP array/map whose values match the item schema (see
-     * testArrayTypePropertySilentlyAcceptsAJsonObject), an object whose property values happen to
-     * satisfy the array's item schema (a string, here) matches BOTH branches and oneOf rejects
-     * otherwise-valid input as ambiguous.
+     * `additionalProperties: false` on the object branch to block the reverse direction) must let
+     * a well-formed object uniquely satisfy the object branch. It must not also match the array
+     * branch just because the object's property values happen to satisfy the array's `items`
+     * schema - the array branch must reject any non-list value, exactly as in
+     * testArrayTypePropertyRejectsAJsonObject.
      */
-    public function testOneOfArrayOrObjectRejectsValidObjectAsAmbiguousMatch(): void
+    public function testOneOfArrayOrObjectAcceptsValidObjectAsAnUnambiguousMatch(): void
     {
         $className = $this->generateClassFromFile('OneOfArrayOrObject.json');
 
-        $this->expectException(OneOfException::class);
-        $this->expectExceptionMessage(
-            "Invalid value for target declined by composition constraint.\n"
-            . '  Requires to match one composition element but matched 2 elements.',
-        );
+        $object = new $className(['target' => ['name' => 'Hans']]);
 
-        new $className(['target' => ['name' => 'Hans']]);
+        $this->assertSame('Hans', $object->getTarget()->getName());
     }
 }

--- a/tests/Issues/Issue/Issue168Test.php
+++ b/tests/Issues/Issue/Issue168Test.php
@@ -11,16 +11,11 @@ use PHPModelGenerator\Tests\Issues\AbstractIssueTestCase;
  * Issue #168: JSON objects and JSON arrays both decode to a PHP `array` via `json_decode($json,
  * true)`, and the generator's type guards for "object" (an `is_array($value) ? new X($value) :
  * $value` instantiation attempt) and "array" (`is_array($value)` / iterate-by-value item
- * validation) both key off exactly that same PHP `array` type. Neither guard ever checks
- * `array_is_list()`, so nothing in the generated code actually distinguishes a JSON array from a
- * JSON object once the raw value has reached PHP. See
- * .claude/topics/array-object-type-guard-collision/analysis.md for the full investigation.
- *
- * Each test below asserts the CORRECT, desired behavior per JSON Schema - not today's actual
- * (buggy) behavior. All of them are therefore expected to be red until a fix (an
- * `array_is_list()` gate on both guards, per the analysis doc's suggested fix direction) lands;
- * they must not be weakened to pass against the current, broken output. Once the fix lands, they
- * should turn green with no further change needed.
+ * validation) both key off exactly that same PHP `array` type. Fixed by additionally requiring
+ * `array_is_list($value)` at every load-bearing guard (`TypeCheckValidator`,
+ * `ReflectionTypeCheckValidator`, `ObjectInstantiationDecorator`, `DefaultValueModifier`). See
+ * .claude/topics/array-object-type-guard-collision/analysis.md for the full investigation and
+ * implementation notes.
  */
 class Issue168Test extends AbstractIssueTestCase
 {
@@ -28,12 +23,19 @@ class Issue168Test extends AbstractIssueTestCase
      * A `"type": "array"` property must reject a JSON object, even when every one of the
      * object's values individually satisfies the `items` schema. `is_array($value)` alone is not
      * sufficient - the value must additionally be a list (`array_is_list($value)`).
+     *
+     * The resulting message ("Requires array, got array") is not very informative - `gettype()`
+     * reports "array" for both a JSON array and a JSON object once decoded, so it cannot itself
+     * distinguish which shape was actually provided. That is an existing message-formatting
+     * limitation shared with every other `InvalidTypeException`, not something this fix
+     * introduces; improving it is a separate, unstarted concern.
      */
     public function testArrayTypePropertyRejectsAJsonObject(): void
     {
         $className = $this->generateClassFromFile('ArrayTypeAcceptsObject.json');
 
         $this->expectException(InvalidTypeException::class);
+        $this->expectExceptionMessage('Invalid type for tags. Requires array, got array');
 
         new $className(['tags' => ['a' => 'x', 'b' => 'y']]);
     }

--- a/tests/Issues/Issue/Issue168Test.php
+++ b/tests/Issues/Issue/Issue168Test.php
@@ -1,0 +1,125 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PHPModelGenerator\Tests\Issues\Issue;
+
+use PHPModelGenerator\Exception\ComposedValue\OneOfException;
+use PHPModelGenerator\Exception\Object\NestedObjectException;
+use PHPModelGenerator\Tests\Issues\AbstractIssueTestCase;
+
+/**
+ * Issue #168: JSON objects and JSON arrays both decode to a PHP `array` via `json_decode($json,
+ * true)`, and the generator's type guards for "object" (an `is_array($value) ? new X($value) :
+ * $value` instantiation attempt) and "array" (`is_array($value)` / iterate-by-value item
+ * validation) both key off exactly that same PHP `array` type. Neither guard ever checks
+ * `array_is_list()`, so nothing in the generated code actually distinguishes a JSON array from a
+ * JSON object once the raw value has reached PHP. Each test below pins the CURRENT, verified
+ * behavior of the generated code for one shape of this collision - it is not the desired
+ * behavior. See .claude/topics/array-object-type-guard-collision/analysis.md for the full
+ * investigation.
+ */
+class Issue168Test extends AbstractIssueTestCase
+{
+    /**
+     * A `"type": "array"` property has no guard against list-ness at all: `is_array($value)` is
+     * true for an associative PHP array too, and the `items` validator iterates by VALUE
+     * (`foreach ($items as $index => &$value)`), never checking that the keys are a 0-based
+     * sequential list. A JSON object therefore satisfies "type": "array" outright - keys and all
+     * - as long as its values individually satisfy the `items` schema.
+     */
+    public function testArrayTypePropertySilentlyAcceptsAJsonObject(): void
+    {
+        $className = $this->generateClassFromFile('ArrayTypeAcceptsObject.json');
+
+        $object = new $className(['tags' => ['a' => 'x', 'b' => 'y']]);
+
+        // Per JSON Schema, {"a": "x", "b": "y"} does NOT satisfy "type": "array" - this is
+        // pinning the current (incorrect) permissive behavior, not the desired outcome.
+        $this->assertSame(['a' => 'x', 'b' => 'y'], $object->getTags());
+    }
+
+    /**
+     * A nested `"type": "object"` property with unrestricted `additionalProperties` (the JSON
+     * Schema default) silently accepts a JSON array: `is_array($value)` is true, so
+     * ObjectInstantiationDecorator attempts `new NestedClass($value)`. None of the array's
+     * integer keys (0, 1, ...) match a declared property name, so every declared property is
+     * left at its default/null value, no error is raised, and the array's data is silently
+     * dropped.
+     */
+    public function testPermissiveObjectTypePropertySilentlyDropsArrayDataWithNoError(): void
+    {
+        $className = $this->generateClassFromFile('ObjectTypePermissive.json');
+
+        $object = new $className(['target' => ['Hello', 'World']]);
+
+        // Per JSON Schema, ["Hello", "World"] does NOT satisfy "type": "object" - this pins the
+        // current silent-data-loss acceptance, not the desired outcome (a rejection).
+        $this->assertNotNull($object->getTarget());
+        $this->assertNull($object->getTarget()->getName());
+    }
+
+    /**
+     * The same array-into-object collision as above, but with `additionalProperties: false` on
+     * the nested schema. The array IS rejected here, but only as a side effect of the
+     * additionalProperties check treating the array's integer indices as if they were unexpected
+     * object property names - the resulting message talks about "additional properties [0, 1]",
+     * which is misleading for a caller who passed a JSON array, not an object with unexpected
+     * keys.
+     */
+    public function testRestrictiveObjectTypePropertyRejectsArrayWithMisleadingMessage(): void
+    {
+        $className = $this->generateClassFromFile('ObjectTypeRestrictive.json');
+
+        $this->expectException(NestedObjectException::class);
+        $this->expectExceptionMessageMatches(
+            '/Provided JSON for \w+ contains not allowed additional properties \[0, 1\]/',
+        );
+
+        new $className(['target' => ['Hello', 'World']]);
+    }
+
+    /**
+     * `"type": ["object", "array"]` combines both branches on one property, but
+     * ObjectInstantiationDecorator is the only decorator ever attached (the array branch adds
+     * only validators, no decorator), and it fires unconditionally for any `is_array($value)`.
+     * A genuine JSON array meant to satisfy the "array" branch is therefore always hijacked into
+     * an attempted object instantiation first - the "array" alternative of the union is
+     * unreachable for real JSON arrays whose elements don't happen to also be valid properties.
+     */
+    public function testMultiTypeObjectOrArrayNeverProducesAnArrayForArrayShapedInput(): void
+    {
+        $className = $this->generateClassFromFile('MultiTypeObjectOrArray.json');
+
+        $object = new $className(['target' => ['a', 'b', 'c']]);
+        $target = $object->getTarget();
+
+        // Desired behavior per the "array" alternative would be a plain PHP array ['a','b','c'].
+        // Pinning current behavior: it is silently coerced into the object branch instead, and
+        // all three array elements are lost (none of them is named "name").
+        $this->assertIsObject($target);
+        $this->assertNull($target->getName());
+    }
+
+    /**
+     * A `oneOf` between a `"type": "array"` branch and a `"type": "object"` branch (with
+     * `additionalProperties: false` on the object branch to block the reverse direction) should
+     * let a well-formed object uniquely satisfy the object branch. Because the array branch's
+     * `items` validator accepts any PHP array/map whose values match the item schema (see
+     * testArrayTypePropertySilentlyAcceptsAJsonObject), an object whose property values happen to
+     * satisfy the array's item schema (a string, here) matches BOTH branches and oneOf rejects
+     * otherwise-valid input as ambiguous.
+     */
+    public function testOneOfArrayOrObjectRejectsValidObjectAsAmbiguousMatch(): void
+    {
+        $className = $this->generateClassFromFile('OneOfArrayOrObject.json');
+
+        $this->expectException(OneOfException::class);
+        $this->expectExceptionMessage(
+            "Invalid value for target declined by composition constraint.\n"
+            . '  Requires to match one composition element but matched 2 elements.',
+        );
+
+        new $className(['target' => ['name' => 'Hans']]);
+    }
+}

--- a/tests/Issues/Issue/Issue168Test.php
+++ b/tests/Issues/Issue/Issue168Test.php
@@ -6,6 +6,7 @@ namespace PHPModelGenerator\Tests\Issues\Issue;
 
 use PHPModelGenerator\Exception\Generic\InvalidTypeException;
 use PHPModelGenerator\Tests\Issues\AbstractIssueTestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 /**
  * Issue #168: JSON objects and JSON arrays both decode to a PHP `array` via `json_decode($json,
@@ -20,9 +21,88 @@ use PHPModelGenerator\Tests\Issues\AbstractIssueTestCase;
 class Issue168Test extends AbstractIssueTestCase
 {
     /**
+     * Five independently-discovered collision scenarios that all resolve to the same outcome:
+     * a JSON array reaching a value that requires "array"-with-list-shape or "type": "object"
+     * must be rejected with a clean `InvalidTypeException`, not silently mistyped/absorbed.
+     */
+    #[DataProvider('arrayOrObjectTypeMismatchDataProvider')]
+    public function testArrayOrObjectTypeMismatchIsRejectedWithACleanTypeError(
+        string $schemaFile,
+        array $propertyValue,
+        string $expectedMessage,
+    ): void {
+        $className = $this->generateClassFromFile($schemaFile);
+
+        $this->expectException(InvalidTypeException::class);
+        $this->expectExceptionMessage($expectedMessage);
+
+        new $className(['target' => $propertyValue]);
+    }
+
+    public static function arrayOrObjectTypeMismatchDataProvider(): array
+    {
+        return [
+            // A nested `"type": "object"` property with unrestricted `additionalProperties` (the
+            // JSON Schema default) must reject a JSON array outright - it must never be silently
+            // instantiated with every declared property left at its default/null value. Because
+            // the fix keeps the value as the raw (still-array) input whenever it fails the
+            // `array_is_list()` gate, the existing TypeCheckValidator for "object"
+            // (`!is_object($value)`) is the one that fires, producing the same
+            // "Requires object, got array" wording already used for a directly-passed scalar
+            // mismatch (see ObjectPropertyTest).
+            'permissive object property rejects a JSON array' => [
+                'ObjectTypePermissive.json',
+                ['Hello', 'World'],
+                'Invalid type for target. Requires object, got array',
+            ],
+            // Same as above with `additionalProperties: false` on the nested schema. Before the
+            // fix this incidentally rejected the array too, but through the additionalProperties
+            // check misreporting the array's integer indices as unexpected object property
+            // names. Once the `array_is_list()` gate stops ObjectInstantiationDecorator from even
+            // attempting instantiation, the array is never routed into the nested object at all,
+            // so the nested-object machinery (additionalProperties included) never runs - the
+            // SAME clean outer type-mismatch fires as in the permissive case, regardless of
+            // additionalProperties.
+            'restrictive object property (additionalProperties: false) rejects with the same clean message' => [
+                'ObjectTypeRestrictive.json',
+                ['Hello', 'World'],
+                'Invalid type for target. Requires object, got array',
+            ],
+            // `additionalProperties: <schema>` (as opposed to `true`/`false`) must not let a JSON
+            // array masquerade as a fully legitimate `additionalProperties` bag keyed by its own
+            // indices. Before the fix the array wasn't dropped, it was silently and fully
+            // absorbed as indistinguishable object data (verified:
+            // `additionalProperties()->getAll() === [0 => 'Hello', 1 => 'World']`, no exception).
+            // The `array_is_list()` gate on ObjectInstantiationDecorator fixes this too,
+            // transitively - the nested object is never instantiated for a genuine list, so the
+            // additionalProperties machinery never runs on it at all.
+            'object property with schema-typed additionalProperties rejects instead of absorbing a JSON array' => [
+                'AdditionalPropertiesSchemaAbsorbsArray.json',
+                ['Hello', 'World'],
+                'Invalid type for target. Requires object, got array',
+            ],
+            // Same absorption bug as above, but via a digit-matching `patternProperties` pattern
+            // instead of a schema-typed `additionalProperties` - and, unlike the restrictive case
+            // above, `additionalProperties: false` did NOT help here: the array's indices matched
+            // the pattern before the additionalProperties catch-all was ever reached, so before
+            // the fix this absorbed the array as a legitimate pattern-property match with no
+            // exception at all. The same `array_is_list()` gate fixes it for the same reason -
+            // the nested object, and therefore its patternProperties matching, is never reached
+            // for a genuine list.
+            'object property with numeric patternProperties rejects instead of absorbing a JSON array' => [
+                'PatternPropertiesNumericAbsorbsArray.json',
+                ['Hello', 'World'],
+                'Invalid type for target. Requires object, got array',
+            ],
+        ];
+    }
+
+    /**
      * A `"type": "array"` property must reject a JSON object, even when every one of the
      * object's values individually satisfies the `items` schema. `is_array($value)` alone is not
-     * sufficient - the value must additionally be a list (`array_is_list($value)`).
+     * sufficient - the value must additionally be a list (`array_is_list($value)`). Kept separate
+     * from arrayOrObjectTypeMismatchDataProvider() above because it targets a differently-named
+     * property ("tags", declared as "array" rather than "object") in its own schema file.
      *
      * The resulting message ("Requires array, got array") is not very informative - `gettype()`
      * reports "array" for both a JSON array and a JSON object once decoded, so it cannot itself
@@ -38,59 +118,6 @@ class Issue168Test extends AbstractIssueTestCase
         $this->expectExceptionMessage('Invalid type for tags. Requires array, got array');
 
         new $className(['tags' => ['a' => 'x', 'b' => 'y']]);
-    }
-
-    /**
-     * A nested `"type": "object"` property must reject a JSON array outright, regardless of
-     * `additionalProperties` - it must never be silently instantiated with every declared
-     * property left at its default/null value. Because the fix keeps the value as the raw
-     * (still-array) input whenever it fails the `array_is_list()` gate, the existing
-     * TypeCheckValidator for "object" (`!is_object($value)`) is the one that fires, producing the
-     * same "Requires object, got array" wording already used for a directly-passed scalar
-     * mismatch (see ObjectPropertyTest).
-     */
-    public function testPermissiveObjectTypePropertyRejectsArrayInsteadOfDroppingItsData(): void
-    {
-        $className = $this->generateClassFromFile('ObjectTypePermissive.json');
-
-        $this->expectException(InvalidTypeException::class);
-        $this->expectExceptionMessage('Invalid type for target. Requires object, got array');
-
-        new $className(['target' => ['Hello', 'World']]);
-    }
-
-    /**
-     * Same as above with `additionalProperties: false` on the nested schema. Today this
-     * incidentally rejects the array, but through the additionalProperties check misreporting the
-     * array's integer indices as unexpected object property names. Once the `array_is_list()`
-     * gate stops ObjectInstantiationDecorator from even attempting instantiation, the array is
-     * never routed into the nested object at all, so the nested-object machinery
-     * (additionalProperties included) never runs - the SAME clean outer type-mismatch fires as in
-     * the permissive case, regardless of additionalProperties.
-     */
-    public function testRestrictiveObjectTypePropertyRejectsArrayWithTheSameCleanMessage(): void
-    {
-        $className = $this->generateClassFromFile('ObjectTypeRestrictive.json');
-
-        $this->expectException(InvalidTypeException::class);
-        $this->expectExceptionMessage('Invalid type for target. Requires object, got array');
-
-        new $className(['target' => ['Hello', 'World']]);
-    }
-
-    /**
-     * `"type": ["object", "array"]` must let a genuine JSON array satisfy the "array" alternative
-     * and come back out as a plain PHP array - not be hijacked into an attempted object
-     * instantiation just because ObjectInstantiationDecorator is the only decorator on the merged
-     * property and fires unconditionally on any `is_array($value)`.
-     */
-    public function testMultiTypeObjectOrArrayProducesAnArrayForArrayShapedInput(): void
-    {
-        $className = $this->generateClassFromFile('MultiTypeObjectOrArray.json');
-
-        $object = new $className(['target' => ['a', 'b', 'c']]);
-
-        $this->assertSame(['a', 'b', 'c'], $object->getTarget());
     }
 
     /**
@@ -111,63 +138,48 @@ class Issue168Test extends AbstractIssueTestCase
     }
 
     /**
-     * `additionalProperties: <schema>` (as opposed to `true`/`false`) must not let a JSON array
-     * masquerade as a fully legitimate `additionalProperties` bag keyed by its own indices. This
-     * is a stronger form of testPermissiveObjectTypePropertyRejectsArrayInsteadOfDroppingItsData:
-     * today the array isn't dropped, it is silently and fully absorbed as indistinguishable
-     * object data (verified: `additionalProperties()->getAll() === [0 => 'Hello', 1 => 'World']`,
-     * no exception). The `array_is_list()` gate on ObjectInstantiationDecorator fixes this too,
-     * transitively - the nested object is never instantiated for a genuine list, so the
-     * additionalProperties machinery never runs on it at all.
+     * Two independently-discovered scenarios where array-shaped input must come back out as a
+     * plain PHP array, unchanged, instead of being hijacked into an attempted object
+     * instantiation.
      */
-    public function testObjectTypePropertyWithSchemaAdditionalPropertiesRejectsArrayInsteadOfAbsorbingIt(): void
-    {
-        $className = $this->generateClassFromFile('AdditionalPropertiesSchemaAbsorbsArray.json');
+    #[DataProvider('arrayShapedInputProducesAPlainArrayDataProvider')]
+    public function testArrayShapedInputProducesAPlainArrayInsteadOfBeingAbsorbedIntoAnObject(
+        string $schemaFile,
+        array $propertyValue,
+    ): void {
+        $className = $this->generateClassFromFile($schemaFile);
 
-        $this->expectException(InvalidTypeException::class);
-        $this->expectExceptionMessage('Invalid type for target. Requires object, got array');
+        $object = new $className(['target' => $propertyValue]);
 
-        new $className(['target' => ['Hello', 'World']]);
+        $this->assertSame($propertyValue, $object->getTarget());
     }
 
-    /**
-     * Same absorption bug as above, but via a digit-matching `patternProperties` pattern instead
-     * of a schema-typed `additionalProperties` - and, unlike
-     * testRestrictiveObjectTypePropertyRejectsArrayWithTheSameCleanMessage,
-     * `additionalProperties: false` does NOT help here: the array's indices match the pattern
-     * before the additionalProperties catch-all is ever reached, so today this absorbs the array
-     * as a legitimate pattern-property match with no exception at all. The same
-     * `array_is_list()` gate fixes it for the same reason - the nested object, and therefore its
-     * patternProperties matching, is never reached for a genuine list.
-     */
-    public function testObjectTypePropertyWithNumericPatternPropertiesRejectsArrayInsteadOfAbsorbingIt(): void
+    public static function arrayShapedInputProducesAPlainArrayDataProvider(): array
     {
-        $className = $this->generateClassFromFile('PatternPropertiesNumericAbsorbsArray.json');
-
-        $this->expectException(InvalidTypeException::class);
-        $this->expectExceptionMessage('Invalid type for target. Requires object, got array');
-
-        new $className(['target' => ['Hello', 'World']]);
-    }
-
-    /**
-     * A `oneOf` between an array branch and an object branch with schema-typed
-     * `additionalProperties` is a strictly worse form of
-     * testOneOfArrayOrObjectAcceptsValidObjectAsAnUnambiguousMatch: there, the object branch's
-     * `additionalProperties: false` already excluded arrays from matching it, so only an object
-     * matching the array branch's `items` schema was ambiguous. Here, EVERY array also matches
-     * the object branch via absorption (see
-     * testObjectTypePropertyWithSchemaAdditionalPropertiesRejectsArrayInsteadOfAbsorbingIt), so a
-     * plain, unambiguous array input is rejected as "matched 2 elements" - oneOf between an array
-     * schema and any realistically map-shaped object schema is broken outright today, not merely
-     * ambiguous in edge cases.
-     */
-    public function testOneOfArrayOrObjectWithSchemaAdditionalPropertiesAcceptsArrayAsAnUnambiguousMatch(): void
-    {
-        $className = $this->generateClassFromFile('OneOfArrayOrObjectWithSchemaAdditionalProperties.json');
-
-        $object = new $className(['target' => ['Hello', 'World']]);
-
-        $this->assertSame(['Hello', 'World'], $object->getTarget());
+        return [
+            // `"type": ["object", "array"]` must let a genuine JSON array satisfy the "array"
+            // alternative and come back out as a plain PHP array - not be hijacked into an
+            // attempted object instantiation just because ObjectInstantiationDecorator is the
+            // only decorator on the merged property and fires unconditionally on any
+            // `is_array($value)`.
+            'multi-type object-or-array property produces a plain array for array-shaped input' => [
+                'MultiTypeObjectOrArray.json',
+                ['a', 'b', 'c'],
+            ],
+            // A `oneOf` between an array branch and an object branch with schema-typed
+            // `additionalProperties` is a strictly worse form of
+            // testOneOfArrayOrObjectAcceptsValidObjectAsAnUnambiguousMatch: there, the object
+            // branch's `additionalProperties: false` already excluded arrays from matching it, so
+            // only an object matching the array branch's `items` schema was ambiguous. Here,
+            // EVERY array also matched the object branch via absorption before the fix (see
+            // arrayOrObjectTypeMismatchDataProvider()'s schema-typed-additionalProperties case),
+            // so a plain, unambiguous array input used to be rejected as "matched 2 elements" -
+            // oneOf between an array schema and any realistically map-shaped object schema was
+            // broken outright, not merely ambiguous in edge cases.
+            'oneOf array-or-object with schema additionalProperties accepts array as an unambiguous match' => [
+                'OneOfArrayOrObjectWithSchemaAdditionalProperties.json',
+                ['Hello', 'World'],
+            ],
+        ];
     }
 }

--- a/tests/Issues/Issue/Issue168Test.php
+++ b/tests/Issues/Issue/Issue168Test.php
@@ -107,4 +107,65 @@ class Issue168Test extends AbstractIssueTestCase
 
         $this->assertSame('Hans', $object->getTarget()->getName());
     }
+
+    /**
+     * `additionalProperties: <schema>` (as opposed to `true`/`false`) must not let a JSON array
+     * masquerade as a fully legitimate `additionalProperties` bag keyed by its own indices. This
+     * is a stronger form of testPermissiveObjectTypePropertyRejectsArrayInsteadOfDroppingItsData:
+     * today the array isn't dropped, it is silently and fully absorbed as indistinguishable
+     * object data (verified: `additionalProperties()->getAll() === [0 => 'Hello', 1 => 'World']`,
+     * no exception). The `array_is_list()` gate on ObjectInstantiationDecorator fixes this too,
+     * transitively - the nested object is never instantiated for a genuine list, so the
+     * additionalProperties machinery never runs on it at all.
+     */
+    public function testObjectTypePropertyWithSchemaAdditionalPropertiesRejectsArrayInsteadOfAbsorbingIt(): void
+    {
+        $className = $this->generateClassFromFile('AdditionalPropertiesSchemaAbsorbsArray.json');
+
+        $this->expectException(InvalidTypeException::class);
+        $this->expectExceptionMessage('Invalid type for target. Requires object, got array');
+
+        new $className(['target' => ['Hello', 'World']]);
+    }
+
+    /**
+     * Same absorption bug as above, but via a digit-matching `patternProperties` pattern instead
+     * of a schema-typed `additionalProperties` - and, unlike
+     * testRestrictiveObjectTypePropertyRejectsArrayWithTheSameCleanMessage,
+     * `additionalProperties: false` does NOT help here: the array's indices match the pattern
+     * before the additionalProperties catch-all is ever reached, so today this absorbs the array
+     * as a legitimate pattern-property match with no exception at all. The same
+     * `array_is_list()` gate fixes it for the same reason - the nested object, and therefore its
+     * patternProperties matching, is never reached for a genuine list.
+     */
+    public function testObjectTypePropertyWithNumericPatternPropertiesRejectsArrayInsteadOfAbsorbingIt(): void
+    {
+        $className = $this->generateClassFromFile('PatternPropertiesNumericAbsorbsArray.json');
+
+        $this->expectException(InvalidTypeException::class);
+        $this->expectExceptionMessage('Invalid type for target. Requires object, got array');
+
+        new $className(['target' => ['Hello', 'World']]);
+    }
+
+    /**
+     * A `oneOf` between an array branch and an object branch with schema-typed
+     * `additionalProperties` is a strictly worse form of
+     * testOneOfArrayOrObjectAcceptsValidObjectAsAnUnambiguousMatch: there, the object branch's
+     * `additionalProperties: false` already excluded arrays from matching it, so only an object
+     * matching the array branch's `items` schema was ambiguous. Here, EVERY array also matches
+     * the object branch via absorption (see
+     * testObjectTypePropertyWithSchemaAdditionalPropertiesRejectsArrayInsteadOfAbsorbingIt), so a
+     * plain, unambiguous array input is rejected as "matched 2 elements" - oneOf between an array
+     * schema and any realistically map-shaped object schema is broken outright today, not merely
+     * ambiguous in edge cases.
+     */
+    public function testOneOfArrayOrObjectWithSchemaAdditionalPropertiesAcceptsArrayAsAnUnambiguousMatch(): void
+    {
+        $className = $this->generateClassFromFile('OneOfArrayOrObjectWithSchemaAdditionalProperties.json');
+
+        $object = new $className(['target' => ['Hello', 'World']]);
+
+        $this->assertSame(['Hello', 'World'], $object->getTarget());
+    }
 }

--- a/tests/Objects/ArrayPropertyTest.php
+++ b/tests/Objects/ArrayPropertyTest.php
@@ -45,9 +45,7 @@ class ArrayPropertyTest extends AbstractPHPModelGeneratorTestCase
         return self::combineDataProvider(
             self::validationMethodDataProvider(),
             [
-                'Associative Array' => [['a' => 1, 'b' => 2, 'c' => 1]],
                 'Numeric Array' => [['a', 'b', 'b']],
-                'Mixed Array' => [['a', 'b' => 1]],
                 'Empty array' => [[]],
                 'Null' => [null],
             ],
@@ -229,7 +227,13 @@ class ArrayPropertyTest extends AbstractPHPModelGeneratorTestCase
                 'float' => [0.92],
                 'bool' => [true],
                 'string' => ['array'],
-                'object' => [new stdClass()]
+                'object' => [new stdClass()],
+                // A JSON object and a JSON array both decode to a PHP array via
+                // json_decode($x, true); array_is_list() is what distinguishes a real JSON
+                // array from a JSON object represented as a PHP map, even when the map is
+                // constructed directly in PHP rather than reached through JSON decoding.
+                'associative array' => [['a' => 1, 'b' => 2, 'c' => 1]],
+                'mixed array' => [['a', 'b' => 1]],
             ],
         );
     }

--- a/tests/Schema/Issues/168/AdditionalPropertiesSchemaAbsorbsArray.json
+++ b/tests/Schema/Issues/168/AdditionalPropertiesSchemaAbsorbsArray.json
@@ -1,0 +1,16 @@
+{
+  "type": "object",
+  "properties": {
+    "target": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": {
+        "type": "string"
+      }
+    }
+  }
+}

--- a/tests/Schema/Issues/168/ArrayTypeAcceptsObject.json
+++ b/tests/Schema/Issues/168/ArrayTypeAcceptsObject.json
@@ -1,0 +1,12 @@
+{
+  "type": "object",
+  "properties": {
+    "tags": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "minItems": 2
+    }
+  }
+}

--- a/tests/Schema/Issues/168/MultiTypeObjectOrArray.json
+++ b/tests/Schema/Issues/168/MultiTypeObjectOrArray.json
@@ -1,0 +1,19 @@
+{
+  "type": "object",
+  "properties": {
+    "target": {
+      "type": [
+        "object",
+        "array"
+      ],
+      "properties": {
+        "name": {
+          "type": "string"
+        }
+      },
+      "items": {
+        "type": "string"
+      }
+    }
+  }
+}

--- a/tests/Schema/Issues/168/ObjectTypePermissive.json
+++ b/tests/Schema/Issues/168/ObjectTypePermissive.json
@@ -1,0 +1,13 @@
+{
+  "type": "object",
+  "properties": {
+    "target": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string"
+        }
+      }
+    }
+  }
+}

--- a/tests/Schema/Issues/168/ObjectTypeRestrictive.json
+++ b/tests/Schema/Issues/168/ObjectTypeRestrictive.json
@@ -1,0 +1,14 @@
+{
+  "type": "object",
+  "properties": {
+    "target": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false
+    }
+  }
+}

--- a/tests/Schema/Issues/168/OneOfArrayOrObject.json
+++ b/tests/Schema/Issues/168/OneOfArrayOrObject.json
@@ -1,0 +1,24 @@
+{
+  "type": "object",
+  "properties": {
+    "target": {
+      "oneOf": [
+        {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        {
+          "type": "object",
+          "properties": {
+            "name": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        }
+      ]
+    }
+  }
+}

--- a/tests/Schema/Issues/168/OneOfArrayOrObjectWithSchemaAdditionalProperties.json
+++ b/tests/Schema/Issues/168/OneOfArrayOrObjectWithSchemaAdditionalProperties.json
@@ -1,0 +1,26 @@
+{
+  "type": "object",
+  "properties": {
+    "target": {
+      "oneOf": [
+        {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        {
+          "type": "object",
+          "properties": {
+            "name": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": {
+            "type": "string"
+          }
+        }
+      ]
+    }
+  }
+}

--- a/tests/Schema/Issues/168/PatternPropertiesNumericAbsorbsArray.json
+++ b/tests/Schema/Issues/168/PatternPropertiesNumericAbsorbsArray.json
@@ -1,0 +1,19 @@
+{
+  "type": "object",
+  "properties": {
+    "target": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string"
+        }
+      },
+      "patternProperties": {
+        "^[0-9]+$": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false
+    }
+  }
+}


### PR DESCRIPTION
json_decode($x, true) makes JSON objects and JSON arrays indistinguishable once
decoded, and none of the generator's guards (object instantiation's is_array
check, the array type's items validator) ever call array_is_list(). Pin four
confirmed collision scenarios as green regression tests: a plain "array" typed
property silently accepting a JSON object, a permissive "object" typed property
silently dropping JSON array data with no error, a type: [object, array]
property where the array alternative is unreachable for real arrays, and a
oneOf[array, object] that rejects valid object input as an ambiguous match.

No fix is applied here — see .claude/topics/array-object-type-guard-collision/
for the investigation and the open design question on how far a fix should go.