### PR TITLE
Fix dynamic property creation in composition branch-default reset. Fixes #169

### DIFF
--- a/src/Model/Validator/AbstractComposedPropertyValidator.php
+++ b/src/Model/Validator/AbstractComposedPropertyValidator.php
@@ -94,10 +94,27 @@ abstract class AbstractComposedPropertyValidator extends ExtractedMethodValidato
 
                 $componentDefaultValueMap[$branchIndex][] = $branchProperty->getName();
 
+                $scopeProperty = $this->scope?->getProperty($branchProperty->getName());
+
+                // Only a branch property which was actually transferred onto the containing
+                // schema (root-schema/base compositions, via
+                // SchemaProcessor::transferComposedPropertiesToSchema()) is a real attribute of
+                // $this. A composition on a named property (e.g. `target: {"oneOf": [...]}`)
+                // never transfers its branches' properties — an object-typed branch instead
+                // compiles to its own separate generated class, instantiated as a nested object.
+                // Resetting such a branch-local property (e.g. the internal
+                // `additionalProperties`/`patternProperties` bookkeeping properties) on $this
+                // would create a dynamic property on the wrong object instead of doing nothing,
+                // which is what's correct here: that nested object already initializes its own
+                // default state through its own constructor, so no external reset is needed.
+                if ($scopeProperty === null) {
+                    continue;
+                }
+
                 // Do not include properties that already have a root-level default on the
                 // parent schema — root defaults are applied unconditionally via PHP field
                 // initializers and must not be overwritten or reset by the branch mechanism.
-                if ($this->scope?->getProperty($branchProperty->getName())?->getDefaultValue() !== null) {
+                if ($scopeProperty->getDefaultValue() !== null) {
                     continue;
                 }
 

--- a/tests/Issues/Issue/Issue169Test.php
+++ b/tests/Issues/Issue/Issue169Test.php
@@ -1,0 +1,114 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PHPModelGenerator\Tests\Issues\Issue;
+
+use PHPModelGenerator\ModelGenerator;
+use PHPModelGenerator\SchemaProcessor\PostProcessor\AdditionalPropertiesAccessorPostProcessor;
+use PHPModelGenerator\SchemaProcessor\PostProcessor\PatternPropertiesAccessorPostProcessor;
+use PHPModelGenerator\Tests\Issues\AbstractIssueTestCase;
+
+/**
+ * Issue #169: the composition branch-default reset (`allBranchDefaultAttributeMap`, built in
+ * AbstractComposedPropertyValidator::setupBranchDefaultHelpers() and consumed by
+ * ComposedItem.phptpl / ConditionalComposedItem.phptpl) must only reset attributes that were
+ * actually transferred onto the containing class.
+ *
+ * For a bare (non-object-wrapped) composition property whose matching branch is itself
+ * object-typed, internal bookkeeping properties such as `_additionalProperties` /
+ * `_patternProperties` / `_patternPropertiesMap` are declared on the branch's own generated
+ * class, not on the containing class. Resetting them via `$this->$branchDefaultAttr = ...`
+ * creates a dynamic property on the wrong object — deprecated since PHP 8.2 and a future fatal
+ * error.
+ */
+class Issue169Test extends AbstractIssueTestCase
+{
+    /**
+     * Constructing the object-typed branch of a bare oneOf whose branch declares
+     * `additionalProperties` must not emit a "Creation of dynamic property" deprecation for
+     * `_additionalProperties`, and the additional properties must still be collected correctly
+     * on the branch's own object.
+     */
+    public function testAdditionalPropertiesBranchOfBareOneOfDoesNotCreateDynamicProperty(): void
+    {
+        $this->modifyModelGenerator = static function (ModelGenerator $generator): void {
+            $generator->addPostProcessor(new AdditionalPropertiesAccessorPostProcessor());
+        };
+
+        $className = $this->generateClassFromFile('bareOneOfAdditionalProperties.json');
+
+        $deprecations = [];
+        set_error_handler(static function (int $errno, string $errstr) use (&$deprecations): bool {
+            $deprecations[] = $errstr;
+            return true;
+        });
+
+        try {
+            $object = new $className(['target' => ['name' => 'foo', 'extra' => 'bar']]);
+        } finally {
+            restore_error_handler();
+        }
+
+        $this->assertSame([], $deprecations);
+        $this->assertSame('foo', $object->getTarget()->getName());
+        $this->assertSame(['extra' => 'bar'], $object->getTarget()->additionalProperties()->getAll());
+    }
+
+    /**
+     * The array-typed branch of the same bare oneOf must remain unaffected by the fix: the
+     * sibling object branch's internal bookkeeping properties are simply excluded from the reset
+     * map, they never had anything to do with the array branch's own value.
+     */
+    public function testArrayBranchOfBareOneOfIsUnaffected(): void
+    {
+        $className = $this->generateClassFromFile('bareOneOfAdditionalProperties.json');
+
+        $object = new $className(['target' => ['Hello', 'World']]);
+
+        $this->assertSame(['Hello', 'World'], $object->getTarget());
+    }
+
+    /**
+     * Same bug via `patternProperties` instead of `additionalProperties`: constructing the
+     * object-typed branch must not emit "Creation of dynamic property" deprecations for
+     * `_patternProperties` / `_patternPropertiesMap`, and the pattern-matched property must
+     * still be collected correctly on the branch's own object.
+     */
+    public function testPatternPropertiesBranchOfBareOneOfDoesNotCreateDynamicProperty(): void
+    {
+        $this->modifyModelGenerator = static function (ModelGenerator $generator): void {
+            $generator->addPostProcessor(new PatternPropertiesAccessorPostProcessor());
+        };
+
+        $className = $this->generateClassFromFile('bareOneOfPatternProperties.json');
+
+        $deprecations = [];
+        set_error_handler(static function (int $errno, string $errstr) use (&$deprecations): bool {
+            $deprecations[] = $errstr;
+            return true;
+        });
+
+        try {
+            $object = new $className(['target' => ['name' => 'foo', 'x-custom' => 'bar']]);
+        } finally {
+            restore_error_handler();
+        }
+
+        $this->assertSame([], $deprecations);
+        $this->assertSame('foo', $object->getTarget()->getName());
+        $this->assertSame(['x-custom' => 'bar'], $object->getTarget()->patternProperties()->get('^x-'));
+    }
+
+    /**
+     * The string-typed branch of the same bare oneOf must remain unaffected by the fix.
+     */
+    public function testStringBranchOfBareOneOfIsUnaffected(): void
+    {
+        $className = $this->generateClassFromFile('bareOneOfPatternProperties.json');
+
+        $object = new $className(['target' => 'plain string']);
+
+        $this->assertSame('plain string', $object->getTarget());
+    }
+}

--- a/tests/Schema/Issues/169/bareOneOfAdditionalProperties.json
+++ b/tests/Schema/Issues/169/bareOneOfAdditionalProperties.json
@@ -1,0 +1,26 @@
+{
+  "type": "object",
+  "properties": {
+    "target": {
+      "oneOf": [
+        {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        {
+          "type": "object",
+          "properties": {
+            "name": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": {
+            "type": "string"
+          }
+        }
+      ]
+    }
+  }
+}

--- a/tests/Schema/Issues/169/bareOneOfPatternProperties.json
+++ b/tests/Schema/Issues/169/bareOneOfPatternProperties.json
@@ -1,0 +1,25 @@
+{
+  "type": "object",
+  "properties": {
+    "target": {
+      "oneOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "name": {
+              "type": "string"
+            }
+          },
+          "patternProperties": {
+            "^x-": {
+              "type": "string"
+            }
+          }
+        }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
fixes #169

The branch-default reset in AbstractComposedPropertyValidator::setupBranchDefaultHelpers()
unconditionally included any branch property with a non-null default in
allBranchDefaultAttributeMap, then reset it via `$this->$branchDefaultAttr = ...` in
ComposedItem.phptpl / ConditionalComposedItem.phptpl. For a bare composition property whose
matching branch is object-typed, internal bookkeeping properties like `_additionalProperties`
and `_patternProperties`/`_patternPropertiesMap` are declared on the branch's own generated
class, not on the containing class, so resetting them on $this created a dynamic property
(deprecated since PHP 8.2) instead of doing nothing, as is correct — the branch's own object
already initializes its own default state.

Only include a branch property in the reset map when it was actually transferred onto the
containing schema.