### PR TITLE
Update tests for InvalidTypeException's array/object disambiguation

### DIFF
--- a/tests/Issues/Issue/Issue168Test.php
+++ b/tests/Issues/Issue/Issue168Test.php
@@ -104,18 +104,18 @@ class Issue168Test extends AbstractIssueTestCase
      * from arrayOrObjectTypeMismatchDataProvider() above because it targets a differently-named
      * property ("tags", declared as "array" rather than "object") in its own schema file.
      *
-     * The resulting message ("requires 'array', got 'array'") is not very informative - `gettype()`
-     * reports "array" for both a JSON array and a JSON object once decoded, so it cannot itself
-     * distinguish which shape was actually provided. That is an existing message-formatting
-     * limitation shared with every other `InvalidTypeException`, not something this fix
-     * introduces; improving it is a separate, unstarted concern.
+     * The resulting message reports "got 'object'": `InvalidTypeException` uses
+     * `array_is_list($providedValue)` - the same signal used at every array/object type guard - to
+     * tell a JSON object apart from a JSON array once both have decoded to a PHP array, instead of
+     * relying on `gettype()` alone (which reports "array" for both and previously produced the
+     * uninformative "requires 'array', got 'array'").
      */
     public function testArrayTypePropertyRejectsAJsonObject(): void
     {
         $className = $this->generateClassFromFile('ArrayTypeAcceptsObject.json');
 
         $this->expectException(InvalidTypeException::class);
-        $this->expectExceptionMessage("Invalid type for 'tags': requires 'array', got 'array'");
+        $this->expectExceptionMessage("Invalid type for 'tags': requires 'array', got 'object'");
 
         new $className(['tags' => ['a' => 'x', 'b' => 'y']]);
     }

--- a/tests/Objects/ArrayPropertyTest.php
+++ b/tests/Objects/ArrayPropertyTest.php
@@ -210,10 +210,15 @@ class ArrayPropertyTest extends AbstractPHPModelGeneratorTestCase
         GeneratorConfiguration $configuration,
         mixed $propertyValue,
     ): void {
+        $providedType = match (true) {
+            is_object($propertyValue) => $propertyValue::class,
+            is_array($propertyValue) && !array_is_list($propertyValue) => 'object',
+            default => gettype($propertyValue),
+        };
+
         $this->expectValidationError(
             $configuration,
-            "Invalid type for 'property': requires 'array', got '" .
-                (is_object($propertyValue) ? $propertyValue::class : gettype($propertyValue)) . "'",
+            "Invalid type for 'property': requires 'array', got '{$providedType}'",
         );
 
         $className = $this->generateClassFromFile('ArrayProperty.json', $configuration);

--- a/tests/Objects/TupleArrayPropertyTest.php
+++ b/tests/Objects/TupleArrayPropertyTest.php
@@ -176,7 +176,7 @@ class TupleArrayPropertyTest extends AbstractPHPModelGeneratorTestCase
                     <<<ERROR
                     Invalid tuple item in array 'property':
                       - invalid tuple #1
-                        * Invalid type for 'tuple item #0 of array property': requires 'int', got 'array'
+                        * Invalid type for 'tuple item #0 of array property': requires 'int', got 'object'
                       - invalid tuple #3
                         * Invalid type for 'tuple item #2 of array property': requires 'object', got 'integer'
                     ERROR,


### PR DESCRIPTION
## Summary

- Closes #171: `"type": "array"` properties rejecting a JSON object previously produced the uninformative `"requires 'array', got 'array'"` message, since `gettype()` can't distinguish a JSON array from a JSON object once both have decoded to a plain PHP array.
- The actual fix lives in `InvalidTypeException` (wol-soft/php-json-schema-model-generator-production#20), which now uses `array_is_list()` to report `got 'object'` for a map-shaped array instead of `got 'array'`.
- This PR updates the affected test assertions in this repo and removes the docblock note that framed the ambiguous wording as an unstarted limitation:
  - `tests/Issues/Issue/Issue168Test.php::testArrayTypePropertyRejectsAJsonObject`
  - `tests/Objects/TupleArrayPropertyTest.php` (tuple item type-mismatch case)
  - `tests/Objects/ArrayPropertyTest.php`'s dynamic expected-message builder, updated to mirror the same array_is_list()-based disambiguation

**Note:** this repo's `composer.json` still requires `wol-soft/php-json-schema-model-generator-production: dev-master`, so these test changes will only pass once wol-soft/php-json-schema-model-generator-production#20 is merged.

## Test plan

- [x] Verified against the fixed production branch via a temporary local path-repository override (not committed): full suite (2872 tests, 7443 assertions) passes.
- [x] `phpcs --standard=phpcs.xml` clean on changed files.
- [ ] Re-run CI once wol-soft/php-json-schema-model-generator-production#20 is merged and `dev-master` picks up the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014dgDExk85rnhmW8WVyaTgj

---
_Generated by [Claude Code](https://claude.ai/code/session_014dgDExk85rnhmW8WVyaTgj)_