### PR TITLE
Register required as a Draft validator factory on type object

### DIFF
--- a/src/Draft/Draft_07.php
+++ b/src/Draft/Draft_07.php
@@ -35,6 +35,7 @@ use PHPModelGenerator\Model\Validator\Factory\Object\MaxPropertiesValidatorFacto
 use PHPModelGenerator\Model\Validator\Factory\Object\MinPropertiesValidatorFactory;
 use PHPModelGenerator\Model\Validator\Factory\Object\PatternPropertiesValidatorFactory;
 use PHPModelGenerator\Model\Validator\Factory\Object\PropertyNamesValidatorFactory;
+use PHPModelGenerator\Model\Validator\Factory\Object\RequiredValidatorFactory;
 use PHPModelGenerator\Model\Validator\Factory\String\FormatValidatorFactory;
 use PHPModelGenerator\Model\Validator\Factory\String\MaxLengthValidatorFactory;
 use PHPModelGenerator\Model\Validator\Factory\String\MinLengthPropertyValidatorFactory;
@@ -47,6 +48,7 @@ class Draft_07 implements DraftInterface
         return (new DraftBuilder())
             ->addType((new Type('object', false))
                 ->addValidator('properties', new PropertiesValidatorFactory())
+                ->addValidator('required', new RequiredValidatorFactory())
                 ->addValidator('propertyNames', new PropertyNamesValidatorFactory())
                 ->addValidator('patternProperties', new PatternPropertiesValidatorFactory())
                 ->addValidator('additionalProperties', new AdditionalPropertiesValidatorFactory())

--- a/src/Model/Property/CompositionPropertyDecorator.php
+++ b/src/Model/Property/CompositionPropertyDecorator.php
@@ -7,6 +7,10 @@ namespace PHPModelGenerator\Model\Property;
 use PHPModelGenerator\Exception\SchemaException;
 use PHPModelGenerator\Model\SchemaDefinition\JsonSchema;
 use PHPModelGenerator\Model\SchemaDefinition\ResolvedDefinitionsCollection;
+use PHPModelGenerator\Model\Validator\ComposedPropertyValidator;
+use PHPModelGenerator\Model\Validator\InstanceOfValidator;
+use PHPModelGenerator\Model\Validator\PropertyValidatorInterface;
+use PHPModelGenerator\Model\Validator\RequiredPropertyValidator;
 
 /**
  * Class CompositionPropertyDecorator
@@ -80,5 +84,45 @@ class CompositionPropertyDecorator extends PropertyProxy
     public function getBranchSchema(): JsonSchema
     {
         return $this->jsonSchema;
+    }
+
+    /**
+     * @inheritdoc
+     *
+     * A composition branch must not render validators that only make sense for the property as
+     * a whole: RequiredPropertyValidator checks presence of the outer property (already checked
+     * once, outside any branch); ComposedPropertyValidator would re-run nested composition
+     * validation already handled by the nested object's own generated class; InstanceOfValidator
+     * against an empty-property placeholder class would incorrectly reject any object value that
+     * satisfies the branch's actual (unconstrained) semantics.
+     *
+     * Filtering here — at render time, without mutating the wrapped property's own validator
+     * list — keeps the exclusion branch-local. The wrapped property may be shared (via
+     * PropertyProxy's underlying-property delegation) with a completely different use of the same
+     * $ref definition, e.g. as a directly required property elsewhere; that other use must keep
+     * its own RequiredPropertyValidator intact.
+     */
+    public function getOrderedValidators(): array
+    {
+        $nestedSchema = $this->getNestedSchema();
+
+        return array_values(array_filter(
+            parent::getOrderedValidators(),
+            static function (PropertyValidatorInterface $validator) use ($nestedSchema): bool {
+                if (is_a($validator, RequiredPropertyValidator::class)) {
+                    return false;
+                }
+
+                if (is_a($validator, ComposedPropertyValidator::class)) {
+                    return false;
+                }
+
+                return !(
+                    is_a($validator, InstanceOfValidator::class)
+                    && $nestedSchema !== null
+                    && empty($nestedSchema->getProperties())
+                );
+            },
+        ));
     }
 }

--- a/src/Model/Validator.php
+++ b/src/Model/Validator.php
@@ -36,7 +36,7 @@ class Validator
     /**
      * The schema keyword (e.g. 'pattern', 'minimum') that caused this validator to be added,
      * as determined by the Draft modifier registry. Null for validators not produced by a
-     * Draft AbstractValidatorFactory (e.g. TypeCheckValidator, RequiredPropertyValidator).
+     * Draft AbstractValidatorFactory (e.g. TypeCheckValidator).
      */
     public function getSourceKey(): ?string
     {

--- a/src/Model/Validator/Factory/Composition/AbstractCompositionValidatorFactory.php
+++ b/src/Model/Validator/Factory/Composition/AbstractCompositionValidatorFactory.php
@@ -12,12 +12,8 @@ use PHPModelGenerator\Model\Property\PropertyInterface;
 use PHPModelGenerator\Model\Property\PropertyType;
 use PHPModelGenerator\Model\Schema;
 use PHPModelGenerator\Model\SchemaDefinition\JsonSchema;
-use PHPModelGenerator\Model\Validator;
-use PHPModelGenerator\Model\Validator\ComposedPropertyValidator;
 use PHPModelGenerator\Model\Validator\Factory\AbstractValidatorFactory;
-use PHPModelGenerator\Model\Validator\InstanceOfValidator;
 use PHPModelGenerator\Model\Validator\PropertyValidator;
-use PHPModelGenerator\Model\Validator\RequiredPropertyValidator;
 use PHPModelGenerator\PropertyProcessor\Decorator\TypeHint\ClearTypeHintDecorator;
 use PHPModelGenerator\PropertyProcessor\Decorator\TypeHint\CompositionTypeHintDecorator;
 use PHPModelGenerator\PropertyProcessor\Filter\CompositionCompatibilityChecker;
@@ -191,34 +187,12 @@ abstract class AbstractCompositionValidatorFactory extends AbstractValidatorFact
                 ),
             );
 
+            // RequiredPropertyValidator/ComposedPropertyValidator/InstanceOfValidator-for-empty-
+            // object exclusion for this branch is handled by
+            // CompositionPropertyDecorator::getOrderedValidators() at render time, not here —
+            // see that method's docblock for why it must not be a destructive, schema-processing-
+            // time filterValidators() call.
             $compositionProperty->onResolve(function () use ($compositionProperty, $property, $merged): void {
-                $nestedSchema = $compositionProperty->getNestedSchema();
-
-                $compositionProperty->filterValidators(
-                    static function (Validator $validator) use ($nestedSchema): bool {
-                        if (is_a($validator->getValidator(), RequiredPropertyValidator::class)) {
-                            return false;
-                        }
-                        if (is_a($validator->getValidator(), ComposedPropertyValidator::class)) {
-                            return false;
-                        }
-                        // An empty object schema ({type: object} with no declared properties)
-                        // must accept any PHP object in composition context. The generated
-                        // placeholder class carries no semantic constraints, so the strict
-                        // instanceof check against it would incorrectly reject valid objects
-                        // (e.g. a DateTime produced by a transforming filter) that are perfectly
-                        // acceptable under the schema's actual semantics.
-                        if (
-                            is_a($validator->getValidator(), InstanceOfValidator::class)
-                            && $nestedSchema !== null
-                            && empty($nestedSchema->getProperties())
-                        ) {
-                            return false;
-                        }
-                        return true;
-                    },
-                );
-
                 if (!($merged && $compositionProperty->getNestedSchema())) {
                     $property->addTypeHintDecorator(new CompositionTypeHintDecorator($compositionProperty));
                 }
@@ -259,13 +233,10 @@ abstract class AbstractCompositionValidatorFactory extends AbstractValidatorFact
 
         $presenceCheck = "array_key_exists('" . addslashes($property->getName()) . "', \$modelData)";
 
+        // RequiredPropertyValidator/ComposedPropertyValidator exclusion for this branch is
+        // handled by CompositionPropertyDecorator::getOrderedValidators() at render time.
         $branchProperty->onResolve(
             function () use ($branchProperty, $presenceCheck): void {
-                $branchProperty->filterValidators(
-                    static fn(Validator $validator): bool =>
-                        !is_a($validator->getValidator(), RequiredPropertyValidator::class) &&
-                        !is_a($validator->getValidator(), ComposedPropertyValidator::class),
-                );
                 $branchProperty->addValidator(
                     new PropertyValidator(
                         $branchProperty,
@@ -308,15 +279,10 @@ abstract class AbstractCompositionValidatorFactory extends AbstractValidatorFact
 
         $branchProperty->markAsAlwaysTrueBranch();
 
-        $branchProperty->onResolve(function () use ($branchProperty): void {
-            $branchProperty->filterValidators(
-                static fn(Validator $validator): bool =>
-                    !is_a($validator->getValidator(), RequiredPropertyValidator::class) &&
-                    !is_a($validator->getValidator(), ComposedPropertyValidator::class),
-            );
-            // No validator added — true schema always succeeds.
-            // No type hint decorator — true schema contributes no type constraint.
-        });
+        // No validator added — true schema always succeeds.
+        // No type hint decorator — true schema contributes no type constraint.
+        // RequiredPropertyValidator/ComposedPropertyValidator exclusion for this branch is
+        // handled by CompositionPropertyDecorator::getOrderedValidators() at render time.
 
         return $branchProperty;
     }

--- a/src/Model/Validator/Factory/Object/PropertiesValidatorFactory.php
+++ b/src/Model/Validator/Factory/Object/PropertiesValidatorFactory.php
@@ -11,15 +11,14 @@ use PHPModelGenerator\Model\Property\PropertyInterface;
 use PHPModelGenerator\Model\Schema;
 use PHPModelGenerator\Model\SchemaDefinition\JsonSchema;
 use PHPModelGenerator\Model\Validator\Factory\AbstractValidatorFactory;
-use PHPModelGenerator\Model\Validator\PropertyDependencyValidator;
 use PHPModelGenerator\Model\Validator\PropertyValidator;
-use PHPModelGenerator\Model\Validator\SchemaDependencyValidator;
-use PHPModelGenerator\PropertyProcessor\Decorator\SchemaNamespaceTransferDecorator;
 use PHPModelGenerator\PropertyProcessor\PropertyFactory;
 use PHPModelGenerator\SchemaProcessor\SchemaProcessor;
 
 class PropertiesValidatorFactory extends AbstractValidatorFactory
 {
+    use PropertyDependencyTrait;
+
     /**
      * @throws SchemaException
      */
@@ -34,11 +33,6 @@ class PropertiesValidatorFactory extends AbstractValidatorFactory
         $propertyFactory = new PropertyFactory();
 
         $json[$this->key] ??= [];
-        // Setup empty properties for required properties which aren't defined in the properties section
-        $json[$this->key] += array_fill_keys(
-            array_diff($json['required'] ?? [], array_keys($json[$this->key])),
-            [],
-        );
 
         $propertySchema = $propertySchema->withJson($json);
 
@@ -123,68 +117,6 @@ class PropertiesValidatorFactory extends AbstractValidatorFactory
             }
 
             $schema->addProperty($nestedProperty);
-        }
-    }
-
-    /**
-     * @throws SchemaException
-     */
-    private function addDependencyValidator(
-        PropertyInterface $property,
-        JsonSchema $dependencyJsonSchema,
-        SchemaProcessor $schemaProcessor,
-        Schema $schema,
-    ): void {
-        $propertyDependency = true;
-
-        foreach ($dependencyJsonSchema->getJson() as $index => $dependency) {
-            if (!is_int($index) || !is_string($dependency)) {
-                $propertyDependency = false;
-                break;
-            }
-        }
-
-        $dependencyPointer = $dependencyJsonSchema->getPointer();
-
-        if ($propertyDependency) {
-            $property->addValidator(
-                (new PropertyDependencyValidator($property, $dependencyJsonSchema->getJson()))
-                    ->withJsonPointer($dependencyPointer),
-            );
-
-            return;
-        }
-
-        $json = $dependencyJsonSchema->getJson();
-        if (!isset($json['type'])) {
-            $dependencyJsonSchema = $dependencyJsonSchema->withJson($json + ['type' => 'object']);
-        }
-
-        $dependencySchema = $schemaProcessor->processSchema(
-            $dependencyJsonSchema,
-            $schema->getClassPath(),
-            "{$schema->getClassName()}_{$property->getName()}_Dependency",
-            $schema->getSchemaDictionary(),
-        );
-
-        $property->addValidator(
-            (new SchemaDependencyValidator($schemaProcessor, $property, $dependencySchema))
-                ->withJsonPointer($dependencyPointer),
-        );
-        $schema->addNamespaceTransferDecorator(new SchemaNamespaceTransferDecorator($dependencySchema));
-
-        $this->transferDependentPropertiesToBaseSchema($dependencySchema, $schema);
-    }
-
-    private function transferDependentPropertiesToBaseSchema(Schema $dependencySchema, Schema $schema): void
-    {
-        foreach ($dependencySchema->getProperties() as $dependencyProperty) {
-            $schema->addProperty(
-                (clone $dependencyProperty)
-                    ->setRequired(false)
-                    ->setType(null)
-                    ->filterValidators(static fn(): bool => false),
-            );
         }
     }
 }

--- a/src/Model/Validator/Factory/Object/PropertyDependencyTrait.php
+++ b/src/Model/Validator/Factory/Object/PropertyDependencyTrait.php
@@ -1,0 +1,85 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PHPModelGenerator\Model\Validator\Factory\Object;
+
+use PHPModelGenerator\Exception\SchemaException;
+use PHPModelGenerator\Model\Property\PropertyInterface;
+use PHPModelGenerator\Model\Schema;
+use PHPModelGenerator\Model\SchemaDefinition\JsonSchema;
+use PHPModelGenerator\Model\Validator\PropertyDependencyValidator;
+use PHPModelGenerator\Model\Validator\SchemaDependencyValidator;
+use PHPModelGenerator\PropertyProcessor\Decorator\SchemaNamespaceTransferDecorator;
+use PHPModelGenerator\SchemaProcessor\SchemaProcessor;
+
+/**
+ * Attaches a property or schema dependency (the 'dependencies' keyword) to a property.
+ * Shared by PropertiesValidatorFactory and RequiredValidatorFactory, as a property's
+ * 'dependencies' entry applies regardless of whether the property was declared in 'properties'
+ * or only exists because it is listed in 'required'.
+ */
+trait PropertyDependencyTrait
+{
+    /**
+     * @throws SchemaException
+     */
+    private function addDependencyValidator(
+        PropertyInterface $property,
+        JsonSchema $dependencyJsonSchema,
+        SchemaProcessor $schemaProcessor,
+        Schema $schema,
+    ): void {
+        $propertyDependency = true;
+
+        foreach ($dependencyJsonSchema->getJson() as $index => $dependency) {
+            if (!is_int($index) || !is_string($dependency)) {
+                $propertyDependency = false;
+                break;
+            }
+        }
+
+        $dependencyPointer = $dependencyJsonSchema->getPointer();
+
+        if ($propertyDependency) {
+            $property->addValidator(
+                (new PropertyDependencyValidator($property, $dependencyJsonSchema->getJson()))
+                    ->withJsonPointer($dependencyPointer),
+            );
+
+            return;
+        }
+
+        $json = $dependencyJsonSchema->getJson();
+        if (!isset($json['type'])) {
+            $dependencyJsonSchema = $dependencyJsonSchema->withJson($json + ['type' => 'object']);
+        }
+
+        $dependencySchema = $schemaProcessor->processSchema(
+            $dependencyJsonSchema,
+            $schema->getClassPath(),
+            "{$schema->getClassName()}_{$property->getName()}_Dependency",
+            $schema->getSchemaDictionary(),
+        );
+
+        $property->addValidator(
+            (new SchemaDependencyValidator($schemaProcessor, $property, $dependencySchema))
+                ->withJsonPointer($dependencyPointer),
+        );
+        $schema->addNamespaceTransferDecorator(new SchemaNamespaceTransferDecorator($dependencySchema));
+
+        $this->transferDependentPropertiesToBaseSchema($dependencySchema, $schema);
+    }
+
+    private function transferDependentPropertiesToBaseSchema(Schema $dependencySchema, Schema $schema): void
+    {
+        foreach ($dependencySchema->getProperties() as $dependencyProperty) {
+            $schema->addProperty(
+                (clone $dependencyProperty)
+                    ->setRequired(false)
+                    ->setType(null)
+                    ->filterValidators(static fn(): bool => false),
+            );
+        }
+    }
+}

--- a/src/Model/Validator/Factory/Object/RequiredValidatorFactory.php
+++ b/src/Model/Validator/Factory/Object/RequiredValidatorFactory.php
@@ -1,0 +1,94 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PHPModelGenerator\Model\Validator\Factory\Object;
+
+use PHPModelGenerator\Exception\SchemaException;
+use PHPModelGenerator\Model\Property\PropertyInterface;
+use PHPModelGenerator\Model\Schema;
+use PHPModelGenerator\Model\SchemaDefinition\JsonSchema;
+use PHPModelGenerator\Model\Validator\Factory\AbstractValidatorFactory;
+use PHPModelGenerator\Model\Validator\RequiredPropertyValidator;
+use PHPModelGenerator\PropertyProcessor\PropertyFactory;
+use PHPModelGenerator\SchemaProcessor\SchemaProcessor;
+
+/**
+ * Attaches a RequiredPropertyValidator to every property named in the object schema's 'required'
+ * list. Fabricates an empty-schema stub property for a required name that isn't declared in
+ * 'properties' — PropertiesValidatorFactory only creates properties for names it finds in
+ * 'properties'.
+ *
+ * Must run after PropertiesValidatorFactory (registered later in the object Type's modifier
+ * list): a name denied via 'properties'/<name> === false that is also required is rejected by
+ * PropertiesValidatorFactory before this factory runs, so a name missing from $schema here always
+ * means "not declared in 'properties' at all", never "denied".
+ */
+class RequiredValidatorFactory extends AbstractValidatorFactory
+{
+    use PropertyDependencyTrait;
+
+    /**
+     * @throws SchemaException
+     */
+    public function modify(
+        SchemaProcessor $schemaProcessor,
+        Schema $schema,
+        PropertyInterface $property,
+        JsonSchema $propertySchema,
+    ): void {
+        $json = $propertySchema->getJson();
+
+        foreach ($json[$this->key] ?? [] as $propertyName) {
+            $requiredProperty = $schema->getProperty((string) $propertyName)
+                ?? $this->createUndeclaredProperty($schemaProcessor, $schema, $propertySchema, (string) $propertyName);
+
+            $requiredProperty->addValidator(
+                (new RequiredPropertyValidator($requiredProperty))
+                    ->withJsonPointer($propertySchema->getPointer() . '/' . $this->key),
+                1,
+            );
+        }
+    }
+
+    /**
+     * @throws SchemaException
+     */
+    private function createUndeclaredProperty(
+        SchemaProcessor $schemaProcessor,
+        Schema $schema,
+        JsonSchema $propertySchema,
+        string $propertyName,
+    ): PropertyInterface {
+        // navigate() cannot traverse into a path segment that doesn't exist in the raw JSON; use
+        // withPointer() to advance the pointer without descending into JSON content.
+        $nestedPropertySchema = $propertySchema
+            ->withPointer(
+                $propertySchema->getPointer() . '/properties/' . JsonSchema::encodePointer($propertyName),
+            )
+            ->withJson([]);
+
+        $nestedProperty = (new PropertyFactory())->create(
+            $schemaProcessor,
+            $schema,
+            $propertyName,
+            $nestedPropertySchema,
+            true,
+        );
+
+        $dependencies = $propertySchema->getJson()['dependencies'][$propertyName] ?? null;
+
+        if ($dependencies !== null) {
+            $this->addDependencyValidator(
+                $nestedProperty,
+                $schema->getJsonSchema()->navigate('dependencies/' . JsonSchema::encodePointer($propertyName)),
+                $schemaProcessor,
+                $schema,
+            );
+        }
+
+        $schema->addProperty($nestedProperty);
+
+        return $nestedProperty;
+    }
+}

--- a/src/PropertyProcessor/PropertyFactory.php
+++ b/src/PropertyProcessor/PropertyFactory.php
@@ -26,7 +26,6 @@ use PHPModelGenerator\Model\Property\PropertyType;
 use PHPModelGenerator\Model\Schema;
 use PHPModelGenerator\Model\SchemaDefinition\JsonSchema;
 use PHPModelGenerator\Model\Validator\MultiTypeCheckValidator;
-use PHPModelGenerator\Model\Validator\RequiredPropertyValidator;
 use PHPModelGenerator\Model\Validator\TypeCheckInterface;
 use PHPModelGenerator\PropertyProcessor\Decorator\Property\PropertyTransferDecorator;
 use PHPModelGenerator\PropertyProcessor\Decorator\SchemaNamespaceTransferDecorator;
@@ -265,18 +264,6 @@ class PropertyFactory
 
         if (isset($json['examples']) && is_array($json['examples'])) {
             $property->setExamples($json['examples']);
-        }
-
-        if ($required && !$isArrayItem) {
-            // Compute the parent object schema pointer by stripping '<name>/properties' (last two
-            // path segments) from the property pointer, then appending the 'required' keyword.
-            $propertyPointer = $propertySchema->getPointer();
-            $segments = $propertyPointer !== '' ? explode('/', ltrim($propertyPointer, '/')) : [];
-            $parentPointer = count($segments) > 2 ? '/' . implode('/', array_slice($segments, 0, -2)) : '';
-            $property->addValidator(
-                (new RequiredPropertyValidator($property))->withJsonPointer($parentPointer . '/required'),
-                1,
-            );
         }
 
         $configuration = $schemaProcessor->getGeneratorConfiguration();

--- a/tests/Objects/RequiredPropertyTest.php
+++ b/tests/Objects/RequiredPropertyTest.php
@@ -5,8 +5,10 @@ declare(strict_types=1);
 namespace PHPModelGenerator\Tests\Objects;
 
 use PHPModelGenerator\Exception\ComposedValue\AllOfException;
+use PHPModelGenerator\Exception\Dependency\InvalidPropertyDependencyException;
 use PHPModelGenerator\Exception\ErrorRegistryException;
 use PHPModelGenerator\Exception\FileSystemException;
+use PHPModelGenerator\Exception\Generic\InvalidTypeException;
 use PHPModelGenerator\Exception\Object\NestedObjectException;
 use PHPModelGenerator\Exception\Object\RequiredValueException;
 use PHPModelGenerator\Exception\RenderException;
@@ -261,6 +263,98 @@ class RequiredPropertyTest extends AbstractPHPModelGeneratorTestCase
             $this->assertInstanceOf(RequiredValueException::class, $inner);
             /** @var RequiredValueException $inner */
             $this->assertSame('/properties/address/required', $inner->getJsonPointer()->pointer);
+        }
+    }
+
+    /**
+     * A required property with no entry in 'properties' gets an empty-schema stub fabricated by
+     * RequiredValidatorFactory. That stub must still pick up a 'dependencies' entry for its own
+     * name, exactly like a declared property would.
+     */
+    public function testRequiredUndeclaredPropertyStubStillPicksUpDependency(): void
+    {
+        $className = $this->generateClassFromFile(
+            'RequiredUndeclaredPropertyWithDependency.json',
+            (new GeneratorConfiguration())->setCollectErrors(false),
+        );
+
+        $object = new $className(['credit_card' => 12345, 'billing_address' => '555 Debitors Lane']);
+        $this->assertSame('555 Debitors Lane', $object->getBillingAddress());
+    }
+
+    public function testRequiredUndeclaredPropertyMissingThrowsRequiredValueException(): void
+    {
+        $className = $this->generateClassFromFile(
+            'RequiredUndeclaredPropertyWithDependency.json',
+            (new GeneratorConfiguration())->setCollectErrors(false),
+        );
+
+        $this->expectException(RequiredValueException::class);
+        $this->expectExceptionMessageMatches("/Missing required value for 'credit_card'/");
+
+        new $className(['billing_address' => '555 Debitors Lane']);
+    }
+
+    public function testRequiredUndeclaredPropertyDependencyNotSatisfiedThrowsAnException(): void
+    {
+        $className = $this->generateClassFromFile(
+            'RequiredUndeclaredPropertyWithDependency.json',
+            (new GeneratorConfiguration())->setCollectErrors(false),
+        );
+
+        try {
+            new $className(['credit_card' => 12345]);
+            $this->fail('Expected InvalidPropertyDependencyException');
+        } catch (InvalidPropertyDependencyException $exception) {
+            $this->assertSame(
+                <<<ERROR
+                Missing required attributes which are dependants of 'credit_card':
+                  - 'billing_address'
+                ERROR,
+                $exception->getMessage(),
+            );
+        }
+    }
+
+    /**
+     * 'a' and 'b' both reference the same $ref definition and are both required, so
+     * SchemaDefinition::resolveReference reuses the same underlying resolved property for 'a'
+     * and for b's allOf branch (the cache key is path+required+dependencies, and both match
+     * here). RequiredValidatorFactory attaches 'a's RequiredPropertyValidator to that shared
+     * property; it must not leak into b's allOf branch validation — which shares the same
+     * underlying property via PropertyProxy delegation — as a duplicate required check.
+     *
+     * A regression here previously showed up as the allOf branch reporting an extra, spurious
+     * RequiredValueException for 'b' (rebound to display 'b' via PropertyProxy::getOrderedValidators()
+     * even though it originated from 'a') alongside the genuine InvalidTypeException for the
+     * missing (null) value.
+     */
+    public function testRequiredPropertySharedRefDoesNotLeakIntoAllOfBranch(): void
+    {
+        $className = $this->generateClassFromFile(
+            'RequiredPropertySharedRefInAllOfBranch.json',
+            (new GeneratorConfiguration())->setCollectErrors(true),
+        );
+
+        try {
+            new $className(['a' => 'x']);
+            $this->fail('Expected ErrorRegistryException');
+        } catch (ErrorRegistryException $registryException) {
+            $allOfException = array_values(array_filter(
+                $registryException->getErrors(),
+                static fn($error): bool => $error instanceof AllOfException,
+            ))[0] ?? null;
+            $this->assertInstanceOf(AllOfException::class, $allOfException);
+
+            $branchErrors = $allOfException->getCompositionErrorCollection()[0]->getErrors();
+            $this->assertCount(
+                1,
+                $branchErrors,
+                "The allOf branch must report only the type mismatch for the missing 'b', not a "
+                    . "duplicate required-value error leaked from the shared \$ref definition "
+                    . "used directly by 'a'",
+            );
+            $this->assertInstanceOf(InvalidTypeException::class, $branchErrors[0]);
         }
     }
 }

--- a/tests/Schema/RequiredPropertyTest/RequiredPropertySharedRefInAllOfBranch.json
+++ b/tests/Schema/RequiredPropertyTest/RequiredPropertySharedRefInAllOfBranch.json
@@ -1,0 +1,24 @@
+{
+  "type": "object",
+  "definitions": {
+    "thing": {
+      "type": "string"
+    }
+  },
+  "properties": {
+    "a": {
+      "$ref": "#/definitions/thing"
+    },
+    "b": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/thing"
+        }
+      ]
+    }
+  },
+  "required": [
+    "a",
+    "b"
+  ]
+}

--- a/tests/Schema/RequiredPropertyTest/RequiredUndeclaredPropertyWithDependency.json
+++ b/tests/Schema/RequiredPropertyTest/RequiredUndeclaredPropertyWithDependency.json
@@ -1,0 +1,16 @@
+{
+  "type": "object",
+  "properties": {
+    "billing_address": {
+      "type": "string"
+    }
+  },
+  "required": [
+    "credit_card"
+  ],
+  "dependencies": {
+    "credit_card": [
+      "billing_address"
+    ]
+  }
+}


### PR DESCRIPTION
Closes #172

## Summary

- `required` had no entry in the object `Type`'s keyword registry; its only effect (attaching `RequiredPropertyValidator`) was hardcoded inside `PropertyFactory::buildProperty()`, bypassing the modifier/`sourceKey` system every other keyword goes through, with a fragile pointer reconstructed by string-splitting the property's own JSON pointer.
- Add `RequiredValidatorFactory`, registered under `'required'` on the object `Type` right after `'properties'`. It attaches `RequiredPropertyValidator` to each named required property (now using the parent schema's own pointer directly — no reconstruction needed) and fabricates a stub property for a required name that isn't declared in `'properties'`.
- Extract the shared dependency-attachment logic `PropertiesValidatorFactory` and `RequiredValidatorFactory` both need into `PropertyDependencyTrait`, since a `dependencies` entry can target a required-but-undeclared property name.
- The per-property required boolean used for nullability/attribute decisions at construction time stays computed in `PropertiesValidatorFactory`, since several modifiers (`TypeCheckModifier`, `ConstModifier`, `DefaultArrayToEmptyArrayModifier`, `EnumValidatorFactory`) read `isRequired()` synchronously while that same property is being built — deferring it would break existing null-rejection behavior for required properties.

## Test plan

- [x] Full test suite passes (2872 tests, 0 failures)
- [x] `phpcs --standard=phpcs.xml` clean on all changed/new files
- [x] Verified no regression by diffing full suite results against a clean checkout of the same base
