### PR TITLE
Render generated code PSR-12 compatible

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     ],
     "require": {
         "wol-soft/php-json-schema-model-generator-production": "dev-master",
-        "wol-soft/php-micro-template": "^1.11.0",
+        "wol-soft/php-micro-template": "^1.12.0",
         "psr/log": "^3.0",
 
         "php": ">=8.4",

--- a/src/Draft/Modifier/ConstModifier.php
+++ b/src/Draft/Modifier/ConstModifier.php
@@ -34,12 +34,12 @@ class ConstModifier implements ModifierInterface
 
         $check = match (true) {
             $property->isRequired()
-                => '$value !== ' . var_export($json['const'], true),
+                => '$value !== ' . RenderHelper::varExportArray($json['const']),
             $schemaProcessor->getGeneratorConfiguration()->isImplicitNullAllowed() && !$property->isRequired()
                 => '!in_array($value, ' . RenderHelper::varExportArray([$json['const'], null]) . ', true)',
             default
                 => "array_key_exists('" . addslashes($property->getName()) . "', \$modelData) && \$value !== "
-                    . var_export($json['const'], true),
+                    . RenderHelper::varExportArray($json['const']),
         };
 
         $property->addValidator(

--- a/src/Model/Attributes/PhpAttribute.php
+++ b/src/Model/Attributes/PhpAttribute.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace PHPModelGenerator\Model\Attributes;
 
+use PHPModelGenerator\Utils\RenderHelper;
+
 final class PhpAttribute
 {
     public const int JSON_POINTER = 1;
@@ -53,7 +55,7 @@ final class PhpAttribute
 
         $args = [];
         foreach ($this->arguments as $key => $value) {
-            $value = var_export($value, true);
+            $value = RenderHelper::varExportArray($value);
             $args[] = is_string($key) ? "$key: $value" : $value;
         }
 

--- a/src/Model/Property/Property.php
+++ b/src/Model/Property/Property.php
@@ -13,6 +13,7 @@ use PHPModelGenerator\Model\Validator;
 use PHPModelGenerator\Model\Validator\PropertyValidatorInterface;
 use PHPModelGenerator\PropertyProcessor\Decorator\Property\PropertyDecoratorInterface;
 use PHPModelGenerator\PropertyProcessor\Decorator\TypeHint\TypeHintDecoratorInterface;
+use PHPModelGenerator\Utils\RenderHelper;
 
 /**
  * Class Property
@@ -354,7 +355,9 @@ class Property extends AbstractProperty
      */
     public function setDefaultValue($defaultValue, bool $raw = false): PropertyInterface
     {
-        $this->defaultValue = $defaultValue !== null && !$raw ? var_export($defaultValue, true) : $defaultValue;
+        $this->defaultValue = $defaultValue !== null && !$raw
+            ? RenderHelper::varExportArray($defaultValue)
+            : $defaultValue;
 
         return $this;
     }

--- a/src/Model/RenderJob.php
+++ b/src/Model/RenderJob.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace PHPModelGenerator\Model;
 
 use PHPMicroTemplate\Exception\PHPMicroTemplateException;
-use PHPMicroTemplate\Render;
 use PHPModelGenerator\Attributes\Internal;
 use PHPModelGenerator\Exception\FileSystemException;
 use PHPModelGenerator\Exception\RenderException;
@@ -14,6 +13,7 @@ use PHPModelGenerator\Model\Attributes\PhpAttribute;
 use PHPModelGenerator\Model\Validator\AbstractComposedPropertyValidator;
 use PHPModelGenerator\SchemaProcessor\Hook\SchemaHookResolver;
 use PHPModelGenerator\SchemaProcessor\PostProcessor\PostProcessor;
+use PHPModelGenerator\Utils\RenderFactory;
 use PHPModelGenerator\Utils\RenderHelper;
 
 /**
@@ -113,7 +113,7 @@ class RenderJob
         );
 
         try {
-            $class = (new Render(__DIR__ . '/../Templates/', 4))->renderTemplate(
+            $class = RenderFactory::create(__DIR__ . '/../Templates/')->renderTemplate(
                 'Model.phptpl',
                 [
                     'namespace'                         => $namespace,

--- a/src/Model/RenderJob.php
+++ b/src/Model/RenderJob.php
@@ -113,7 +113,7 @@ class RenderJob
         );
 
         try {
-            $class = (new Render(__DIR__ . '/../Templates/'))->renderTemplate(
+            $class = (new Render(__DIR__ . '/../Templates/', 4))->renderTemplate(
                 'Model.phptpl',
                 [
                     'namespace'                         => $namespace,
@@ -140,7 +140,7 @@ class RenderJob
             // @codeCoverageIgnoreEnd
         }
 
-        return $class;
+        return RenderHelper::collapseBlankLines($class);
     }
 
     /**

--- a/src/Model/Validator/AbstractComposedPropertyValidator.php
+++ b/src/Model/Validator/AbstractComposedPropertyValidator.php
@@ -6,6 +6,7 @@ namespace PHPModelGenerator\Model\Validator;
 
 use PHPModelGenerator\Model\Property\CompositionPropertyDecorator;
 use PHPModelGenerator\SchemaProcessor\PostProcessor\RenderedMethod;
+use PHPModelGenerator\Utils\RenderHelper;
 
 /**
  * Class AbstractComposedPropertyValidator
@@ -71,7 +72,7 @@ abstract class AbstractComposedPropertyValidator extends ExtractedMethodValidato
         $this->templateValues['hasModifiedValuesMethod'] = $hasNestedSchemaWithProperties;
 
         if (!$hasNestedSchemaWithProperties) {
-            $this->templateValues['allBranchDefaultAttributeMap'] = var_export([], true);
+            $this->templateValues['allBranchDefaultAttributeMap'] = RenderHelper::varExportArray([]);
 
             return false;
         }
@@ -122,7 +123,9 @@ abstract class AbstractComposedPropertyValidator extends ExtractedMethodValidato
             }
         }
 
-        $this->templateValues['allBranchDefaultAttributeMap'] = var_export($allBranchDefaultAttributeMap, true);
+        $this->templateValues['allBranchDefaultAttributeMap'] = RenderHelper::varExportArray(
+            $allBranchDefaultAttributeMap,
+        );
         $this->templateValues['modifiedValuesMethod'] = $this->modifiedValuesMethod;
 
         $this->scope->addMethod(
@@ -133,8 +136,8 @@ abstract class AbstractComposedPropertyValidator extends ExtractedMethodValidato
                 'GetModifiedValues.phptpl',
                 [
                     'modifiedValuesMethod' => $this->modifiedValuesMethod,
-                    'componentDefaultValueMap' => var_export($componentDefaultValueMap, true),
-                    'propertyAccessors' => var_export($propertyAccessors, true),
+                    'componentDefaultValueMap' => RenderHelper::varExportArray($componentDefaultValueMap),
+                    'propertyAccessors' => RenderHelper::varExportArray($propertyAccessors),
                 ],
             ),
         );

--- a/src/Model/Validator/AdditionalPropertiesValidator.php
+++ b/src/Model/Validator/AdditionalPropertiesValidator.php
@@ -103,9 +103,9 @@ class AdditionalPropertiesValidator extends PropertyTemplateValidator
      */
     public function getValidatorSetUp(): string
     {
-        return '
+        return <<<'CODE'
             $properties = $value;
             $invalidProperties = [];
-        ';
+            CODE;
     }
 }

--- a/src/Model/Validator/ComposedPropertyValidator.php
+++ b/src/Model/Validator/ComposedPropertyValidator.php
@@ -8,6 +8,7 @@ use PHPModelGenerator\Model\GeneratorConfiguration;
 use PHPModelGenerator\Model\Property\CompositionPropertyDecorator;
 use PHPModelGenerator\Model\Property\PropertyInterface;
 use PHPModelGenerator\Model\Validator;
+use PHPModelGenerator\Utils\RenderHelper;
 
 /**
  * Class ComposedPropertyValidator
@@ -27,11 +28,47 @@ class ComposedPropertyValidator extends AbstractComposedPropertyValidator
         $this->initModifiedValuesMethod();
         $this->isResolved = true;
 
+        $schema = $validatorVariables['schema'];
+
         parent::__construct(
             $generatorConfiguration,
             $property,
             DIRECTORY_SEPARATOR . 'Validator' . DIRECTORY_SEPARATOR . 'ComposedItem.phptpl',
-            array_merge($validatorVariables, ['modifiedValuesMethod' => $this->modifiedValuesMethod]),
+            array_merge($validatorVariables, [
+                'modifiedValuesMethod' => $this->modifiedValuesMethod,
+                // Rendered as its own template and embedded via viewHelper.indent() instead of being inlined
+                // directly: the shared per-composition-element validation body sits at a different real nesting
+                // depth depending on whether isMutableBaseValidator holds (it wraps the body in an extra
+                // "} else {" for its cache-check) - one literal indentation can't be correct for both, so the
+                // body is written once, at its own canonical depth, and the two call sites in ComposedItem.phptpl
+                // each indent the rendered result to their own real depth. Rendered once per composition
+                // property, so it must be a closure invoked from inside the {% foreach %} loop rather than a
+                // value precomputed here.
+                'renderComposedItemBody' => function (
+                    $compositionProperty,
+                    $isMutableBaseValidator,
+                    $hasModifiedValuesMethod,
+                    $modifiedValuesMethod,
+                    $postPropose,
+                ) use (
+                    $schema,
+                    $generatorConfiguration,
+                ): string {
+                    return $this->getRenderer()->renderTemplate(
+                        DIRECTORY_SEPARATOR . 'Validator' . DIRECTORY_SEPARATOR . 'ComposedItemBody.phptpl',
+                        [
+                            'compositionProperty' => $compositionProperty,
+                            'schema' => $schema,
+                            'generatorConfiguration' => $generatorConfiguration,
+                            'viewHelper' => new RenderHelper($generatorConfiguration),
+                            'isMutableBaseValidator' => $isMutableBaseValidator,
+                            'hasModifiedValuesMethod' => $hasModifiedValuesMethod,
+                            'modifiedValuesMethod' => $modifiedValuesMethod,
+                            'postPropose' => $postPropose,
+                        ],
+                    );
+                },
+            ]),
             $exceptionClass,
             ['&$succeededCompositionElements', '&$compositionErrorCollection'],
         );

--- a/src/Model/Validator/ComposedPropertyValidator.php
+++ b/src/Model/Validator/ComposedPropertyValidator.php
@@ -58,10 +58,10 @@ class ComposedPropertyValidator extends AbstractComposedPropertyValidator
      */
     public function getValidatorSetUp(): string
     {
-        return '
+        return <<<'CODE'
             $succeededCompositionElements = 0;
             $compositionErrorCollection = [];
-        ';
+            CODE;
     }
 
     /**

--- a/src/Model/Validator/ContentValidator.php
+++ b/src/Model/Validator/ContentValidator.php
@@ -33,14 +33,16 @@ class ContentValidator extends AbstractPropertyValidator
     public function getCheck(): string
     {
         return sprintf(
-            'is_string($value) && (function () use ($value, &$contentValidatorException): bool {
-                try {
-                    \%s::validate($value);
-                } catch (\Throwable $contentValidatorException) {
-                    return true;
-                }
-                return false;
-            })()',
+            <<<'CODE'
+                is_string($value) && (function () use ($value, &$contentValidatorException): bool {
+                    try {
+                        \%s::validate($value);
+                    } catch (\Throwable $contentValidatorException) {
+                        return true;
+                    }
+                    return false;
+                })()
+                CODE,
             $this->validator::class,
         );
     }

--- a/src/Model/Validator/ExtractedMethodValidator.php
+++ b/src/Model/Validator/ExtractedMethodValidator.php
@@ -71,11 +71,13 @@ abstract class ExtractedMethodValidator extends PropertyTemplateValidator
                 ],
             );
         } catch (PHPMicroTemplateException $exception) {
+            // @codeCoverageIgnoreStart
             throw new RenderException(
                 "Can't render extracted method {$this->getExtractedMethodName()}",
                 0,
                 $exception,
             );
+            // @codeCoverageIgnoreEnd
         }
     }
 

--- a/src/Model/Validator/ExtractedMethodValidator.php
+++ b/src/Model/Validator/ExtractedMethodValidator.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace PHPModelGenerator\Model\Validator;
 
+use PHPMicroTemplate\Exception\PHPMicroTemplateException;
+use PHPModelGenerator\Exception\RenderException;
 use PHPModelGenerator\Model\GeneratorConfiguration;
 use PHPModelGenerator\Model\MethodInterface;
 use PHPModelGenerator\Model\Property\PropertyInterface;
@@ -45,16 +47,36 @@ abstract class ExtractedMethodValidator extends PropertyTemplateValidator
 
             public function getCode(): string
             {
-                $renderHelper = new RenderHelper($this->generatorConfiguration);
-                return "private function {$this->validator->getExtractedMethodName()}(&\$value, \$modelData): void {
-                    {$this->validator->getValidatorSetUp()}
-                    
-                    if ({$this->validator->getCheck()}) {
-                        {$renderHelper->validationError($this->validator)}
-                    }
-                }";
+                return $this->validator->renderExtractedMethod($this->generatorConfiguration);
             }
         };
+    }
+
+    /**
+     * @throws RenderException
+     */
+    public function renderExtractedMethod(GeneratorConfiguration $generatorConfiguration): string
+    {
+        $renderHelper = new RenderHelper($generatorConfiguration);
+
+        try {
+            return $this->getRenderer()->renderTemplate(
+                DIRECTORY_SEPARATOR . 'Validator' . DIRECTORY_SEPARATOR . 'ExtractedMethod.phptpl',
+                [
+                    'methodName' => $this->getExtractedMethodName(),
+                    'setUp' => $this->getValidatorSetUp(),
+                    'check' => $this->getCheck(),
+                    'errorHandling' => $renderHelper->validationError($this),
+                    'viewHelper' => $renderHelper,
+                ],
+            );
+        } catch (PHPMicroTemplateException $exception) {
+            throw new RenderException(
+                "Can't render extracted method {$this->getExtractedMethodName()}",
+                0,
+                $exception,
+            );
+        }
     }
 
     public function getExtractedMethodName(): string

--- a/src/Model/Validator/Factory/Object/MaxPropertiesValidatorFactory.php
+++ b/src/Model/Validator/Factory/Object/MaxPropertiesValidatorFactory.php
@@ -12,15 +12,16 @@ use PHPModelGenerator\Model\Validator\PropertyValidatorInterface;
 
 class MaxPropertiesValidatorFactory extends SimpleBaseValidatorFactory
 {
-    private const string COUNT_PROPERTIES =
-        'count(
+    private const string COUNT_PROPERTIES = <<<'CODE'
+        count(
             array_unique(
                 array_merge(
                     array_keys($this->_rawModelDataInput),
                     array_keys($modelData),
                 )
             ),
-        )';
+        )
+        CODE;
 
     protected function isValueValid(mixed $value): bool
     {

--- a/src/Model/Validator/Factory/Object/MinPropertiesValidatorFactory.php
+++ b/src/Model/Validator/Factory/Object/MinPropertiesValidatorFactory.php
@@ -13,15 +13,16 @@ use PHPModelGenerator\Model\Validator\PropertyValidatorInterface;
 
 class MinPropertiesValidatorFactory extends SimpleBaseValidatorFactory
 {
-    private const string COUNT_PROPERTIES =
-        'count(
+    private const string COUNT_PROPERTIES = <<<'CODE'
+        count(
             array_unique(
                 array_merge(
                     array_keys($this->_rawModelDataInput),
                     array_keys($modelData),
                 )
             ),
-        )';
+        )
+        CODE;
 
     protected function isValueValid(mixed $value): bool
     {

--- a/src/Model/Validator/FilterValidator.php
+++ b/src/Model/Validator/FilterValidator.php
@@ -59,7 +59,7 @@ class FilterValidator extends PropertyTemplateValidator
                     : '',
                 'filterClass' => $this->filter->getFilter()[0],
                 'filterMethod' => $this->filter->getFilter()[1],
-                'filterOptions' => var_export($this->filterOptions, true),
+                'filterOptions' => RenderHelper::varExportArray($this->filterOptions),
                 'filterValueValidator' => new PropertyValidator(
                     $property,
                     '',

--- a/src/Model/Validator/ForbiddenPatternPropertiesValidator.php
+++ b/src/Model/Validator/ForbiddenPatternPropertiesValidator.php
@@ -43,10 +43,10 @@ class ForbiddenPatternPropertiesValidator extends AbstractPropertyValidator
 
     public function getValidatorSetUp(): string
     {
-        return '
+        return <<<'CODE'
             $properties = $value;
             $invalidProperties = [];
-        ';
+            CODE;
     }
 
     public function getCheck(): string
@@ -63,7 +63,9 @@ class ForbiddenPatternPropertiesValidator extends AbstractPropertyValidator
                     }
                     \$invalidProperties[\$propertyKey] = [
                         new \PHPModelGenerator\Exception\Generic\DeniedPropertyException(
-                            \$propertyValue, \$propertyKey, '$escapedPointer'
+                            \$propertyValue,
+                            \$propertyKey,
+                            '$escapedPointer',
                         ),
                     ];
                 }

--- a/src/Model/Validator/PatternPropertiesValidator.php
+++ b/src/Model/Validator/PatternPropertiesValidator.php
@@ -97,9 +97,9 @@ class PatternPropertiesValidator extends PropertyTemplateValidator
      */
     public function getValidatorSetUp(): string
     {
-        return '
+        return <<<'CODE'
             $properties = $value;
             $invalidProperties = [];
-        ';
+            CODE;
     }
 }

--- a/src/Model/Validator/PropertyTemplateValidator.php
+++ b/src/Model/Validator/PropertyTemplateValidator.php
@@ -58,11 +58,13 @@ class PropertyTemplateValidator extends AbstractPropertyValidator
     public function getCheck(): string
     {
         try {
-            return $this->getRenderer()->renderTemplate(
+            // trailing whitespace carries no meaning for a PHP expression check, but a template ending on its own
+            // line (the common case) would otherwise leave a blank line behind wherever the check gets embedded
+            return rtrim($this->getRenderer()->renderTemplate(
                 $this->template,
                 // make sure the current bound property is available in the template
                 $this->templateValues + ['property' => $this->property],
-            );
+            ));
         } catch (PHPMicroTemplateException $exception) {
             throw new RenderException("Can't render property validation template {$this->template}", 0, $exception);
         }
@@ -73,6 +75,7 @@ class PropertyTemplateValidator extends AbstractPropertyValidator
         if (!self::$renderer) {
             self::$renderer = new Render(
                 join(DIRECTORY_SEPARATOR, [__DIR__, '..', '..', 'Templates']) . DIRECTORY_SEPARATOR,
+                4,
             );
         }
 

--- a/src/Model/Validator/PropertyTemplateValidator.php
+++ b/src/Model/Validator/PropertyTemplateValidator.php
@@ -9,6 +9,7 @@ use PHPMicroTemplate\Render;
 use PHPModelGenerator\Exception\RenderException;
 use PHPModelGenerator\Model\Property\PropertyInterface;
 use PHPModelGenerator\Model\Schema;
+use PHPModelGenerator\Utils\RenderFactory;
 
 /**
  * Class PropertyTemplateValidator
@@ -21,8 +22,6 @@ class PropertyTemplateValidator extends AbstractPropertyValidator
     protected $templateValues;
     /** @var Schema|null */
     protected $scope;
-
-    private static ?Render $renderer = null;
 
     /**
      * PropertyTemplateValidator constructor.
@@ -72,13 +71,8 @@ class PropertyTemplateValidator extends AbstractPropertyValidator
 
     protected function getRenderer(): Render
     {
-        if (!self::$renderer) {
-            self::$renderer = new Render(
-                join(DIRECTORY_SEPARATOR, [__DIR__, '..', '..', 'Templates']) . DIRECTORY_SEPARATOR,
-                4,
-            );
-        }
-
-        return self::$renderer;
+        return RenderFactory::create(
+            join(DIRECTORY_SEPARATOR, [__DIR__, '..', '..', 'Templates']) . DIRECTORY_SEPARATOR,
+        );
     }
 }

--- a/src/Model/Validator/SchemaDependencyValidator.php
+++ b/src/Model/Validator/SchemaDependencyValidator.php
@@ -29,19 +29,32 @@ class SchemaDependencyValidator extends PropertyTemplateValidator
     {
         $this->isResolved = true;
 
+        $generatorConfiguration = $schemaProcessor->getGeneratorConfiguration();
+
+        $nestedProperty = (new Property("{$property->getName()}Dependency", null, $schema->getJsonSchema()))
+            ->addDecorator(new ObjectInstantiationDecorator($schema->getClassName(), $generatorConfiguration));
+
         parent::__construct(
             $property,
             DIRECTORY_SEPARATOR . 'Validator' . DIRECTORY_SEPARATOR . 'SchemaDependency.phptpl',
             [
-                'viewHelper' => new RenderHelper($schemaProcessor->getGeneratorConfiguration()),
-                'generatorConfiguration' => $schemaProcessor->getGeneratorConfiguration(),
-                'transferProperties' => $schema->getProperties(),
-                // set up a helper property for handling of the nested object
-                'nestedProperty' => (new Property("{$property->getName()}Dependency", null, $schema->getJsonSchema()))
-                    ->addDecorator(new ObjectInstantiationDecorator(
-                        $schema->getClassName(),
-                        $schemaProcessor->getGeneratorConfiguration(),
-                    ))
+                'viewHelper' => new RenderHelper($generatorConfiguration),
+                'generatorConfiguration' => $generatorConfiguration,
+                'nestedProperty' => $nestedProperty,
+                // Rendered as its own template and embedded via viewHelper.indent() instead of being inlined
+                // directly: the shared validation body sits at a different real nesting depth depending on
+                // whether collectErrors() wraps it in a bare block or a try {} - one literal indentation can't
+                // be correct for both, so the body is written once, at its own canonical depth, and the two
+                // call sites in SchemaDependency.phptpl each indent the rendered result to their own real depth.
+                'renderSchemaDependencyBody' => function () use ($generatorConfiguration, $nestedProperty): string {
+                    return $this->getRenderer()->renderTemplate(
+                        DIRECTORY_SEPARATOR . 'Validator' . DIRECTORY_SEPARATOR . 'SchemaDependencyBody.phptpl',
+                        [
+                            'viewHelper' => new RenderHelper($generatorConfiguration),
+                            'nestedProperty' => $nestedProperty,
+                        ],
+                    );
+                },
             ],
             InvalidSchemaDependencyException::class,
             ['&$dependencyException'],

--- a/src/PropertyProcessor/Decorator/Property/ObjectInstantiationDecorator.php
+++ b/src/PropertyProcessor/Decorator/Property/ObjectInstantiationDecorator.php
@@ -4,11 +4,11 @@ declare(strict_types=1);
 
 namespace PHPModelGenerator\PropertyProcessor\Decorator\Property;
 
-use PHPMicroTemplate\Render;
 use PHPModelGenerator\Exception\Object\NestedObjectException;
 use PHPModelGenerator\Model\GeneratorConfiguration;
 use PHPModelGenerator\Model\Property\PropertyInterface;
 use PHPModelGenerator\Model\Validator\PropertyValidator;
+use PHPModelGenerator\Utils\RenderFactory;
 use PHPModelGenerator\Utils\RenderHelper;
 
 /**
@@ -18,20 +18,11 @@ use PHPModelGenerator\Utils\RenderHelper;
  */
 class ObjectInstantiationDecorator implements PropertyDecoratorInterface
 {
-    /** @var Render */
-    protected static $renderer;
-
     /**
      * ObjectInstantiationDecorator constructor.
      */
     public function __construct(protected string $className, protected GeneratorConfiguration $generatorConfiguration)
     {
-        if (!static::$renderer) {
-            static::$renderer = new Render(
-                join(DIRECTORY_SEPARATOR, [__DIR__, '..', '..', '..', 'Templates']) . DIRECTORY_SEPARATOR,
-                4,
-            );
-        }
     }
 
     /**
@@ -39,7 +30,9 @@ class ObjectInstantiationDecorator implements PropertyDecoratorInterface
      */
     public function decorate(string $input, PropertyInterface $property, bool $nestedProperty): string
     {
-        return static::$renderer->renderTemplate(
+        return RenderFactory::create(
+            join(DIRECTORY_SEPARATOR, [__DIR__, '..', '..', '..', 'Templates']) . DIRECTORY_SEPARATOR,
+        )->renderTemplate(
             DIRECTORY_SEPARATOR . 'Decorator' . DIRECTORY_SEPARATOR . 'ObjectInstantiationDecorator.phptpl',
             [
                 'input' => $input,

--- a/src/PropertyProcessor/Decorator/Property/ObjectInstantiationDecorator.php
+++ b/src/PropertyProcessor/Decorator/Property/ObjectInstantiationDecorator.php
@@ -29,6 +29,7 @@ class ObjectInstantiationDecorator implements PropertyDecoratorInterface
         if (!static::$renderer) {
             static::$renderer = new Render(
                 join(DIRECTORY_SEPARATOR, [__DIR__, '..', '..', '..', 'Templates']) . DIRECTORY_SEPARATOR,
+                4,
             );
         }
     }

--- a/src/PropertyProcessor/Filter/FilterPreTransformGuardValidator.php
+++ b/src/PropertyProcessor/Filter/FilterPreTransformGuardValidator.php
@@ -97,11 +97,13 @@ final class FilterPreTransformGuardValidator extends ExtractedMethodValidator
                 ],
             );
         } catch (PHPMicroTemplateException $exception) {
+            // @codeCoverageIgnoreStart
             throw new RenderException(
                 "Can't render filter pre-transform guard {$this->getExtractedMethodName()}",
                 0,
                 $exception,
             );
+            // @codeCoverageIgnoreEnd
         }
     }
 }

--- a/src/PropertyProcessor/Filter/FilterPreTransformGuardValidator.php
+++ b/src/PropertyProcessor/Filter/FilterPreTransformGuardValidator.php
@@ -4,12 +4,15 @@ declare(strict_types=1);
 
 namespace PHPModelGenerator\PropertyProcessor\Filter;
 
+use PHPMicroTemplate\Exception\PHPMicroTemplateException;
+use PHPModelGenerator\Exception\RenderException;
 use PHPModelGenerator\Model\GeneratorConfiguration;
 use PHPModelGenerator\Model\MethodInterface;
 use PHPModelGenerator\Model\Property\PropertyInterface;
 use PHPModelGenerator\Model\Schema;
 use PHPModelGenerator\Model\Validator\AbstractComposedPropertyValidator;
 use PHPModelGenerator\Model\Validator\ExtractedMethodValidator;
+use PHPModelGenerator\Utils\RenderHelper;
 
 /**
  * Wraps an input-space composition validator with a skip guard that bypasses the entire
@@ -67,26 +70,38 @@ final class FilterPreTransformGuardValidator extends ExtractedMethodValidator
      */
     public function getMethod(): MethodInterface
     {
-        $guardMethodName = $this->getExtractedMethodName();
-        $innerMethodName = $this->inner->getExtractedMethodName();
-        $skipCheck = $this->skipCheck;
-
-        return new class ($guardMethodName, $innerMethodName, $skipCheck) implements MethodInterface {
-            public function __construct(
-                private readonly string $guardMethodName,
-                private readonly string $innerMethodName,
-                private readonly string $skipCheck,
-            ) {}
+        return new class ($this) implements MethodInterface {
+            public function __construct(private readonly FilterPreTransformGuardValidator $validator)
+            {}
 
             public function getCode(): string
             {
-                return "private function {$this->guardMethodName}(&\$value, \$modelData): void {
-                    if ({$this->skipCheck}) {
-                        return;
-                    }
-                    \$this->{$this->innerMethodName}(\$value, \$modelData);
-                }";
+                return $this->validator->renderGuardMethod();
             }
         };
+    }
+
+    /**
+     * @throws RenderException
+     */
+    public function renderGuardMethod(): string
+    {
+        try {
+            return $this->getRenderer()->renderTemplate(
+                DIRECTORY_SEPARATOR . 'Validator' . DIRECTORY_SEPARATOR . 'FilterPreTransformGuard.phptpl',
+                [
+                    'guardMethodName' => $this->getExtractedMethodName(),
+                    'innerMethodName' => $this->inner->getExtractedMethodName(),
+                    'skipCheck' => $this->skipCheck,
+                    'viewHelper' => new RenderHelper($this->generatorConfiguration),
+                ],
+            );
+        } catch (PHPMicroTemplateException $exception) {
+            throw new RenderException(
+                "Can't render filter pre-transform guard {$this->getExtractedMethodName()}",
+                0,
+                $exception,
+            );
+        }
     }
 }

--- a/src/SchemaProcessor/Hook/SchemaHookResolver.php
+++ b/src/SchemaProcessor/Hook/SchemaHookResolver.php
@@ -55,9 +55,16 @@ class SchemaHookResolver
 
     private function resolveHook(string $filterHook, mixed ...$parameters): string
     {
+        // A hook may legitimately have no code to contribute for a given call (eg. a hook which only applies to
+        // a subset of properties or configurations). Filtering those out before joining avoids the "\n\n"
+        // separator surviving as a stray leading/trailing/middle blank when mixed with a hook that does emit
+        // code, which would corrupt the embedding template's ambient indentation for the remaining code.
         return join(
             "\n\n",
-            array_map(static fn($hook): string => $hook->getCode(...$parameters), $this->getHooks($filterHook)),
+            array_filter(
+                array_map(static fn($hook): string => $hook->getCode(...$parameters), $this->getHooks($filterHook)),
+                static fn(string $code): bool => $code !== '',
+            ),
         );
     }
 }

--- a/src/SchemaProcessor/PostProcessor/BuilderClassPostProcessor.php
+++ b/src/SchemaProcessor/PostProcessor/BuilderClassPostProcessor.php
@@ -62,21 +62,23 @@ class BuilderClassPostProcessor extends PostProcessor
 
             $result = file_put_contents(
                 $filename = str_replace('.php', 'Builder.php', $schema->getTargetFileName()),
-                (new Render(__DIR__ . DIRECTORY_SEPARATOR . 'Templates' . DIRECTORY_SEPARATOR))->renderTemplate(
-                    'BuilderClass.phptpl',
-                    [
-                        'namespace'              => $namespace,
-                        'class'                  => $schema->getClassName(),
-                        'schema'                 => $schema,
-                        'properties'             => $properties,
-                        'use'                    => $this->getBuilderClassImports(
-                            $properties,
-                            $schema->getUsedClasses(),
-                            $namespace,
-                        ),
-                        'generatorConfiguration' => $this->generatorConfiguration,
-                        'viewHelper'             => new RenderHelper($this->generatorConfiguration),
-                    ],
+                RenderHelper::collapseBlankLines(
+                    (new Render(__DIR__ . DIRECTORY_SEPARATOR . 'Templates' . DIRECTORY_SEPARATOR, 4))->renderTemplate(
+                        'BuilderClass.phptpl',
+                        [
+                            'namespace'              => $namespace,
+                            'class'                  => $schema->getClassName(),
+                            'schema'                 => $schema,
+                            'properties'             => $properties,
+                            'use'                    => $this->getBuilderClassImports(
+                                $properties,
+                                $schema->getUsedClasses(),
+                                $namespace,
+                            ),
+                            'generatorConfiguration' => $this->generatorConfiguration,
+                            'viewHelper'             => new RenderHelper($this->generatorConfiguration),
+                        ],
+                    ),
                 )
             );
 

--- a/src/SchemaProcessor/PostProcessor/BuilderClassPostProcessor.php
+++ b/src/SchemaProcessor/PostProcessor/BuilderClassPostProcessor.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace PHPModelGenerator\SchemaProcessor\PostProcessor;
 
-use PHPMicroTemplate\Render;
 use PHPModelGenerator\Exception\FileSystemException;
 use PHPModelGenerator\Exception\ValidationException;
 use PHPModelGenerator\Interfaces\BuilderInterface;
@@ -15,6 +14,7 @@ use PHPModelGenerator\Model\Schema;
 use PHPModelGenerator\Model\Validator;
 use PHPModelGenerator\PropertyProcessor\Decorator\TypeHint\TypeHintDecorator;
 use PHPModelGenerator\PropertyProcessor\Decorator\TypeHint\TypeHintTransferDecorator;
+use PHPModelGenerator\Utils\RenderFactory;
 use PHPModelGenerator\Utils\RenderHelper;
 use ReflectionClass;
 
@@ -63,22 +63,23 @@ class BuilderClassPostProcessor extends PostProcessor
             $result = file_put_contents(
                 $filename = str_replace('.php', 'Builder.php', $schema->getTargetFileName()),
                 RenderHelper::collapseBlankLines(
-                    (new Render(__DIR__ . DIRECTORY_SEPARATOR . 'Templates' . DIRECTORY_SEPARATOR, 4))->renderTemplate(
-                        'BuilderClass.phptpl',
-                        [
-                            'namespace'              => $namespace,
-                            'class'                  => $schema->getClassName(),
-                            'schema'                 => $schema,
-                            'properties'             => $properties,
-                            'use'                    => $this->getBuilderClassImports(
-                                $properties,
-                                $schema->getUsedClasses(),
-                                $namespace,
-                            ),
-                            'generatorConfiguration' => $this->generatorConfiguration,
-                            'viewHelper'             => new RenderHelper($this->generatorConfiguration),
-                        ],
-                    ),
+                    RenderFactory::create(__DIR__ . DIRECTORY_SEPARATOR . 'Templates' . DIRECTORY_SEPARATOR)
+                        ->renderTemplate(
+                            'BuilderClass.phptpl',
+                            [
+                                'namespace'              => $namespace,
+                                'class'                  => $schema->getClassName(),
+                                'schema'                 => $schema,
+                                'properties'             => $properties,
+                                'use'                    => $this->getBuilderClassImports(
+                                    $properties,
+                                    $schema->getUsedClasses(),
+                                    $namespace,
+                                ),
+                                'generatorConfiguration' => $this->generatorConfiguration,
+                                'viewHelper'             => new RenderHelper($this->generatorConfiguration),
+                            ],
+                        ),
                 )
             );
 

--- a/src/SchemaProcessor/PostProcessor/CompanionGeneratorTrait.php
+++ b/src/SchemaProcessor/PostProcessor/CompanionGeneratorTrait.php
@@ -4,10 +4,10 @@ declare(strict_types=1);
 
 namespace PHPModelGenerator\SchemaProcessor\PostProcessor;
 
-use PHPMicroTemplate\Render;
 use PHPModelGenerator\Exception\FileSystemException;
 use PHPModelGenerator\Model\GeneratorConfiguration;
 use PHPModelGenerator\Model\Schema;
+use PHPModelGenerator\Utils\RenderFactory;
 use PHPModelGenerator\Utils\RenderHelper;
 
 /**
@@ -63,7 +63,7 @@ trait CompanionGeneratorTrait
         $result = file_put_contents(
             $filename,
             RenderHelper::collapseBlankLines(
-                (new Render(__DIR__ . DIRECTORY_SEPARATOR . 'Templates' . DIRECTORY_SEPARATOR, 4))
+                RenderFactory::create(__DIR__ . DIRECTORY_SEPARATOR . 'Templates' . DIRECTORY_SEPARATOR)
                     ->renderTemplate($templatePath, $templateVars),
             ),
         );

--- a/src/SchemaProcessor/PostProcessor/CompanionGeneratorTrait.php
+++ b/src/SchemaProcessor/PostProcessor/CompanionGeneratorTrait.php
@@ -8,6 +8,7 @@ use PHPMicroTemplate\Render;
 use PHPModelGenerator\Exception\FileSystemException;
 use PHPModelGenerator\Model\GeneratorConfiguration;
 use PHPModelGenerator\Model\Schema;
+use PHPModelGenerator\Utils\RenderHelper;
 
 /**
  * Provides shared companion-class generation infrastructure for post-processors that
@@ -61,8 +62,10 @@ trait CompanionGeneratorTrait
 
         $result = file_put_contents(
             $filename,
-            (new Render(__DIR__ . DIRECTORY_SEPARATOR . 'Templates' . DIRECTORY_SEPARATOR))
-                ->renderTemplate($templatePath, $templateVars),
+            RenderHelper::collapseBlankLines(
+                (new Render(__DIR__ . DIRECTORY_SEPARATOR . 'Templates' . DIRECTORY_SEPARATOR, 4))
+                    ->renderTemplate($templatePath, $templateVars),
+            ),
         );
 
         if ($result === false) {

--- a/src/SchemaProcessor/PostProcessor/EnumPostProcessor.php
+++ b/src/SchemaProcessor/PostProcessor/EnumPostProcessor.php
@@ -28,6 +28,7 @@ use PHPModelGenerator\ModelGenerator;
 use PHPModelGenerator\PropertyProcessor\Filter\FilterProcessor;
 use PHPModelGenerator\Utils\ArrayHash;
 use PHPModelGenerator\Utils\NormalizedName;
+use PHPModelGenerator\Utils\RenderFactory;
 use PHPModelGenerator\Utils\RenderHelper;
 use PHPModelGenerator\Utils\TypeCheck;
 
@@ -58,7 +59,7 @@ class EnumPostProcessor extends PostProcessor
     ) {
         (new ModelGenerator())->generateModelDirectory($targetDirectory);
 
-        $this->renderer = new Render(__DIR__ . DIRECTORY_SEPARATOR . 'Templates' . DIRECTORY_SEPARATOR, 4);
+        $this->renderer = RenderFactory::create(__DIR__ . DIRECTORY_SEPARATOR . 'Templates' . DIRECTORY_SEPARATOR);
         $this->namespace = trim($namespace, '\\');
         $this->targetDirectory = $targetDirectory;
         $this->enumFilterToken = (new EnumFilter())->getToken();

--- a/src/SchemaProcessor/PostProcessor/EnumPostProcessor.php
+++ b/src/SchemaProcessor/PostProcessor/EnumPostProcessor.php
@@ -28,6 +28,7 @@ use PHPModelGenerator\ModelGenerator;
 use PHPModelGenerator\PropertyProcessor\Filter\FilterProcessor;
 use PHPModelGenerator\Utils\ArrayHash;
 use PHPModelGenerator\Utils\NormalizedName;
+use PHPModelGenerator\Utils\RenderHelper;
 use PHPModelGenerator\Utils\TypeCheck;
 
 /**
@@ -57,7 +58,7 @@ class EnumPostProcessor extends PostProcessor
     ) {
         (new ModelGenerator())->generateModelDirectory($targetDirectory);
 
-        $this->renderer = new Render(__DIR__ . DIRECTORY_SEPARATOR . 'Templates' . DIRECTORY_SEPARATOR);
+        $this->renderer = new Render(__DIR__ . DIRECTORY_SEPARATOR . 'Templates' . DIRECTORY_SEPARATOR, 4);
         $this->namespace = trim($namespace, '\\');
         $this->targetDirectory = $targetDirectory;
         $this->enumFilterToken = (new EnumFilter())->getToken();
@@ -420,7 +421,7 @@ class EnumPostProcessor extends PostProcessor
         $name = ucfirst((string) preg_replace('/\W/', '', ucwords($name, '_-. ')));
 
         foreach ($values as $value) {
-            $cases[$this->getCaseName($map, $value, $jsonSchema)] = var_export($value, true);
+            $cases[$this->getCaseName($map, $value, $jsonSchema)] = RenderHelper::varExportArray($value);
         }
 
         $backedType = null;
@@ -440,14 +441,16 @@ class EnumPostProcessor extends PostProcessor
 
         $result = file_put_contents(
             $filename = $this->targetDirectory . DIRECTORY_SEPARATOR . $name . '.php',
-            $this->renderer->renderTemplate(
-                'Enum.phptpl',
-                [
-                    'namespace' => $this->namespace,
-                    'name' => $name,
-                    'cases' => $cases,
-                    'backedType' => $backedType,
-                ],
+            RenderHelper::collapseBlankLines(
+                $this->renderer->renderTemplate(
+                    'Enum.phptpl',
+                    [
+                        'namespace' => $this->namespace,
+                        'name' => $name,
+                        'cases' => $cases,
+                        'backedType' => $backedType,
+                    ],
+                ),
             )
         );
 

--- a/src/SchemaProcessor/PostProcessor/Internal/SerializationPostProcessor.php
+++ b/src/SchemaProcessor/PostProcessor/Internal/SerializationPostProcessor.php
@@ -21,6 +21,7 @@ use PHPModelGenerator\SchemaProcessor\Hook\SerializationHookInterface;
 use PHPModelGenerator\SchemaProcessor\PostProcessor\PostProcessor;
 use PHPModelGenerator\SchemaProcessor\PostProcessor\RenderedMethod;
 use PHPModelGenerator\Traits\SerializableTrait;
+use PHPModelGenerator\Utils\RenderHelper;
 
 /**
  * Class SerializationPostProcessor
@@ -81,7 +82,7 @@ class SerializationPostProcessor extends PostProcessor
                                 'property' => $property,
                                 'serializerClass' => $serializerClass,
                                 'serializerMethod' => $serializerMethod,
-                                'serializerOptions' => var_export($validator->getFilterOptions(), true),
+                                'serializerOptions' => RenderHelper::varExportArray($validator->getFilterOptions()),
                             ],
                         )
                     );
@@ -113,7 +114,9 @@ class SerializationPostProcessor extends PostProcessor
                                     'key' => $validator->getKey(),
                                     'serializerClass' => $serializerClass,
                                     'serializerMethod' => $serializerMethod,
-                                    'serializerOptions' => var_export($filterValidator->getFilterOptions(), true),
+                                    'serializerOptions' => RenderHelper::varExportArray(
+                                        $filterValidator->getFilterOptions(),
+                                    ),
                                 ],
                             )
                         );
@@ -189,7 +192,9 @@ class SerializationPostProcessor extends PostProcessor
                 [
                     'serializerClass' => $serializerClass,
                     'serializerMethod' => $serializerMethod,
-                    'serializerOptions' => var_export($transformingFilterValidator->getFilterOptions(), true),
+                    'serializerOptions' => RenderHelper::varExportArray(
+                        $transformingFilterValidator->getFilterOptions(),
+                    ),
                 ],
             )
         );
@@ -211,7 +216,7 @@ class SerializationPostProcessor extends PostProcessor
             return;
         }
 
-        $keysExport = var_export(array_values($writeOnlyAttributes), true);
+        $keysExport = RenderHelper::varExportArray(array_values($writeOnlyAttributes));
 
         $schema->addSchemaHook(
             new class ($keysExport) implements SerializationHookInterface
@@ -222,7 +227,11 @@ class SerializationPostProcessor extends PostProcessor
                 public function getCode(): string
                 {
                     return sprintf(
-                        'foreach (%s as $_writeOnlyKey) { unset($data[$_writeOnlyKey]); }',
+                        <<<'CODE'
+                        foreach (%s as $_writeOnlyKey) {
+                            unset($data[$_writeOnlyKey]);
+                        }
+                        CODE,
                         $this->keysExport,
                     );
                 }

--- a/src/SchemaProcessor/PostProcessor/PopulatePostProcessor.php
+++ b/src/SchemaProcessor/PostProcessor/PopulatePostProcessor.php
@@ -7,6 +7,8 @@ namespace PHPModelGenerator\SchemaProcessor\PostProcessor;
 use PHPModelGenerator\Model\GeneratorConfiguration;
 use PHPModelGenerator\Model\Schema;
 use PHPModelGenerator\SchemaProcessor\Hook\SchemaHookResolver;
+use PHPModelGenerator\Utils\RenderFactory;
+use PHPModelGenerator\Utils\RenderHelper;
 
 /**
  * Class PopulatePostProcessor
@@ -17,6 +19,8 @@ class PopulatePostProcessor extends PostProcessor
 {
     public function process(Schema $schema, GeneratorConfiguration $generatorConfiguration): void
     {
+        $schemaHookResolver = new SchemaHookResolver($schema);
+
         $schema->addMethod(
             'populate',
             new RenderedMethod(
@@ -24,8 +28,26 @@ class PopulatePostProcessor extends PostProcessor
                 $generatorConfiguration,
                 'Populate.phptpl',
                 [
-                    'schemaHookResolver' => new SchemaHookResolver($schema),
+                    'schemaHookResolver' => $schemaHookResolver,
                     'true' => true,
+                    // Rendered as its own template and embedded via viewHelper.indent() instead of being inlined
+                    // directly: the shared rollback-tracking/setter-dispatch body sits at a different real
+                    // nesting depth depending on whether collectErrors() wraps it in a bare block or a try {} -
+                    // one literal indentation can't be correct for both, so the body is written once, at its own
+                    // canonical depth, and the two call sites in Populate.phptpl each indent the rendered result
+                    // to their own real depth.
+                    'renderPopulateBody' => function () use (
+                        $schema,
+                        $generatorConfiguration,
+                        $schemaHookResolver,
+                    ): string {
+                        return RenderFactory::create(__DIR__ . DIRECTORY_SEPARATOR . 'Templates' . DIRECTORY_SEPARATOR)
+                            ->renderTemplate('PopulateBody.phptpl', [
+                                'schema' => $schema,
+                                'schemaHookResolver' => $schemaHookResolver,
+                                'viewHelper' => new RenderHelper($generatorConfiguration),
+                            ]);
+                    },
                 ],
             )
         );

--- a/src/SchemaProcessor/PostProcessor/RenderedMethod.php
+++ b/src/SchemaProcessor/PostProcessor/RenderedMethod.php
@@ -55,7 +55,7 @@ class RenderedMethod implements MethodInterface
     protected function getRenderer(): Render
     {
         if (!self::$renderer) {
-            self::$renderer = new Render(__DIR__ . DIRECTORY_SEPARATOR . 'Templates' . DIRECTORY_SEPARATOR);
+            self::$renderer = new Render(__DIR__ . DIRECTORY_SEPARATOR . 'Templates' . DIRECTORY_SEPARATOR, 4);
         }
 
         return self::$renderer;

--- a/src/SchemaProcessor/PostProcessor/RenderedMethod.php
+++ b/src/SchemaProcessor/PostProcessor/RenderedMethod.php
@@ -11,6 +11,7 @@ use PHPMicroTemplate\Render;
 use PHPModelGenerator\Model\GeneratorConfiguration;
 use PHPModelGenerator\Model\MethodInterface;
 use PHPModelGenerator\Model\Schema;
+use PHPModelGenerator\Utils\RenderFactory;
 use PHPModelGenerator\Utils\RenderHelper;
 
 /**
@@ -20,8 +21,6 @@ use PHPModelGenerator\Utils\RenderHelper;
  */
 class RenderedMethod implements MethodInterface
 {
-    private static ?Render $renderer = null;
-
     public function __construct(
         private readonly Schema $schema,
         private readonly GeneratorConfiguration $generatorConfiguration,
@@ -54,10 +53,6 @@ class RenderedMethod implements MethodInterface
 
     protected function getRenderer(): Render
     {
-        if (!self::$renderer) {
-            self::$renderer = new Render(__DIR__ . DIRECTORY_SEPARATOR . 'Templates' . DIRECTORY_SEPARATOR, 4);
-        }
-
-        return self::$renderer;
+        return RenderFactory::create(__DIR__ . DIRECTORY_SEPARATOR . 'Templates' . DIRECTORY_SEPARATOR);
     }
 }

--- a/src/SchemaProcessor/PostProcessor/Templates/AdditionalProperties/AdditionalPropertiesAccessorMethod.phptpl
+++ b/src/SchemaProcessor/PostProcessor/Templates/AdditionalProperties/AdditionalPropertiesAccessorMethod.phptpl
@@ -3,8 +3,8 @@ public function additionalProperties(): {{ accessorType }}
     return $this->_additionalPropertiesAccessor ??= new {{ accessorType }}(
         $this->_additionalProperties,
         {% if not immutable %}
-        $this->_setAdditionalProperty(...),
-        $this->_removeAdditionalProperty(...),
+            $this->_setAdditionalProperty(...),
+            $this->_removeAdditionalProperty(...),
         {% endif %}
     );
 }

--- a/src/SchemaProcessor/PostProcessor/Templates/AdditionalProperties/RemoveAdditionalProperty.phptpl
+++ b/src/SchemaProcessor/PostProcessor/Templates/AdditionalProperties/RemoveAdditionalProperty.phptpl
@@ -1,5 +1,5 @@
 /**
- * {% if minPropertyValidator %}@throws {% if generatorConfiguration.collectErrors() %}{{ viewHelper.getSimpleClassName(generatorConfiguration.getErrorRegistryClass()) }}{% else %}ValidationException{% endif %}{% endif %}
+ *{% if minPropertyValidator %} @throws {% if generatorConfiguration.collectErrors() %}{{ viewHelper.getSimpleClassName(generatorConfiguration.getErrorRegistryClass()) }}{% else %}ValidationException{% endif %}{% endif %}
  */
 private function _removeAdditionalProperty(string $key): bool
 {

--- a/src/SchemaProcessor/PostProcessor/Templates/AdditionalProperties/SetAdditionalProperty.phptpl
+++ b/src/SchemaProcessor/PostProcessor/Templates/AdditionalProperties/SetAdditionalProperty.phptpl
@@ -1,6 +1,6 @@
 /**
- * {% if hasObjectProperties %}@throws RegularPropertyAsAdditionalPropertyException
- * {% endif %}{% if schema.getBaseValidators() %}@throws {% if generatorConfiguration.collectErrors() %}{{ viewHelper.getSimpleClassName(generatorConfiguration.getErrorRegistryClass()) }}{% else %}ValidationException{% endif %}{% endif %}
+ *{% if hasObjectProperties %} @throws RegularPropertyAsAdditionalPropertyException{% endif %}
+ *{% if schema.getBaseValidators() %} @throws {% if generatorConfiguration.collectErrors() %}{{ viewHelper.getSimpleClassName(generatorConfiguration.getErrorRegistryClass()) }}{% else %}ValidationException{% endif %}{% endif %}
  */
 private function _setAdditionalProperty(
     string $key,

--- a/src/SchemaProcessor/PostProcessor/Templates/BuilderClass.phptpl
+++ b/src/SchemaProcessor/PostProcessor/Templates/BuilderClass.phptpl
@@ -74,10 +74,7 @@ class {{ class }}Builder implements BuilderInterface
         {% if not property.isInternal() %}
             /**
              * Get the value of {{ property.getName() }}.
-{% if property.getDescription() %}{#
-    Renders the description line only when present, avoiding a redundant blank " *" separator either side
-    of it when there's no description.
-#}
+{% if property.getDescription() %}
                  *
                  * {{ property.getDescription() }}
 {% endif %}
@@ -93,14 +90,6 @@ class {{ class }}Builder implements BuilderInterface
              * Set the value of {{ property.getName() }}.
              *
              * @param {{ viewHelper.getTypeHintAnnotation(property) }} ${{ property.getAttribute(true) }}{% if property.getDescription() %} {{ property.getDescription() }}{% endif %}
-{% if property.getValidators() %}{#
-    Builder setters currently never carry validators (BuilderClassPostProcessor strips them via
-    filterValidators()), making this branch presently unreachable, but it stays correct - and avoids a
-    redundant blank " *" separator - for whenever that changes.
-#}
-                 *
-                 * @throws {% if generatorConfiguration.collectErrors() %}{{ viewHelper.getSimpleClassName(generatorConfiguration.getErrorRegistryClass()) }}{% else %}ValidationException{% endif %}
-{% endif %}
              *
              * @return static
              */

--- a/src/SchemaProcessor/PostProcessor/Templates/BuilderClass.phptpl
+++ b/src/SchemaProcessor/PostProcessor/Templates/BuilderClass.phptpl
@@ -1,8 +1,5 @@
 <?php
 
-// @codingStandardsIgnoreFile
-// @codeCoverageIgnoreStart
-
 declare(strict_types=1);
 
 {% if namespace %}
@@ -77,12 +74,8 @@ class {{ class }}Builder implements BuilderInterface
             /**
              * Get the value of {{ property.getName() }}.
 {% if property.getDescription() %}{#
-    Standalone if, nested inside further standalone-dedented blocks (foreach/if/if): the surrounding literal
-    " *" separator lines sit at 13 source columns and land at real column 5 (those outer blocks' own dedents
-    strip 8 total). This if's body passes through that same outer strip plus one further blockIndentWidth (4)
-    dedent of its own, so it needs 13 + 8 + 4 = 17 source columns to land at that same real column 5. Confirmed
-    empirically (generate + measure), not derived by counting nesting on paper - see project conventions on why.
-    Avoids stacking a redundant unconditional " *" separator both before and after an absent description.
+    Renders the description line only when present, avoiding a redundant blank " *" separator either side
+    of it when there's no description.
 #}
                  *
                  * {{ property.getDescription() }}
@@ -100,11 +93,9 @@ class {{ class }}Builder implements BuilderInterface
              *
              * @param {{ viewHelper.getTypeHintAnnotation(property) }} ${{ property.getAttribute(true) }}{% if property.getDescription() %} {{ property.getDescription() }}{% endif %}
 {% if property.getValidators() %}{#
-    Standalone if - see the getName() docblock above for why its body needs 17 source columns to land at the
-    same real column 5 as the surrounding literal " *" lines. Builder setters currently never actually carry
-    validators (BuilderClassPostProcessor strips them via filterValidators()), making this branch presently
-    unreachable, but it stays correct - and avoids stacking a redundant separator either side of it - for
-    whenever that changes.
+    Builder setters currently never carry validators (BuilderClassPostProcessor strips them via
+    filterValidators()), making this branch presently unreachable, but it stays correct - and avoids a
+    redundant blank " *" separator - for whenever that changes.
 #}
                  *
                  * @throws {% if generatorConfiguration.collectErrors() %}{{ viewHelper.getSimpleClassName(generatorConfiguration.getErrorRegistryClass()) }}{% else %}ValidationException{% endif %}
@@ -141,5 +132,3 @@ class {{ class }}Builder implements BuilderInterface
         {% endif %}
     {% endforeach %}
 }
-
-// @codeCoverageIgnoreEnd

--- a/src/SchemaProcessor/PostProcessor/Templates/BuilderClass.phptpl
+++ b/src/SchemaProcessor/PostProcessor/Templates/BuilderClass.phptpl
@@ -18,6 +18,7 @@ class {{ class }}Builder implements BuilderInterface
 {
     /** @var array */
     protected $_rawModelDataInput = [];
+
     /** @var Meta|null */
     private $_metaAccessor = null;
 

--- a/src/SchemaProcessor/PostProcessor/Templates/BuilderClass.phptpl
+++ b/src/SchemaProcessor/PostProcessor/Templates/BuilderClass.phptpl
@@ -3,7 +3,7 @@
 // @codingStandardsIgnoreFile
 // @codeCoverageIgnoreStart
 
-declare(strict_types = 1);
+declare(strict_types=1);
 
 {% if namespace %}
     namespace {{ namespace }};
@@ -76,10 +76,19 @@ class {{ class }}Builder implements BuilderInterface
         {% if not property.isInternal() %}
             /**
              * Get the value of {{ property.getName() }}.
+{% if property.getDescription() %}{#
+    Standalone if, nested inside further standalone-dedented blocks (foreach/if/if): the surrounding literal
+    " *" separator lines sit at 13 source columns and land at real column 5 (those outer blocks' own dedents
+    strip 8 total). This if's body passes through that same outer strip plus one further blockIndentWidth (4)
+    dedent of its own, so it needs 13 + 8 + 4 = 17 source columns to land at that same real column 5. Confirmed
+    empirically (generate + measure), not derived by counting nesting on paper - see project conventions on why.
+    Avoids stacking a redundant unconditional " *" separator both before and after an absent description.
+#}
+                 *
+                 * {{ property.getDescription() }}
+{% endif %}
              *
-             * {% if property.getDescription() %}{{ property.getDescription() }}{% endif %}
-             *
-             * {% if viewHelper.getTypeHintAnnotation(property) %}@return {{ viewHelper.getTypeHintAnnotation(property, false, true) }}{% endif %}
+             *{% if viewHelper.getTypeHintAnnotation(property) %} @return {{ viewHelper.getTypeHintAnnotation(property, false, true) }}{% endif %}
              */
             public function get{{ viewHelper.ucfirst(property.getAttribute()) }}(): {{ viewHelper.getType(property, false, true) }}
             {
@@ -90,15 +99,24 @@ class {{ class }}Builder implements BuilderInterface
              * Set the value of {{ property.getName() }}.
              *
              * @param {{ viewHelper.getTypeHintAnnotation(property) }} ${{ property.getAttribute(true) }}{% if property.getDescription() %} {{ property.getDescription() }}{% endif %}
-             *
-             * {% if property.getValidators() %}@throws {% if generatorConfiguration.collectErrors() %}{{ viewHelper.getSimpleClassName(generatorConfiguration.getErrorRegistryClass()) }}{% else %}ValidationException{% endif %}{% endif %}
+{% if property.getValidators() %}{#
+    Standalone if - see the getName() docblock above for why its body needs 17 source columns to land at the
+    same real column 5 as the surrounding literal " *" lines. Builder setters currently never actually carry
+    validators (BuilderClassPostProcessor strips them via filterValidators()), making this branch presently
+    unreachable, but it stays correct - and avoids stacking a redundant separator either side of it - for
+    whenever that changes.
+#}
+                 *
+                 * @throws {% if generatorConfiguration.collectErrors() %}{{ viewHelper.getSimpleClassName(generatorConfiguration.getErrorRegistryClass()) }}{% else %}ValidationException{% endif %}
+{% endif %}
              *
              * @return static
              */
             public function set{{ viewHelper.ucfirst(property.getAttribute()) }}(
                 {{ viewHelper.getType(property) }} ${{ property.getAttribute(true) }}
             ): static {
-                if (array_key_exists('{{ property.getName() }}', $this->_rawModelDataInput)
+                if (
+                    array_key_exists('{{ property.getName() }}', $this->_rawModelDataInput)
                     && $this->_rawModelDataInput['{{ property.getName() }}'] === ${{ property.getAttribute(true) }}
                 ) {
                     return $this;
@@ -107,7 +125,7 @@ class {{ class }}Builder implements BuilderInterface
                 $value = $modelData['{{ property.getName() }}'] = ${{ property.getAttribute(true) }};
 
                 {% foreach property.getOrderedValidators() as validator %}
-                    {{ viewHelper.renderValidator(validator, schema) }}
+                    {{ viewHelper.renderValidator(validator, schema, 2) }}
                 {% endforeach %}
 
                 {% if property.getOrderedValidators() and generatorConfiguration.collectErrors() %}

--- a/src/SchemaProcessor/PostProcessor/Templates/Companion/AdditionalPropertiesCompanion.phptpl
+++ b/src/SchemaProcessor/PostProcessor/Templates/Companion/AdditionalPropertiesCompanion.phptpl
@@ -3,7 +3,7 @@
 // @codingStandardsIgnoreFile
 // @codeCoverageIgnoreStart
 
-declare(strict_types = 1);
+declare(strict_types=1);
 
 {% if namespace %}
     namespace {{ namespace }};
@@ -16,7 +16,9 @@ declare(strict_types = 1);
 class {{ companionClassName }}
 {
     {% if immutable %}
-        public function __construct(private readonly array $additionalProperties) {}
+        public function __construct(
+            private readonly array $additionalProperties,
+        ) {}
     {% else %}
         public function __construct(
             private array &$additionalProperties,

--- a/src/SchemaProcessor/PostProcessor/Templates/Companion/AdditionalPropertiesCompanion.phptpl
+++ b/src/SchemaProcessor/PostProcessor/Templates/Companion/AdditionalPropertiesCompanion.phptpl
@@ -1,8 +1,5 @@
 <?php
 
-// @codingStandardsIgnoreFile
-// @codeCoverageIgnoreStart
-
 declare(strict_types=1);
 
 {% if namespace %}
@@ -60,5 +57,3 @@ class {{ companionClassName }}
         }
     {% endif %}
 }
-
-// @codeCoverageIgnoreEnd

--- a/src/SchemaProcessor/PostProcessor/Templates/Companion/PatternPropertiesCompanion.phptpl
+++ b/src/SchemaProcessor/PostProcessor/Templates/Companion/PatternPropertiesCompanion.phptpl
@@ -1,8 +1,5 @@
 <?php
 
-// @codingStandardsIgnoreFile
-// @codeCoverageIgnoreStart
-
 declare(strict_types=1);
 
 {% if namespace %}
@@ -35,5 +32,3 @@ class {{ companionClassName }}
         return $this->patternProperties[$hash];
     }
 }
-
-// @codeCoverageIgnoreEnd

--- a/src/SchemaProcessor/PostProcessor/Templates/Companion/PatternPropertiesCompanion.phptpl
+++ b/src/SchemaProcessor/PostProcessor/Templates/Companion/PatternPropertiesCompanion.phptpl
@@ -3,7 +3,7 @@
 // @codingStandardsIgnoreFile
 // @codeCoverageIgnoreStart
 
-declare(strict_types = 1);
+declare(strict_types=1);
 
 {% if namespace %}
     namespace {{ namespace }};
@@ -15,7 +15,9 @@ declare(strict_types = 1);
 
 class {{ companionClassName }}
 {
-    public function __construct(private array &$patternProperties) {}
+    public function __construct(
+        private array &$patternProperties,
+    ) {}
 
     /**
      * @return {{ getReturnAnnotation }}

--- a/src/SchemaProcessor/PostProcessor/Templates/CompositionValidation.phptpl
+++ b/src/SchemaProcessor/PostProcessor/Templates/CompositionValidation.phptpl
@@ -3,15 +3,15 @@
  *
  * @param array $modifiedModelData An array containing all updated data as key-value pairs
  *
- * {% if not generatorConfiguration.collectErrors() %}@throws ValidationException{% endif %}
+ *{% if not generatorConfiguration.collectErrors() %} @throws ValidationException{% endif %}
  */
 private function _validateComposition_{{ index }}(array &$modifiedModelData): void
 {
     $validatorIndex = {{ index }};
     $value = $modelData = array_merge($this->_rawModelDataInput, $modifiedModelData);
 
-    {{ validator.getValidatorSetUp() }}
-    if ({{ validator.getCheck() }}) {
+    {{ viewHelper.indent(validator.getValidatorSetUp(), 1) }}
+    if {{ viewHelper.formatCondition(validator.getCheck(), 1) }} {
         {{ viewHelper.validationError(validator) }}
     }
 

--- a/src/SchemaProcessor/PostProcessor/Templates/GetModifiedValues.phptpl
+++ b/src/SchemaProcessor/PostProcessor/Templates/GetModifiedValues.phptpl
@@ -8,7 +8,8 @@ private function {{ modifiedValuesMethod }}(
     $branchDefaultProps = $componentDefaultValueMap[$componentIndex] ?? [];
 
     foreach ({{ propertyAccessors }} as $key => $accessor) {
-        if ((isset($originalModelData[$key]) || in_array($key, $branchDefaultProps))
+        if (
+            (isset($originalModelData[$key]) || in_array($key, $branchDefaultProps))
             && method_exists($nestedCompositionObject, $accessor)
             && ($modifiedValue = $nestedCompositionObject->$accessor())
                 !== ($originalModelData[$key] ?? !$modifiedValue)

--- a/src/SchemaProcessor/PostProcessor/Templates/Populate.phptpl
+++ b/src/SchemaProcessor/PostProcessor/Templates/Populate.phptpl
@@ -22,35 +22,9 @@ public function populate(array $modelData): self
 
     {% if generatorConfiguration.collectErrors() %}
         $this->_errorRegistry = new {{ viewHelper.getSimpleClassName(generatorConfiguration.getErrorRegistryClass()) }}();
-    {% else %}
-        try {
-    {% endif %}
 
-    foreach (['_additionalProperties', '_patternProperties'] as $property) {
-        if (isset($this->{$property})) {
-            $rollbackValues[$property] = $this->{$property};
-        }
-    }
+        {{ viewHelper.indent(renderPopulateBody(), 1) }}
 
-    {% if schema.getBaseValidators() %}
-        $this->_executeBaseValidators($modelData);
-    {% endif %}
-
-    {% foreach schema.getProperties() as property %}
-        {% if not property.isInternal() %}
-            if (
-                array_key_exists('{{ property.getName() }}', $modelData) &&
-                $modelData['{{ property.getName() }}'] !== $this->{{ property.getAttribute(true) }}
-            ) {
-                {{ schemaHookResolver.resolveSetterBeforeValidationHook(property, true) }}
-
-                $rollbackValues['{{ property.getAttribute(true) }}'] = $this->{{ property.getAttribute(true) }};
-                $this->_process{{ viewHelper.ucfirst(property.getAttribute()) }}($modelData);
-            }
-        {% endif %}
-    {% endforeach %}
-
-    {% if generatorConfiguration.collectErrors() %}
         if (count($this->_errorRegistry->getErrors())) {
             foreach ($rollbackValues as $property => $value) {
                 $this->{$property} = $value;
@@ -59,6 +33,8 @@ public function populate(array $modelData): self
             throw $this->_errorRegistry;
         }
     {% else %}
+        try {
+            {{ viewHelper.indent(renderPopulateBody(), 2) }}
         } catch (ValidationException $exception) {
             foreach ($rollbackValues as $property => $value) {
                 $this->{$property} = $value;

--- a/src/SchemaProcessor/PostProcessor/Templates/Populate.phptpl
+++ b/src/SchemaProcessor/PostProcessor/Templates/Populate.phptpl
@@ -38,7 +38,8 @@ public function populate(array $modelData): self
 
     {% foreach schema.getProperties() as property %}
         {% if not property.isInternal() %}
-            if (array_key_exists('{{ property.getName() }}', $modelData) &&
+            if (
+                array_key_exists('{{ property.getName() }}', $modelData) &&
                 $modelData['{{ property.getName() }}'] !== $this->{{ property.getAttribute(true) }}
             ) {
                 {{ schemaHookResolver.resolveSetterBeforeValidationHook(property, true) }}

--- a/src/SchemaProcessor/PostProcessor/Templates/PopulateBody.phptpl
+++ b/src/SchemaProcessor/PostProcessor/Templates/PopulateBody.phptpl
@@ -1,0 +1,23 @@
+foreach (['_additionalProperties', '_patternProperties'] as $property) {
+    if (isset($this->{$property})) {
+        $rollbackValues[$property] = $this->{$property};
+    }
+}
+
+{% if schema.getBaseValidators() %}
+    $this->_executeBaseValidators($modelData);
+{% endif %}
+
+{% foreach schema.getProperties() as property %}
+    {% if not property.isInternal() %}
+        if (
+            array_key_exists('{{ property.getName() }}', $modelData) &&
+            $modelData['{{ property.getName() }}'] !== $this->{{ property.getAttribute(true) }}
+        ) {
+            {{ schemaHookResolver.resolveSetterBeforeValidationHook(property, true) }}
+
+            $rollbackValues['{{ property.getAttribute(true) }}'] = $this->{{ property.getAttribute(true) }};
+            $this->_process{{ viewHelper.ucfirst(property.getAttribute()) }}($modelData);
+        }
+    {% endif %}
+{% endforeach %}

--- a/src/SchemaProcessor/PostProcessor/Templates/Serialization/SerializationHook.phptpl
+++ b/src/SchemaProcessor/PostProcessor/Templates/Serialization/SerializationHook.phptpl
@@ -1,7 +1,7 @@
 {% if schemaHookResolver.resolveSerializationHook() %}
     protected function _resolveSerializationHook(array $data, int $depth, array $except): array
     {
-        {{ schemaHookResolver.resolveSerializationHook() }}
+        {{ viewHelper.indent(schemaHookResolver.resolveSerializationHook(), 1) }}
 
         return $data;
     }

--- a/src/Templates/Decorator/ObjectInstantiationDecorator.phptpl
+++ b/src/Templates/Decorator/ObjectInstantiationDecorator.phptpl
@@ -6,7 +6,7 @@
             {{ viewHelper.validationError(nestedValidator) }}
         {% else %}
             {% if generatorConfiguration.collectErrors() %}
-                foreach($instantiationException->getErrors() as $nestedValidationError) {
+                foreach ($instantiationException->getErrors() as $nestedValidationError) {
                     $this->_errorRegistry->addError($nestedValidationError);
                 }
             {% else %}

--- a/src/Templates/Model.phptpl
+++ b/src/Templates/Model.phptpl
@@ -3,7 +3,7 @@
 // @codingStandardsIgnoreFile
 // @codeCoverageIgnoreStart
 
-declare(strict_types = 1);
+declare(strict_types=1);
 
 {% if namespace %}
     namespace {{ namespace }};
@@ -16,10 +16,20 @@ use PHPModelGenerator\Accessor\Meta;
 
 /**
  * Class {{ schema.getClassName() }}
-{% if namespace %} * @package {{ namespace }} {% endif %}
+{% if namespace %} * @package {{ namespace }}{% endif %}
  *
-{% if schema.getDescription() %} * {{ schema.getDescription() }}
- *{% endif %}
+{% if schema.getDescription() %}{#
+    Standalone if: its body is dedented by 4 (blockIndentWidth), so the 5 leading spaces below (not the usual 1)
+    leave exactly " * ..." - the customary single space before the asterisk - after dedent, instead of stripping
+    it away entirely. A non-standalone inline tag (eg. "{% if namespace %} * ...{% endif %}" above) is the
+    simpler choice whenever a branch stays on one line, but this branch needs two of its own lines
+    (" * description" and a blank " *" separator); a non-standalone multi-line branch keeps its own trailing
+    newline even when the condition is false, leaving a stray blank comment line behind. The comment itself sits
+    glued to the if-tag rather than on its own line above, so stripping it doesn't leave a blank line behind too.
+#}
+     * {{ schema.getDescription() }}
+     *
+{% endif %}
  * This is an auto-implemented class implemented by the php-json-schema-model-generator.
  * If you need to implement something in this class use inheritance. Else you will lose your changes if the classes
  * are re-generated.
@@ -27,7 +37,7 @@ use PHPModelGenerator\Accessor\Meta;
 {% foreach schema.getAttributes() as attribute %}
 #[{{ attribute.render() }}]
 {% endforeach %}
-class {{ schema.getClassName() }} {% if schema.getInterfaces() %}implements {{ viewHelper.joinClassNames(schema.getInterfaces()) }}{% endif %}
+class {{ schema.getClassName() }}{% if schema.getInterfaces() %} implements {{ viewHelper.joinClassNames(schema.getInterfaces()) }}{% endif %}
 {
     {% if schema.getTraits() %}use {{ viewHelper.joinClassNames(schema.getTraits()) }};{% endif %}
 
@@ -64,7 +74,7 @@ class {{ schema.getClassName() }} {% if schema.getInterfaces() %}implements {{ v
             $this->_errorRegistry = new {{ viewHelper.getSimpleClassName(generatorConfiguration.getErrorRegistryClass()) }}();
         {% endif %}
 
-        {{ schemaHookResolver.resolveConstructorBeforeValidationHook() }}
+        {{ viewHelper.indent(schemaHookResolver.resolveConstructorBeforeValidationHook(), 2) }}
 
         {% if schema.getBaseValidators() %}
             $this->_executeBaseValidators($rawModelDataInput);
@@ -93,7 +103,7 @@ class {{ schema.getClassName() }} {% if schema.getInterfaces() %}implements {{ v
             $value = &$modelData;
 
             {% foreach baseValidatorsWithoutCompositions as validator %}
-                {{ viewHelper.renderValidator(validator, schema) }}
+                {{ viewHelper.renderValidator(validator, schema, 2) }}
             {% endforeach %}
 
             {% foreach schema.getCompositionValidatorKeys() as compositionValidatorKey %}
@@ -117,7 +127,7 @@ class {{ schema.getClassName() }} {% if schema.getInterfaces() %}implements {{ v
                  * {{ property.getComment() }}{% endif %}{% foreach property.getExamples() as example %}
                  * @example {{ viewHelper.exportValue(example) }}{% endforeach %}
                  *
-                 * {% if viewHelper.getTypeHintAnnotation(property, true) %}@return {{ viewHelper.getTypeHintAnnotation(property, true) }}{% endif %}
+                 *{% if viewHelper.getTypeHintAnnotation(property, true) %} @return {{ viewHelper.getTypeHintAnnotation(property, true) }}{% endif %}
                  */
                 public function get{{ viewHelper.ucfirst(property.getAttribute()) }}(): {{ viewHelper.getType(property, true) }}
                 {
@@ -133,7 +143,7 @@ class {{ schema.getClassName() }} {% if schema.getInterfaces() %}implements {{ v
                  *
                  * @param {{ viewHelper.getTypeHintAnnotation(property) }} ${{ property.getAttribute(true) }}{% if property.getDescription() %} {{ property.getDescription() }}{% endif %}
                  *
-                 * {% if property.getValidators() %}@throws {% if generatorConfiguration.collectErrors() %}{{ viewHelper.getSimpleClassName(generatorConfiguration.getErrorRegistryClass()) }}{% else %}ValidationException{% endif %}{% endif %}
+                 *{% if property.getValidators() %} @throws {% if generatorConfiguration.collectErrors() %}{{ viewHelper.getSimpleClassName(generatorConfiguration.getErrorRegistryClass()) }}{% else %}ValidationException{% endif %}{% endif %}
                  *
                  * @return static
                  */
@@ -174,7 +184,7 @@ class {{ schema.getClassName() }} {% if schema.getInterfaces() %}implements {{ v
              *
              * @param array $modelData
              *
-             * {% if property.getValidators() %}@throws {% if generatorConfiguration.collectErrors() %}{{ viewHelper.getSimpleClassName(generatorConfiguration.getErrorRegistryClass()) }}{% else %}ValidationException{% endif %}{% endif %}
+             *{% if property.getValidators() %} @throws {% if generatorConfiguration.collectErrors() %}{{ viewHelper.getSimpleClassName(generatorConfiguration.getErrorRegistryClass()) }}{% else %}ValidationException{% endif %}{% endif %}
              */
             protected function _process{{ viewHelper.ucfirst(property.getAttribute()) }}(array $modelData): void
             {
@@ -186,7 +196,7 @@ class {{ schema.getClassName() }} {% if schema.getInterfaces() %}implements {{ v
 
                 $value = array_key_exists('{{ property.getName() }}', $modelData) ? $modelData['{{ property.getName() }}'] : $this->{{ property.getAttribute(true) }};
 
-                {{ viewHelper.resolvePropertyDecorator(property, true) }}
+                {{ viewHelper.resolvePropertyDecorator(property, true, 2) }}
 
                 $this->{{ property.getAttribute(true) }} = $this->_validate{{ viewHelper.ucfirst(property.getAttribute()) }}($value, $modelData);
             }
@@ -197,7 +207,7 @@ class {{ schema.getClassName() }} {% if schema.getInterfaces() %}implements {{ v
             protected function _validate{{ viewHelper.ucfirst(property.getAttribute()) }}($value, array $modelData)
             {
                 {% foreach property.getOrderedValidators() as validator %}
-                    {{ viewHelper.renderValidator(validator, schema) }}
+                    {{ viewHelper.renderValidator(validator, schema, 2) }}
                 {% endforeach %}
 
                 return $value;
@@ -205,7 +215,7 @@ class {{ schema.getClassName() }} {% if schema.getInterfaces() %}implements {{ v
         {% endif %}
     {% endforeach %}
 
-    {{ viewHelper.renderMethods(schema) }}
+{{ viewHelper.renderMethods(schema) }}
 }
 
 // @codeCoverageIgnoreEnd

--- a/src/Templates/Model.phptpl
+++ b/src/Templates/Model.phptpl
@@ -40,10 +40,12 @@ class {{ schema.getClassName() }}{% if schema.getInterfaces() %} implements {{ v
         {% endforeach %}
         /**{% if viewHelper.getTypeHintAnnotation(property, true) %} @var {{ viewHelper.getTypeHintAnnotation(property, true) }}{% endif %}{% if property.getDescription() %} {{ property.getDescription() }}{% endif %} */
         {% if property.isInternal() %}private{% else %}protected{% endif %} ${{ property.getAttribute(true) }}{% if not viewHelper.isNull(property.getDefaultValue()) %} = {{ property.getDefaultValue() }}{% endif %};
+
     {% endforeach %}
     #[Internal]
     /** @var array<string, mixed> */
     protected array $_rawModelDataInput = [];
+
     #[Internal]
     /** @var Meta|null */
     private ?Meta $_metaAccessor = null;

--- a/src/Templates/Model.phptpl
+++ b/src/Templates/Model.phptpl
@@ -1,8 +1,5 @@
 <?php
 
-// @codingStandardsIgnoreFile
-// @codeCoverageIgnoreStart
-
 declare(strict_types=1);
 
 {% if namespace %}
@@ -19,13 +16,9 @@ use PHPModelGenerator\Accessor\Meta;
 {% if namespace %} * @package {{ namespace }}{% endif %}
  *
 {% if schema.getDescription() %}{#
-    Standalone if: its body is dedented by 4 (blockIndentWidth), so the 5 leading spaces below (not the usual 1)
-    leave exactly " * ..." - the customary single space before the asterisk - after dedent, instead of stripping
-    it away entirely. A non-standalone inline tag (eg. "{% if namespace %} * ...{% endif %}" above) is the
-    simpler choice whenever a branch stays on one line, but this branch needs two of its own lines
-    (" * description" and a blank " *" separator); a non-standalone multi-line branch keeps its own trailing
-    newline even when the condition is false, leaving a stray blank comment line behind. The comment itself sits
-    glued to the if-tag rather than on its own line above, so stripping it doesn't leave a blank line behind too.
+    A standalone if (unlike the inline "{% if namespace %} * ...{% endif %}" tag above) is needed here since
+    this branch spans two of its own lines (the description and a blank " *" separator) rather than staying
+    inline on one.
 #}
      * {{ schema.getDescription() }}
      *
@@ -122,10 +115,17 @@ class {{ schema.getClassName() }}{% if schema.getInterfaces() %} implements {{ v
             {% if not property.isWriteOnly() %}
                 /**
                  * Get the value of {{ property.getName() }}.
-                 *{% if property.getDescription() %}
-                 * {{ property.getDescription() }}{% endif %}{% if property.getComment() %}
-                 * {{ property.getComment() }}{% endif %}{% foreach property.getExamples() as example %}
-                 * @example {{ viewHelper.exportValue(example) }}{% endforeach %}
+                 {% if property.getDescription() %}
+                     *
+                     * {{ property.getDescription() }}
+                 {% endif %}
+                 {% if property.getComment() %}
+                     *
+                     * {{ property.getComment() }}
+                 {% endif %}
+                 {% foreach property.getExamples() as example %}
+                     * @example {{ viewHelper.exportValue(example) }}
+                 {% endforeach %}
                  *
                  *{% if viewHelper.getTypeHintAnnotation(property, true) %} @return {{ viewHelper.getTypeHintAnnotation(property, true) }}{% endif %}
                  */
@@ -142,8 +142,10 @@ class {{ schema.getClassName() }}{% if schema.getInterfaces() %} implements {{ v
                  * Set the value of {{ property.getName() }}.
                  *
                  * @param {{ viewHelper.getTypeHintAnnotation(property) }} ${{ property.getAttribute(true) }}{% if property.getDescription() %} {{ property.getDescription() }}{% endif %}
-                 *
-                 *{% if property.getValidators() %} @throws {% if generatorConfiguration.collectErrors() %}{{ viewHelper.getSimpleClassName(generatorConfiguration.getErrorRegistryClass()) }}{% else %}ValidationException{% endif %}{% endif %}
+                 {% if property.getValidators() %}
+                     *
+                     * @throws {% if generatorConfiguration.collectErrors() %}{{ viewHelper.getSimpleClassName(generatorConfiguration.getErrorRegistryClass()) }}{% else %}ValidationException{% endif %}
+                 {% endif %}
                  *
                  * @return static
                  */
@@ -217,5 +219,3 @@ class {{ schema.getClassName() }}{% if schema.getInterfaces() %} implements {{ v
 
 {{ viewHelper.renderMethods(schema) }}
 }
-
-// @codeCoverageIgnoreEnd

--- a/src/Templates/Validator/AdditionalProperties.phptpl
+++ b/src/Templates/Validator/AdditionalProperties.phptpl
@@ -22,10 +22,10 @@
                 $this->_errorRegistry = new {{ viewHelper.getSimpleClassName(generatorConfiguration.getErrorRegistryClass()) }}();
             {% endif %}
 
-            {{ viewHelper.resolvePropertyDecorator(validationProperty) }}
+            {{ viewHelper.resolvePropertyDecorator(validationProperty, false, 3) }}
 
             {% foreach validationProperty.getOrderedValidators() as validator %}
-                {{ viewHelper.renderValidator(validator, schema) }}
+                {{ viewHelper.renderValidator(validator, schema, 3) }}
             {% endforeach %}
 
             {% if generatorConfiguration.collectErrors() %}

--- a/src/Templates/Validator/ArrayContains.phptpl
+++ b/src/Templates/Validator/ArrayContains.phptpl
@@ -13,10 +13,10 @@ is_array($value) && (function (&$items) {
                 $this->_errorRegistry = new {{ viewHelper.getSimpleClassName(generatorConfiguration.getErrorRegistryClass()) }}();
             {% endif %}
 
-            {{ viewHelper.resolvePropertyDecorator(property) }}
+            {{ viewHelper.resolvePropertyDecorator(property, false, 3) }}
 
             {% foreach property.getOrderedValidators() as validator %}
-                {{ viewHelper.renderValidator(validator, schema) }}
+                {{ viewHelper.renderValidator(validator, schema, 3) }}
             {% endforeach %}
 
             {% if generatorConfiguration.collectErrors() %}

--- a/src/Templates/Validator/ArrayItem.phptpl
+++ b/src/Templates/Validator/ArrayItem.phptpl
@@ -9,10 +9,10 @@ is_array($value) && (function (&$items) use (&$invalidItems{{ suffix }}, $modelD
         {% endif %}
 
         try {
-            {{ viewHelper.resolvePropertyDecorator(nestedProperty) }}
+            {{ viewHelper.resolvePropertyDecorator(nestedProperty, false, 3) }}
 
             {% foreach nestedProperty.getOrderedValidators() as validator %}
-                {{ viewHelper.renderValidator(validator, schema) }}
+                {{ viewHelper.renderValidator(validator, schema, 3) }}
             {% endforeach %}
 
             {% if generatorConfiguration.collectErrors() %}

--- a/src/Templates/Validator/ArrayTuple.phptpl
+++ b/src/Templates/Validator/ArrayTuple.phptpl
@@ -16,10 +16,10 @@ is_array($value) && (function (&$items) use (&$invalidTuples, $modelData) {
             {% endif %}
 
             $value = &$items[$index++];
-            {{ viewHelper.resolvePropertyDecorator(tuple) }}
+            {{ viewHelper.resolvePropertyDecorator(tuple, false, 2) }}
 
             {% foreach tuple.getOrderedValidators() as validator %}
-                {{ viewHelper.renderValidator(validator, schema) }}
+                {{ viewHelper.renderValidator(validator, schema, 2) }}
             {% endforeach %}
 
             {% if generatorConfiguration.collectErrors() %}

--- a/src/Templates/Validator/ComposedItem.phptpl
+++ b/src/Templates/Validator/ComposedItem.phptpl
@@ -52,55 +52,10 @@
                         throw new \Exception();
                     }
                 } else {
-            {% endif %}
-
-            {% if generatorConfiguration.collectErrors() %}
-                // collect errors for each composition element
-                $this->_errorRegistry = new {{ viewHelper.getSimpleClassName(generatorConfiguration.getErrorRegistryClass()) }}();
-            {% endif %}
-
-            {% if not postPropose %}
-                $proposedValue = $proposedValue ?? $value;
-            {% endif %}
-
-            {{ viewHelper.resolvePropertyDecorator(compositionProperty, false, 2) }}
-
-            {% foreach compositionProperty.getOrderedValidators() as validator %}
-                {{ viewHelper.renderValidator(validator, schema, 2) }}
-            {% endforeach %}
-
-            {% if generatorConfiguration.collectErrors() %}
-                $compositionErrorCollection[] = $this->_errorRegistry;
-
-                {% if viewHelper.isMutableBaseValidator(generatorConfiguration, isBaseValidator) %}
-                    if (isset($validatorIndex)) {
-                        $this->_propertyValidationState[$validatorIndex][$validatorComponentIndex] = $this->_errorRegistry;
-                    }
-                {% endif %}
-
-                // an error inside the composed validation occurred. Throw an exception to count the validity of the
-                // composition item
-                if ($this->_errorRegistry->getErrors()) {
-                    throw new \Exception();
+                    {{ viewHelper.indent(renderComposedItemBody(compositionProperty, true, hasModifiedValuesMethod, modifiedValuesMethod, postPropose), 3) }}
                 }
-            {% endif %}
-
-            {% if postPropose %}
-                $proposedValue = $proposedValue ?? $value;
-            {% endif %}
-
-            {% if hasModifiedValuesMethod %}
-                if (is_object($value)) {
-                    $modifiedValues = array_merge($modifiedValues, $this->{{ modifiedValuesMethod }}($originalModelData, $value, $validatorComponentIndex));
-                }
-            {% endif %}
-            {% if viewHelper.isMutableBaseValidator(generatorConfiguration, isBaseValidator) %}
-                {% if not generatorConfiguration.collectErrors() %}
-                    if (isset($validatorIndex)) {
-                        $this->_propertyValidationState[$validatorIndex][$validatorComponentIndex] = true;
-                    }
-                {% endif %}
-            }
+            {% else %}
+                {{ viewHelper.indent(renderComposedItemBody(compositionProperty, false, hasModifiedValuesMethod, modifiedValuesMethod, postPropose), 2) }}
             {% endif %}
         } catch (\Exception $e) {
             {% if viewHelper.isMutableBaseValidator(generatorConfiguration, isBaseValidator)

--- a/src/Templates/Validator/ComposedItem.phptpl
+++ b/src/Templates/Validator/ComposedItem.phptpl
@@ -27,7 +27,8 @@
             {% if viewHelper.isMutableBaseValidator(generatorConfiguration, isBaseValidator) %}
                 // check if the state of the validator is already known.
                 // If none of the properties affected by the validator are changed the validator must not be re-evaluated
-                if (isset($validatorIndex) &&
+                if (
+                    isset($validatorIndex) &&
                     isset($this->_propertyValidationState[$validatorIndex][$validatorComponentIndex]) &&
                     !array_intersect(
                         array_keys($modifiedModelData),
@@ -53,46 +54,46 @@
                 } else {
             {% endif %}
 
-                {% if generatorConfiguration.collectErrors() %}
-                    // collect errors for each composition element
-                    $this->_errorRegistry = new {{ viewHelper.getSimpleClassName(generatorConfiguration.getErrorRegistryClass()) }}();
-                {% endif %}
+            {% if generatorConfiguration.collectErrors() %}
+                // collect errors for each composition element
+                $this->_errorRegistry = new {{ viewHelper.getSimpleClassName(generatorConfiguration.getErrorRegistryClass()) }}();
+            {% endif %}
 
-                {% if not postPropose %}
-                    $proposedValue = $proposedValue ?? $value;
-                {% endif %}
+            {% if not postPropose %}
+                $proposedValue = $proposedValue ?? $value;
+            {% endif %}
 
-                {{ viewHelper.resolvePropertyDecorator(compositionProperty) }}
+            {{ viewHelper.resolvePropertyDecorator(compositionProperty, false, 2) }}
 
-                {% foreach compositionProperty.getOrderedValidators() as validator %}
-                    {{ viewHelper.renderValidator(validator, schema) }}
-                {% endforeach %}
+            {% foreach compositionProperty.getOrderedValidators() as validator %}
+                {{ viewHelper.renderValidator(validator, schema, 2) }}
+            {% endforeach %}
 
-                {% if generatorConfiguration.collectErrors() %}
-                    $compositionErrorCollection[] = $this->_errorRegistry;
+            {% if generatorConfiguration.collectErrors() %}
+                $compositionErrorCollection[] = $this->_errorRegistry;
 
-                    {% if viewHelper.isMutableBaseValidator(generatorConfiguration, isBaseValidator) %}
-                        if (isset($validatorIndex)) {
-                            $this->_propertyValidationState[$validatorIndex][$validatorComponentIndex] = $this->_errorRegistry;
-                        }
-                    {% endif %}
-
-                    // an error inside the composed validation occurred. Throw an exception to count the validity of the
-                    // composition item
-                    if ($this->_errorRegistry->getErrors()) {
-                        throw new \Exception();
+                {% if viewHelper.isMutableBaseValidator(generatorConfiguration, isBaseValidator) %}
+                    if (isset($validatorIndex)) {
+                        $this->_propertyValidationState[$validatorIndex][$validatorComponentIndex] = $this->_errorRegistry;
                     }
                 {% endif %}
 
-                {% if postPropose %}
-                    $proposedValue = $proposedValue ?? $value;
-                {% endif %}
+                // an error inside the composed validation occurred. Throw an exception to count the validity of the
+                // composition item
+                if ($this->_errorRegistry->getErrors()) {
+                    throw new \Exception();
+                }
+            {% endif %}
 
-                {% if hasModifiedValuesMethod %}
-                    if (is_object($value)) {
-                        $modifiedValues = array_merge($modifiedValues, $this->{{ modifiedValuesMethod }}($originalModelData, $value, $validatorComponentIndex));
-                    }
-                {% endif %}
+            {% if postPropose %}
+                $proposedValue = $proposedValue ?? $value;
+            {% endif %}
+
+            {% if hasModifiedValuesMethod %}
+                if (is_object($value)) {
+                    $modifiedValues = array_merge($modifiedValues, $this->{{ modifiedValuesMethod }}($originalModelData, $value, $validatorComponentIndex));
+                }
+            {% endif %}
             {% if viewHelper.isMutableBaseValidator(generatorConfiguration, isBaseValidator) %}
                 {% if not generatorConfiguration.collectErrors() %}
                     if (isset($validatorIndex)) {
@@ -133,7 +134,7 @@
                 $value = array_merge($value, $modifiedValues);
             }
 
-            {{ viewHelper.resolvePropertyDecorator(mergedProperty) }}
+            {{ viewHelper.resolvePropertyDecorator(mergedProperty, false, 2) }}
         } elseif ($compositionSatisfied) {
             $value = $proposedValue;
         } else {

--- a/src/Templates/Validator/ComposedItemBody.phptpl
+++ b/src/Templates/Validator/ComposedItemBody.phptpl
@@ -1,0 +1,47 @@
+{% if generatorConfiguration.collectErrors() %}
+    // collect errors for each composition element
+    $this->_errorRegistry = new {{ viewHelper.getSimpleClassName(generatorConfiguration.getErrorRegistryClass()) }}();
+{% endif %}
+
+{% if not postPropose %}
+    $proposedValue = $proposedValue ?? $value;
+{% endif %}
+
+{{ viewHelper.resolvePropertyDecorator(compositionProperty, false, 0) }}
+
+{% foreach compositionProperty.getOrderedValidators() as validator %}
+    {{ viewHelper.renderValidator(validator, schema, 0) }}
+{% endforeach %}
+
+{% if generatorConfiguration.collectErrors() %}
+    $compositionErrorCollection[] = $this->_errorRegistry;
+
+    {% if isMutableBaseValidator %}
+        if (isset($validatorIndex)) {
+            $this->_propertyValidationState[$validatorIndex][$validatorComponentIndex] = $this->_errorRegistry;
+        }
+    {% endif %}
+
+    // an error inside the composed validation occurred. Throw an exception to count the validity of the
+    // composition item
+    if ($this->_errorRegistry->getErrors()) {
+        throw new \Exception();
+    }
+{% endif %}
+
+{% if postPropose %}
+    $proposedValue = $proposedValue ?? $value;
+{% endif %}
+
+{% if hasModifiedValuesMethod %}
+    if (is_object($value)) {
+        $modifiedValues = array_merge($modifiedValues, $this->{{ modifiedValuesMethod }}($originalModelData, $value, $validatorComponentIndex));
+    }
+{% endif %}
+{% if isMutableBaseValidator %}
+    {% if not generatorConfiguration.collectErrors() %}
+        if (isset($validatorIndex)) {
+            $this->_propertyValidationState[$validatorIndex][$validatorComponentIndex] = true;
+        }
+    {% endif %}
+{% endif %}

--- a/src/Templates/Validator/ConditionalComposedItem.phptpl
+++ b/src/Templates/Validator/ConditionalComposedItem.phptpl
@@ -14,10 +14,10 @@
     {% endif %}
 
     try {
-        {{ viewHelper.resolvePropertyDecorator(ifProperty) }}
+        {{ viewHelper.resolvePropertyDecorator(ifProperty, false, 2) }}
 
         {% foreach ifProperty.getOrderedValidators() as validator %}
-            {{ viewHelper.renderValidator(validator, schema) }}
+            {{ viewHelper.renderValidator(validator, schema, 2) }}
         {% endforeach %}
 
         {% if generatorConfiguration.collectErrors() %}
@@ -37,10 +37,10 @@
     if (!$ifException) {
         {% if thenProperty %}
             try {
-                {{ viewHelper.resolvePropertyDecorator(thenProperty) }}
+                {{ viewHelper.resolvePropertyDecorator(thenProperty, false, 3) }}
 
                 {% foreach thenProperty.getOrderedValidators() as validator %}
-                    {{ viewHelper.renderValidator(validator, schema) }}
+                    {{ viewHelper.renderValidator(validator, schema, 3) }}
                 {% endforeach %}
 
                 {% if generatorConfiguration.collectErrors() %}
@@ -55,10 +55,10 @@
     } else {
         {% if elseProperty %}
             try {
-                {{ viewHelper.resolvePropertyDecorator(elseProperty) }}
+                {{ viewHelper.resolvePropertyDecorator(elseProperty, false, 3) }}
 
                 {% foreach elseProperty.getOrderedValidators() as validator %}
-                    {{ viewHelper.renderValidator(validator, schema) }}
+                    {{ viewHelper.renderValidator(validator, schema, 3) }}
                 {% endforeach %}
 
                 {% if generatorConfiguration.collectErrors() %}

--- a/src/Templates/Validator/ExtractedMethod.phptpl
+++ b/src/Templates/Validator/ExtractedMethod.phptpl
@@ -1,0 +1,10 @@
+private function {{ methodName }}(&$value, $modelData): void
+{
+    {% if setUp %}
+        {{ viewHelper.indent(setUp, 1) }}
+
+    {% endif %}
+    if {{ viewHelper.formatCondition(check, 1) }} {
+        {{ viewHelper.indent(errorHandling, 2) }}
+    }
+}

--- a/src/Templates/Validator/Filter.phptpl
+++ b/src/Templates/Validator/Filter.phptpl
@@ -1,6 +1,6 @@
-{% if skipTransformedValuesCheck %}{{ skipTransformedValuesCheck }} && {% endif %}
-(
-    {% if typeCheck %}{{ typeCheck }} && {% endif %}
+{% if skipTransformedValuesCheck %}{{ skipTransformedValuesCheck }} &&
+{% endif %}(
+    {% if typeCheck %}{{ typeCheck }} &&{% endif %}
     (function (&$value) use (&$transformationFailed): bool {
         // make sure exceptions from the filter are caught and added to the error handling
         try {

--- a/src/Templates/Validator/FilterPreTransformGuard.phptpl
+++ b/src/Templates/Validator/FilterPreTransformGuard.phptpl
@@ -1,0 +1,8 @@
+private function {{ guardMethodName }}(&$value, $modelData): void
+{
+    if {{ viewHelper.formatCondition(skipCheck, 1) }} {
+        return;
+    }
+
+    $this->{{ innerMethodName }}($value, $modelData);
+}

--- a/src/Templates/Validator/PatternProperties.phptpl
+++ b/src/Templates/Validator/PatternProperties.phptpl
@@ -16,10 +16,10 @@
                 $this->_errorRegistry = new {{ viewHelper.getSimpleClassName(generatorConfiguration.getErrorRegistryClass()) }}();
             {% endif %}
 
-            {{ viewHelper.resolvePropertyDecorator(validationProperty) }}
+            {{ viewHelper.resolvePropertyDecorator(validationProperty, false, 3) }}
 
             {% foreach validationProperty.getOrderedValidators() as validator %}
-                {{ viewHelper.renderValidator(validator, schema) }}
+                {{ viewHelper.renderValidator(validator, schema, 3) }}
             {% endforeach %}
 
             {% if generatorConfiguration.collectErrors() %}

--- a/src/Templates/Validator/PropertyNames.phptpl
+++ b/src/Templates/Validator/PropertyNames.phptpl
@@ -13,7 +13,7 @@
             {% endif %}
 
             {% foreach nameValidationProperty.getOrderedValidators() as validator %}
-                {{ viewHelper.renderValidator(validator, schema) }}
+                {{ viewHelper.renderValidator(validator, schema, 3) }}
             {% endforeach %}
 
             {% if generatorConfiguration.collectErrors() %}

--- a/src/Templates/Validator/SchemaDependency.phptpl
+++ b/src/Templates/Validator/SchemaDependency.phptpl
@@ -7,7 +7,7 @@ array_key_exists('{{ property.getName() }}', $modelData) && (function () use ($m
     {% endif %}
 
     $value = $modelData;
-    {{ viewHelper.resolvePropertyDecorator(nestedProperty) }}
+    {{ viewHelper.resolvePropertyDecorator(nestedProperty, false, 1) }}
 
     {% if generatorConfiguration.collectErrors() %}
         if ($this->_errorRegistry->getErrors()) {

--- a/src/Templates/Validator/SchemaDependency.phptpl
+++ b/src/Templates/Validator/SchemaDependency.phptpl
@@ -2,20 +2,17 @@ array_key_exists('{{ property.getName() }}', $modelData) && (function () use ($m
     {% if generatorConfiguration.collectErrors() %}
         $originalErrorRegistry = $this->_errorRegistry;
         $this->_errorRegistry = new {{ viewHelper.getSimpleClassName(generatorConfiguration.getErrorRegistryClass()) }}();
-    {% else %}
-        try {
-    {% endif %}
 
-    $value = $modelData;
-    {{ viewHelper.resolvePropertyDecorator(nestedProperty, false, 1) }}
+        {{ viewHelper.indent(renderSchemaDependencyBody(), 1) }}
 
-    {% if generatorConfiguration.collectErrors() %}
         if ($this->_errorRegistry->getErrors()) {
             $dependencyException = $this->_errorRegistry;
         }
 
         $this->_errorRegistry = $originalErrorRegistry;
     {% else %}
+        try {
+            {{ viewHelper.indent(renderSchemaDependencyBody(), 2) }}
         } catch (\Exception $e) {
             $dependencyException = $e;
         }

--- a/src/Templates/Validator/SchemaDependencyBody.phptpl
+++ b/src/Templates/Validator/SchemaDependencyBody.phptpl
@@ -1,0 +1,2 @@
+$value = $modelData;
+{{ viewHelper.resolvePropertyDecorator(nestedProperty, false, 0) }}

--- a/src/Utils/RenderFactory.php
+++ b/src/Utils/RenderFactory.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PHPModelGenerator\Utils;
+
+use PHPMicroTemplate\Render;
+use PHPMicroTemplate\RenderConfig;
+
+/**
+ * Class RenderFactory
+ *
+ * Single point of truth for constructing Render instances: every consumer in this library renders with
+ * autoIndent enabled to get PSR-12-compliant output, so that choice lives here instead of being repeated
+ * (and risking drift) at every call site. Instances are cached per base path, since a Render instance holds
+ * no request-specific state and every call site with the same base path can safely share one.
+ *
+ * @package PHPModelGenerator\Utils
+ */
+class RenderFactory
+{
+    /** @var Render[] */
+    private static array $renderers = [];
+
+    public static function create(string $basePath): Render
+    {
+        return self::$renderers[$basePath] ??= new Render($basePath, new RenderConfig(true));
+    }
+}

--- a/src/Utils/RenderFactory.php
+++ b/src/Utils/RenderFactory.php
@@ -24,6 +24,6 @@ class RenderFactory
 
     public static function create(string $basePath): Render
     {
-        return self::$renderers[$basePath] ??= new Render($basePath, new RenderConfig(true));
+        return self::$renderers[$basePath] ??= new Render($basePath, new RenderConfig(autoIndent: true));
     }
 }

--- a/src/Utils/RenderHelper.php
+++ b/src/Utils/RenderHelper.php
@@ -55,13 +55,51 @@ class RenderHelper
     /**
      * Resolve all associated decorators of a property
      */
-    public function resolvePropertyDecorator(PropertyInterface $property, bool $nestedProperty = false): string
-    {
+    public function resolvePropertyDecorator(
+        PropertyInterface $property,
+        bool $nestedProperty = false,
+        int $indentLevel = 0,
+    ): string {
         if (!$property->getDecorators()) {
             return '';
         }
 
-        return '$value = ' . $property->resolveDecorator('$value', $nestedProperty) . ';';
+        return self::indent(
+            '$value = ' . $property->resolveDecorator('$value', $nestedProperty) . ';',
+            $indentLevel,
+        );
+    }
+
+    /**
+     * Indent every line of $code but the first by $indentLevel additional levels of 4 spaces. The first line is
+     * left untouched as it directly follows the calling context's own leading whitespace, which already puts it at
+     * the correct column - only the continuation lines of a multi-line snippet need to be shifted to match.
+     */
+    public static function indent(string $code, int $indentLevel): string
+    {
+        if ($indentLevel === 0 || $code === '') {
+            return $code;
+        }
+
+        return str_replace("\n", "\n" . str_repeat('    ', $indentLevel), $code);
+    }
+
+    /**
+     * Wrap $check in parentheses for use as an if-condition. PSR-12 requires a multi-line condition's first
+     * expression to start on the line after the opening parenthesis, with the closing parenthesis back at the
+     * condition's own column - a single-line check keeps the compact "(check)" form instead, since that rule only
+     * applies once a condition already spans multiple lines. $indentLevel is the level the "if" keyword itself sits
+     * at (0 if it starts its own line/string), used to align the closing parenthesis under it and the check one
+     * level deeper.
+     */
+    public static function formatCondition(string $check, int $indentLevel): string
+    {
+        if (!str_contains($check, "\n")) {
+            return "($check)";
+        }
+
+        return "(\n" . str_repeat('    ', $indentLevel + 1) . self::indent($check, $indentLevel + 1)
+            . "\n" . str_repeat('    ', $indentLevel) . ')';
     }
 
     /**
@@ -72,7 +110,7 @@ class RenderHelper
         $exceptionConstructor = sprintf(
             'new \%s($value ?? null, ...%s)',
             $validator->getExceptionClass(),
-            preg_replace('/\'&(\$\w+)\'/i', '$1', var_export($validator->getExceptionParams(), true)),
+            preg_replace('/\'&(\$\w+)\'/i', '$1', self::varExportArray($validator->getExceptionParams())),
         );
 
         if ($this->generatorConfiguration->collectErrors()) {
@@ -141,7 +179,7 @@ class RenderHelper
         return implode('|', $parts);
     }
 
-    public function renderValidator(PropertyValidatorInterface $validator, Schema $schema): string
+    public function renderValidator(PropertyValidatorInterface $validator, Schema $schema, int $indentLevel = 0): string
     {
         // scoping of the validator might be required as validators from a composition might be transferred to a
         // different schema
@@ -150,12 +188,13 @@ class RenderHelper
         }
 
         if (!$validator instanceof ExtractedMethodValidator) {
-            return "
-{$validator->getValidatorSetUp()}
-if ({$validator->getCheck()}) {
-    {$this->validationError($validator)}
-}
-";
+            $setUp = $validator->getValidatorSetUp();
+
+            $code = ($setUp !== '' ? "{$setUp}\n" : '')
+                . 'if ' . self::formatCondition($validator->getCheck(), 0)
+                . " {\n    {$this->validationError($validator)}\n}";
+
+            return self::indent($code, $indentLevel);
         }
 
         if (!$schema->hasMethod($validator->getExtractedMethodName())) {
@@ -165,13 +204,22 @@ if ({$validator->getCheck()}) {
         return "\$this->{$validator->getExtractedMethodName()}(\$value, \$modelData);";
     }
 
+    /**
+     * Every rendered method's own getCode() output is self-contained, built relative to its own first line sitting
+     * at column 0 - the same convention every other multi-line snippet in this class follows. Concatenating several
+     * methods together means only the very first one could ever inherit a "free" ambient column from the calling
+     * template (and only if it happened to be first), so every method here - including the first - is explicitly
+     * indented one full level (matching the class body) instead of relying on template-side ambient indentation.
+     */
     public function renderMethods(Schema $schema): string
     {
         $renderedMethods = '';
 
         // don't change to a foreach loop as the render process of a method might add additional methods
         for ($i = 0; $i < count($schema->getMethods()); $i++) {
-            $renderedMethods .= $schema->getMethods()[array_keys($schema->getMethods())[$i]]->getCode() . "\n\n";
+            $code = $schema->getMethods()[array_keys($schema->getMethods())[$i]]->getCode();
+
+            $renderedMethods .= '    ' . self::indent($code, 1) . "\n\n";
         }
 
         return $renderedMethods;
@@ -182,9 +230,37 @@ if ({$validator->getCheck()}) {
         return !$generatorConfiguration->isImmutable() && $isBaseValidator;
     }
 
-    public static function varExportArray(array $values): string
+    /**
+     * Render $value as a PHP literal suitable for embedding directly in generated code: short-array ([...]) syntax
+     * for arrays (recursively, preserving string keys for associative arrays), plain var_export() for everything
+     * else. var_export() alone always emits the old array (...) syntax for arrays, which - unlike its output for
+     * scalars - is genuinely multi-line and needs the caller to account for indentation; routing every array value
+     * embedded in generated code through this method avoids that.
+     */
+    public static function varExportArray(mixed $values): string
     {
-        return preg_replace('(\d+\s=>)', '', var_export($values, true));
+        if (!is_array($values)) {
+            return self::exportScalar($values);
+        }
+
+        $isList = array_is_list($values);
+
+        $entries = [];
+        foreach ($values as $key => $value) {
+            $exportedValue = is_array($value) ? self::varExportArray($value) : self::exportScalar($value);
+            $entries[] = $isList ? $exportedValue : var_export($key, true) . ' => ' . $exportedValue;
+        }
+
+        return '[' . implode(', ', $entries) . ']';
+    }
+
+    /**
+     * var_export(null, true) returns the string "NULL" - unlike its output for true/false, which is already
+     * lowercase "true"/"false" - so it's the one scalar case PSR-12's lowercase-constant rule always rejects.
+     */
+    private static function exportScalar(mixed $value): string
+    {
+        return $value === null ? 'null' : var_export($value, true);
     }
 
     public static function filterClassImports(array $imports, string $namespace): array
@@ -196,5 +272,27 @@ if ({$validator->getCheck()}) {
                 strstr(trim(str_replace("$namespace", '', $classPath), '\\'), '\\')
                     || (!str_contains($classPath, '\\') && !empty($namespace)),
         );
+    }
+
+    /**
+     * The template engine only removes {% %} tags themselves, not the surrounding whitespace/newline of the line
+     * they occupy, so a tag placed alone on its own line (the common case for {% if %}/{% foreach %}) leaves a
+     * whitespace-only line behind in the rendered output. Normalize those away instead of restructuring every
+     * template to avoid a tag ever sitting alone on a line, which would make the templates themselves far less
+     * readable. Also drops blank lines directly after an opening brace or directly before a closing one, which
+     * PSR-12 disallows regardless of how they got there.
+     *
+     * Shared by every renderer that writes a class file to disk (the main RenderJob, and the
+     * Builder/Companion/Enum post processors), since every one of them renders through the same templating engine
+     * and is subject to the same artifact.
+     */
+    public static function collapseBlankLines(string $code): string
+    {
+        $code = preg_replace('/^[ \t]+$/m', '', $code);
+        $code = preg_replace('/\n{3,}/', "\n\n", $code);
+        $code = preg_replace('/\{\n\n+/', "{\n", $code);
+        $code = preg_replace('/\n\n+([ \t]*\})/', "\n$1", $code);
+
+        return $code;
     }
 }

--- a/tests/AbstractPHPModelGeneratorTestCase.php
+++ b/tests/AbstractPHPModelGeneratorTestCase.php
@@ -12,6 +12,7 @@ use PHPModelGenerator\Logger\EchoLogger;
 use PHPModelGenerator\Model\SchemaDefinition\JsonSchema;
 use PHPModelGenerator\SchemaProvider\OpenAPIv3Provider;
 use PHPModelGenerator\SchemaProvider\RecursiveDirectoryProvider;
+use PHPModelGenerator\Tests\CodeQuality\GeneratedCodeAuditor;
 use PHPModelGenerator\Utils\ClassNameGenerator;
 use PHPModelGenerator\Exception\ErrorRegistryException;
 use PHPModelGenerator\Exception\FileSystemException;
@@ -87,6 +88,10 @@ abstract class AbstractPHPModelGeneratorTestCase extends TestCase
                     $failedResultDir . $nestedDir . DIRECTORY_SEPARATOR . basename($file),
                 );
             }
+        }
+
+        if (GeneratedCodeAuditor::isEnabled()) {
+            GeneratedCodeAuditor::collect(TEST_BASE_DIR . '/Models', static::class . '::' . $this->name());
         }
 
         $this->names = [];

--- a/tests/CodeQuality/GeneratedCodeAuditor.php
+++ b/tests/CodeQuality/GeneratedCodeAuditor.php
@@ -59,12 +59,7 @@ final class GeneratedCodeAuditor
             self::$fileCounter++;
             $auditPath = self::$auditDirectory . '/' . self::$fileCounter . '_' . $file->getFilename();
 
-            file_put_contents(
-                $auditPath,
-                // "@codingStandardsIgnoreFile" makes phpcs skip the file outright, which would silently exclude
-                // it from the audit rather than actually checking it
-                preg_replace('/^\/\/ @codingStandardsIgnoreFile\n/m', '', file_get_contents($file->getPathname())),
-            );
+            copy($file->getPathname(), $auditPath);
 
             self::$testLabelByAuditPath[$auditPath] = $testLabel;
         }

--- a/tests/CodeQuality/GeneratedCodeAuditor.php
+++ b/tests/CodeQuality/GeneratedCodeAuditor.php
@@ -1,0 +1,128 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PHPModelGenerator\Tests\CodeQuality;
+
+use FilesystemIterator;
+use RecursiveDirectoryIterator;
+use RecursiveIteratorIterator;
+use SplFileInfo;
+
+/**
+ * Opt-in (PHPCS_GENERATED_CODE_AUDIT=1) hook that lets the whole test suite double as a corpus for the generated
+ * code coding standard: every test's tearDown() hands the models directory to collect(), which copies every PHP
+ * file found there - not just the main schema classes returned by ModelGenerator::generateModels(), but also
+ * Builder/Companion/Enum classes, which their post processors write directly to disk and never register in that
+ * return value - into a process-lifetime directory. A single phpcs run over that whole directory, triggered once
+ * via register_shutdown_function() after the last test finishes, produces one JSON report grouping findings by
+ * the test that produced each file, for evaluating formatting edge cases across the existing schema fixtures
+ * without hand-picking a subset of them.
+ */
+final class GeneratedCodeAuditor
+{
+    private const ENV_VAR = 'PHPCS_GENERATED_CODE_AUDIT';
+    private const REPORT_PATH_ENV_VAR = 'PHPCS_GENERATED_CODE_AUDIT_REPORT';
+
+    private static ?string $auditDirectory = null;
+    private static int $fileCounter = 0;
+    private static array $testLabelByAuditPath = [];
+
+    public static function isEnabled(): bool
+    {
+        return (bool) getenv(self::ENV_VAR);
+    }
+
+    public static function collect(string $modelsDirectory, string $testLabel): void
+    {
+        if (!is_dir($modelsDirectory)) {
+            return;
+        }
+
+        if (self::$auditDirectory === null) {
+            self::$auditDirectory = sys_get_temp_dir() . '/phpcs-generated-code-audit-' . uniqid('', true);
+            mkdir(self::$auditDirectory, 0777, true);
+
+            register_shutdown_function([self::class, 'report']);
+        }
+
+        $iterator = new RecursiveIteratorIterator(
+            new RecursiveDirectoryIterator($modelsDirectory, FilesystemIterator::SKIP_DOTS),
+        );
+
+        /** @var SplFileInfo $file */
+        foreach ($iterator as $file) {
+            if ($file->getExtension() !== 'php') {
+                continue;
+            }
+
+            self::$fileCounter++;
+            $auditPath = self::$auditDirectory . '/' . self::$fileCounter . '_' . $file->getFilename();
+
+            file_put_contents(
+                $auditPath,
+                // "@codingStandardsIgnoreFile" makes phpcs skip the file outright, which would silently exclude
+                // it from the audit rather than actually checking it
+                preg_replace('/^\/\/ @codingStandardsIgnoreFile\n/m', '', file_get_contents($file->getPathname())),
+            );
+
+            self::$testLabelByAuditPath[$auditPath] = $testLabel;
+        }
+    }
+
+    public static function report(): void
+    {
+        if (self::$auditDirectory === null) {
+            return;
+        }
+
+        // phpcs writes its "Time: ...; Memory: ..." summary to stderr even for machine-readable reports, so
+        // stderr must stay separate from stdout - merging it would corrupt the JSON report on stdout
+        $command = sprintf(
+            '%s --standard=%s --report=json %s',
+            escapeshellarg(__DIR__ . '/../../vendor/bin/phpcs'),
+            escapeshellarg(__DIR__ . '/../generated_code_phpcs.xml'),
+            escapeshellarg(self::$auditDirectory),
+        );
+
+        $phpcsReport = json_decode(shell_exec($command) ?? '', true) ?? ['totals' => [], 'files' => []];
+
+        $findings = [];
+        foreach ($phpcsReport['files'] ?? [] as $auditPath => $fileReport) {
+            foreach ($fileReport['messages'] as $message) {
+                $findings[] = [
+                    'test' => self::$testLabelByAuditPath[$auditPath] ?? 'unknown',
+                    'file' => preg_replace('/^\d+_/', '', basename($auditPath)),
+                    'line' => $message['line'],
+                    'type' => $message['type'],
+                    'source' => $message['source'],
+                    'message' => $message['message'],
+                ];
+            }
+        }
+
+        $reportPath = getenv(self::REPORT_PATH_ENV_VAR) ?: (sys_get_temp_dir() . '/generated-code-audit-report.json');
+
+        file_put_contents(
+            $reportPath,
+            json_encode(
+                [
+                    'totals' => $phpcsReport['totals'] ?? [],
+                    'filesChecked' => count($phpcsReport['files'] ?? []),
+                    'findings' => $findings,
+                ],
+                JSON_PRETTY_PRINT,
+            ),
+        );
+
+        fwrite(
+            STDERR,
+            sprintf(
+                "\nGenerated-code audit: %d finding(s) across %d file(s). Report: %s\n",
+                count($findings),
+                count($phpcsReport['files'] ?? []),
+                $reportPath,
+            ),
+        );
+    }
+}

--- a/tests/CodeQuality/GeneratedCodeFormattingTest.php
+++ b/tests/CodeQuality/GeneratedCodeFormattingTest.php
@@ -1,0 +1,328 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PHPModelGenerator\Tests\CodeQuality;
+
+use DateTime;
+use PHPModelGenerator\Filter\FilterInterface;
+use PHPModelGenerator\Model\GeneratorConfiguration;
+use PHPModelGenerator\Model\Property\PropertyInterface;
+use PHPModelGenerator\Model\Schema;
+use PHPModelGenerator\ModelGenerator;
+use PHPModelGenerator\SchemaProcessor\Hook\SetterBeforeValidationHookInterface;
+use PHPModelGenerator\SchemaProcessor\PostProcessor\AdditionalPropertiesAccessorPostProcessor;
+use PHPModelGenerator\SchemaProcessor\PostProcessor\BuilderClassPostProcessor;
+use PHPModelGenerator\SchemaProcessor\PostProcessor\PostProcessor;
+use PHPModelGenerator\Tests\AbstractPHPModelGeneratorTestCase;
+
+/**
+ * Runs the dedicated generated-code PHPCS ruleset (tests/generated_code_phpcs.xml) against classes generated
+ * from schemas exercising allOf composition, pattern/additional properties, array tuples/items/contains,
+ * if/then/else composition, propertyNames, schema dependencies and builder classes, to guard the formatting of
+ * the generated PHP code itself.
+ */
+class GeneratedCodeFormattingTest extends AbstractPHPModelGeneratorTestCase
+{
+    public function testComposedPropertyGeneratesCodeMatchingTheCodingStandard(): void
+    {
+        $this->generateClassFromFile(
+            'ComposedVehicle.json',
+            (new GeneratorConfiguration())
+                ->setNamespacePrefix('\\GeneratedCodeFormattingTest')
+                ->setImmutable(false)
+                ->setCollectErrors(true),
+        );
+
+        $report = $this->runPhpcs($this->getGeneratedFiles());
+
+        $this->assertSame([], $this->collectMessages($report), $this->formatReport($report));
+    }
+
+    /**
+     * Generating without a namespace prefix is an intentionally supported configuration (setNamespacePrefix() is
+     * optional), which tests/generated_code_phpcs.xml accounts for by excluding
+     * PSR1.Classes.ClassDeclaration.MissingNamespace. Exercise that case explicitly so the exclusion is proven
+     * necessary and correct, rather than trusting it was added for the right reason.
+     */
+    public function testComposedPropertyWithoutNamespaceGeneratesCodeMatchingTheCodingStandard(): void
+    {
+        $this->generateClassFromFile(
+            'ComposedVehicle.json',
+            (new GeneratorConfiguration())
+                ->setImmutable(false)
+                ->setCollectErrors(true),
+        );
+
+        $report = $this->runPhpcs($this->getGeneratedFiles());
+
+        $this->assertSame([], $this->collectMessages($report), $this->formatReport($report));
+    }
+
+    /**
+     * Covers the indentLevel wiring of PatternProperties, AdditionalProperties, ArrayTuple, ArrayItem,
+     * ArrayContains, ConditionalComposedItem (if/then/else), PropertyNames, SchemaDependency, a forbidden
+     * (patternProperties: false) pattern and a writeOnly property's serialization-exclusion hook in one
+     * generation pass, since each construct is an independent top-level schema keyword/property that doesn't
+     * interact with the others. collectErrors(true) matches the branch actually verified for SchemaDependency -
+     * its generated check has a structurally different (and separately tracked, still-imperfect) shape under
+     * collectErrors(false), which AbstractPHPModelGeneratorTestCase::generateClass() defaults to when no
+     * configuration is passed explicitly. setSerialization(true) is required for the writeOnly exclusion hook
+     * to be generated at all.
+     */
+    public function testComprehensivePropertyTypesGenerateCodeMatchingTheCodingStandard(): void
+    {
+        $this->generateClassFromFile(
+            'ComprehensiveFormatting.json',
+            (new GeneratorConfiguration())
+                ->setNamespacePrefix('\\GeneratedCodeFormattingTest')
+                ->setImmutable(false)
+                ->setCollectErrors(true)
+                ->setSerialization(true),
+        );
+
+        $report = $this->runPhpcs($this->getGeneratedFiles());
+
+        $this->assertSame([], $this->collectMessages($report), $this->formatReport($report));
+    }
+
+    /**
+     * A filter chain where a filter runs after a transforming filter (here: dateTime followed by a custom
+     * stripTime filter) renders Filter.phptpl with skipTransformedValuesCheck populated ("!$transformationFailed
+     * &&" prefixing the check), a branch the other tests never exercise since their filters aren't chained after
+     * a transforming filter. That branch previously left a stray blank line ahead of the check whenever
+     * skipTransformedValuesCheck was empty (the dateTime filter itself, first in the chain) - both states of the
+     * same template need coverage since the fix could regress either independently.
+     */
+    public function testFilterChainGeneratesCodeMatchingTheCodingStandard(): void
+    {
+        $this->generateClassFromFile(
+            'FilterChain.json',
+            (new GeneratorConfiguration())
+                ->setNamespacePrefix('\\GeneratedCodeFormattingTest')
+                ->addFilter($this->getStripTimeFilter()),
+        );
+
+        $report = $this->runPhpcs($this->getGeneratedFiles());
+
+        $this->assertSame([], $this->collectMessages($report), $this->formatReport($report));
+    }
+
+    private function getStripTimeFilter(): FilterInterface
+    {
+        // getFilter() is embedded verbatim as a literal class reference in the generated code, so it must name a
+        // real, non-anonymous class - self::class inside the anonymous FilterInterface wrapper below would
+        // resolve to the anonymous class itself, producing an unreferenceable "class@anonymous..." name.
+        return new class implements FilterInterface {
+            public function getToken(): string
+            {
+                return 'stripTime';
+            }
+
+            public function getFilter(): array
+            {
+                return [GeneratedCodeFormattingTest::class, 'stripTimeFilter'];
+            }
+        };
+    }
+
+    public static function stripTimeFilter(?DateTime $value): ?DateTime
+    {
+        return $value?->setTime(0, 0);
+    }
+
+    /**
+     * AdditionalPropertiesAccessorPostProcessor's additionalProperties() method is rendered through
+     * RenderedMethod, which - unlike most other rendering paths - enables php-micro-template's block dedent
+     * (blockIndentWidth 4), stripping one level of leading whitespace from a standalone {% if %}'s body before
+     * it is embedded. AdditionalPropertiesAccessorMethod.phptpl previously wrote the "not immutable" branch's
+     * body at the same column as the {% if %} tag itself instead of one level deeper as that convention
+     * requires, so the dedent stripped real indentation instead of a no-op decorative level, under-indenting
+     * the setter/remover arguments by one level. This only surfaces with setImmutable(false), since the whole
+     * branch is empty otherwise.
+     */
+    public function testAdditionalPropertiesAccessorGeneratesCodeMatchingTheCodingStandard(): void
+    {
+        $this->modifyModelGenerator = static function (ModelGenerator $generator): void {
+            $generator->addPostProcessor(new AdditionalPropertiesAccessorPostProcessor());
+        };
+
+        $this->generateClassFromFile(
+            'ComprehensiveFormatting.json',
+            (new GeneratorConfiguration())
+                ->setNamespacePrefix('\\GeneratedCodeFormattingTest')
+                ->setImmutable(false)
+                ->setCollectErrors(true),
+        );
+
+        $report = $this->runPhpcs($this->getGeneratedFiles());
+
+        $this->assertSame([], $this->collectMessages($report), $this->formatReport($report));
+    }
+
+    /**
+     * When two or more properties both match a patternProperties pattern, PatternPropertiesPostProcessor emits a
+     * constructor hook with one "$this->_patternProperties[...][...] = &$this->...;" line per matching property.
+     * Model.phptpl previously interpolated that hook's code with a raw {{ }} (no indent() wrapping), so only the
+     * hook's first line inherited the template's ambient indentation - every subsequent line rendered at column
+     * 0, since the hook itself concatenates its lines with no per-line indentation of its own. A single matching
+     * property never exercised this, since the hook body was only ever one line.
+     */
+    public function testPatternPropertyMatchingObjectPropertyGeneratesCodeMatchingTheCodingStandard(): void
+    {
+        $this->generateClassFromFile(
+            'PatternPropertyMatchingObjectProperty.json',
+            (new GeneratorConfiguration())->setNamespacePrefix('\\GeneratedCodeFormattingTest'),
+        );
+
+        $report = $this->runPhpcs($this->getGeneratedFiles());
+
+        $this->assertSame([], $this->collectMessages($report), $this->formatReport($report));
+    }
+
+    /**
+     * ComprehensiveFormatting.json's patternProperties always registers an internal
+     * SetterBeforeValidationHookInterface hook (ExtendObjectPropertiesMatchingPatternPropertiesPostProcessor)
+     * that returns '' for every property not matching a pattern - which is every property in this schema.
+     * SchemaHookResolver::resolveHook() previously joined all hooks' code with "\n\n" unconditionally, so mixing
+     * that empty hook with a second, real hook (registered below) left a stray "\n\n" in the joined result,
+     * pushing the real hook's code onto its own line at column 0 regardless of the embedding template's ambient
+     * indentation - a single-hook schema never exercised this, since join() of one element is a no-op.
+     */
+    public function testMultipleSetterHooksWithAnEmptyHookGenerateCodeMatchingTheCodingStandard(): void
+    {
+        $this->modifyModelGenerator = static function (ModelGenerator $generator): void {
+            $generator->addPostProcessor(new class () extends PostProcessor {
+                public function process(Schema $schema, GeneratorConfiguration $generatorConfiguration): void
+                {
+                    $schema->addSchemaHook(new class () implements SetterBeforeValidationHookInterface {
+                        public function getCode(PropertyInterface $property, bool $batchUpdate = false): string
+                        {
+                            return '// setter hook';
+                        }
+                    });
+                }
+            });
+        };
+
+        $this->generateClassFromFile(
+            'ComprehensiveFormatting.json',
+            (new GeneratorConfiguration())
+                ->setNamespacePrefix('\\GeneratedCodeFormattingTest')
+                ->setImmutable(false)
+                ->setCollectErrors(true)
+                ->setSerialization(true),
+        );
+
+        $report = $this->runPhpcs($this->getGeneratedFiles());
+
+        $this->assertSame([], $this->collectMessages($report), $this->formatReport($report));
+    }
+
+    public function testBuilderClassGeneratesCodeMatchingTheCodingStandard(): void
+    {
+        $this->modifyModelGenerator = static function (ModelGenerator $generator): void {
+            $generator->addPostProcessor(new BuilderClassPostProcessor());
+        };
+
+        $this->generateClassFromFile(
+            'ComposedVehicle.json',
+            (new GeneratorConfiguration())
+                ->setNamespacePrefix('\\GeneratedCodeFormattingTest')
+                ->setCollectErrors(true),
+        );
+
+        // BuilderClassPostProcessor writes its Builder class directly to disk next to the main class file -
+        // it never registers with ModelGenerator::generateModels(), so getGeneratedFiles() alone would miss it
+        $builderFiles = array_map(
+            static fn(string $file): string => str_replace('.php', 'Builder.php', $file),
+            $this->getGeneratedFiles(),
+        );
+
+        $report = $this->runPhpcs([...$this->getGeneratedFiles(), ...$builderFiles]);
+
+        $this->assertSame([], $this->collectMessages($report), $this->formatReport($report));
+    }
+
+    /**
+     * @param string[] $files
+     */
+    private function runPhpcs(array $files): array
+    {
+        $strippedFiles = array_map($this->stripIgnoreFileMarker(...), $files);
+
+        // phpcs writes its "Time: ...; Memory: ..." summary to stderr even for machine-readable reports, so
+        // stderr must stay separate from stdout - merging it would corrupt the JSON report on stdout
+        $command = sprintf(
+            '%s --standard=%s --report=json %s',
+            escapeshellarg(__DIR__ . '/../../vendor/bin/phpcs'),
+            escapeshellarg(__DIR__ . '/../generated_code_phpcs.xml'),
+            implode(' ', array_map('escapeshellarg', $strippedFiles)),
+        );
+
+        $output = shell_exec($command);
+        $report = json_decode($output ?? '', true);
+
+        $this->assertIsArray($report, "phpcs didn't return a valid JSON report:\n" . $output);
+
+        return $report;
+    }
+
+    /**
+     * Generated classes carry "// @codingStandardsIgnoreFile", which makes phpcs skip the file entirely. Strip
+     * it from a throwaway copy so the coding standard actually gets applied for this test, without touching the
+     * original file the rest of the test run still relies on (it has already been require()d by the generator).
+     */
+    private function stripIgnoreFileMarker(string $file): string
+    {
+        // keep the .php extension so phpcs' default extension filter still picks the copy up
+        $strippedFile = preg_replace('/\.php$/', '.phpcs-check.php', $file);
+
+        file_put_contents(
+            $strippedFile,
+            preg_replace('/^\/\/ @codingStandardsIgnoreFile\n/m', '', file_get_contents($file)),
+        );
+
+        return $strippedFile;
+    }
+
+    /**
+     * @return array{type: string, source: string, line: int, message: string}[]
+     */
+    private function collectMessages(array $report): array
+    {
+        $messages = [];
+
+        foreach ($report['files'] as $file => $fileReport) {
+            foreach ($fileReport['messages'] as $message) {
+                $messages[] = [
+                    'file' => $file,
+                    'line' => $message['line'],
+                    'type' => $message['type'],
+                    'source' => $message['source'],
+                    'message' => $message['message'],
+                ];
+            }
+        }
+
+        return $messages;
+    }
+
+    private function formatReport(array $report): string
+    {
+        $lines = ["phpcs found {$report['totals']['errors']} error(s) and {$report['totals']['warnings']} warning(s):"];
+
+        foreach ($this->collectMessages($report) as $message) {
+            $lines[] = sprintf(
+                '%s:%d [%s] %s (%s)',
+                basename($message['file']),
+                $message['line'],
+                $message['type'],
+                $message['message'],
+                $message['source'],
+            );
+        }
+
+        return implode("\n", $lines);
+    }
+}

--- a/tests/CodeQuality/GeneratedCodeFormattingTest.php
+++ b/tests/CodeQuality/GeneratedCodeFormattingTest.php
@@ -13,6 +13,7 @@ use PHPModelGenerator\ModelGenerator;
 use PHPModelGenerator\SchemaProcessor\Hook\SetterBeforeValidationHookInterface;
 use PHPModelGenerator\SchemaProcessor\PostProcessor\AdditionalPropertiesAccessorPostProcessor;
 use PHPModelGenerator\SchemaProcessor\PostProcessor\BuilderClassPostProcessor;
+use PHPModelGenerator\SchemaProcessor\PostProcessor\PopulatePostProcessor;
 use PHPModelGenerator\SchemaProcessor\PostProcessor\PostProcessor;
 use PHPModelGenerator\Tests\AbstractPHPModelGeneratorTestCase;
 
@@ -32,6 +33,46 @@ class GeneratedCodeFormattingTest extends AbstractPHPModelGeneratorTestCase
                 ->setNamespacePrefix('\\GeneratedCodeFormattingTest')
                 ->setImmutable(false)
                 ->setCollectErrors(true),
+        );
+
+        $report = $this->runPhpcs($this->getGeneratedFiles());
+
+        $this->assertSame([], $this->collectMessages($report), $this->formatReport($report));
+    }
+
+    /**
+     * A composition directly on the schema root (as opposed to a nested property like ComposedVehicle's "specs")
+     * combined with setImmutable(false) activates RenderHelper::isMutableBaseValidator(), which wraps
+     * ComposedItem.phptpl's shared per-composition-element validation body in an extra "} else {" for a
+     * cache-check - a real nesting level deeper than the non-mutable-base-validator case covered above. Both
+     * collectErrors states are covered since ComposedItemBody.phptpl also branches on collectErrors() internally.
+     * Regression guard for the fix that extracted the shared body into its own ComposedItemBody.phptpl, rendered
+     * once per composition element and indented to the correct depth depending on isMutableBaseValidator, instead
+     * of relying on one literal indentation to be correct for both.
+     */
+    public function testRootLevelMutableCompositionGeneratesCodeMatchingTheCodingStandard(): void
+    {
+        $this->generateClassFromFile(
+            'RootLevelMutableComposition.json',
+            (new GeneratorConfiguration())
+                ->setNamespacePrefix('\\GeneratedCodeFormattingTest')
+                ->setImmutable(false)
+                ->setCollectErrors(true),
+        );
+
+        $report = $this->runPhpcs($this->getGeneratedFiles());
+
+        $this->assertSame([], $this->collectMessages($report), $this->formatReport($report));
+    }
+
+    public function testRootLevelMutableCompositionWithoutCollectErrorsGeneratesCodeMatchingTheCodingStandard(): void
+    {
+        $this->generateClassFromFile(
+            'RootLevelMutableComposition.json',
+            (new GeneratorConfiguration())
+                ->setNamespacePrefix('\\GeneratedCodeFormattingTest')
+                ->setImmutable(false)
+                ->setCollectErrors(false),
         );
 
         $report = $this->runPhpcs($this->getGeneratedFiles());
@@ -62,22 +103,51 @@ class GeneratedCodeFormattingTest extends AbstractPHPModelGeneratorTestCase
     /**
      * Covers the indentLevel wiring of PatternProperties, AdditionalProperties, ArrayTuple, ArrayItem,
      * ArrayContains, ConditionalComposedItem (if/then/else), PropertyNames, SchemaDependency, a forbidden
-     * (patternProperties: false) pattern and a writeOnly property's serialization-exclusion hook in one
-     * generation pass, since each construct is an independent top-level schema keyword/property that doesn't
-     * interact with the others. collectErrors(true) matches the branch actually verified for SchemaDependency -
-     * its generated check has a structurally different (and separately tracked, still-imperfect) shape under
-     * collectErrors(false), which AbstractPHPModelGeneratorTestCase::generateClass() defaults to when no
-     * configuration is passed explicitly. setSerialization(true) is required for the writeOnly exclusion hook
-     * to be generated at all.
+     * (patternProperties: false) pattern, a writeOnly property's serialization-exclusion hook and
+     * PopulatePostProcessor's populate() method in one generation pass, since each construct is an independent
+     * top-level schema keyword/property/post-processor that doesn't interact with the others.
+     * setSerialization(true) is required for the writeOnly exclusion hook to be generated at all.
      */
     public function testComprehensivePropertyTypesGenerateCodeMatchingTheCodingStandard(): void
     {
+        $this->modifyModelGenerator = static function (ModelGenerator $generator): void {
+            $generator->addPostProcessor(new PopulatePostProcessor());
+        };
+
         $this->generateClassFromFile(
             'ComprehensiveFormatting.json',
             (new GeneratorConfiguration())
                 ->setNamespacePrefix('\\GeneratedCodeFormattingTest')
                 ->setImmutable(false)
                 ->setCollectErrors(true)
+                ->setSerialization(true),
+        );
+
+        $report = $this->runPhpcs($this->getGeneratedFiles());
+
+        $this->assertSame([], $this->collectMessages($report), $this->formatReport($report));
+    }
+
+    /**
+     * SchemaDependency.phptpl's and Populate.phptpl's shared validation bodies each sit at a different real
+     * nesting depth depending on whether collectErrors() wraps them in a bare block or a try {} - the
+     * collectErrors(true) case above never exercised the collectErrors(false) shape for either. Regression guard
+     * for the fix that extracted both shared bodies into their own sub-templates (SchemaDependencyBody.phptpl,
+     * PopulateBody.phptpl), rendered once each and indented to the correct depth for each branch, instead of
+     * relying on one literal indentation to be correct for both.
+     */
+    public function testSchemaDependencyAndPopulateWithoutCollectErrorsGenerateCodeMatchingTheCodingStandard(): void
+    {
+        $this->modifyModelGenerator = static function (ModelGenerator $generator): void {
+            $generator->addPostProcessor(new PopulatePostProcessor());
+        };
+
+        $this->generateClassFromFile(
+            'ComprehensiveFormatting.json',
+            (new GeneratorConfiguration())
+                ->setNamespacePrefix('\\GeneratedCodeFormattingTest')
+                ->setImmutable(false)
+                ->setCollectErrors(false)
                 ->setSerialization(true),
         );
 

--- a/tests/CodeQuality/GeneratedCodeFormattingTest.php
+++ b/tests/CodeQuality/GeneratedCodeFormattingTest.php
@@ -144,16 +144,16 @@ class GeneratedCodeFormattingTest extends AbstractPHPModelGeneratorTestCase
         $this->assertMatchesRegularExpression(
             '/' . preg_quote(
                 <<<'DOCBLOCK'
-    /**
-     * Get the value of tags.
-     *
-     * The tags associated with this record
-     *
-     * internal: sourced from the tagging service
-     * @example ["urgent"]
-     *
-     * @return
-DOCBLOCK,
+                    /**
+                     * Get the value of tags.
+                     *
+                     * The tags associated with this record
+                     *
+                     * internal: sourced from the tagging service
+                     * @example ["urgent"]
+                     *
+                     * @return
+                DOCBLOCK,
                 '/',
             ) . ' \S+\[\]\|null' . preg_quote("\n     */", '/') . '/',
             $classContent,
@@ -161,12 +161,12 @@ DOCBLOCK,
 
         $this->assertStringContainsString(
             <<<'DOCBLOCK'
-    /**
-     * Get the value of config.
-     *
-     * @return mixed
-     */
-DOCBLOCK,
+                /**
+                 * Get the value of config.
+                 *
+                 * @return mixed
+                 */
+            DOCBLOCK,
             $classContent,
         );
 
@@ -174,20 +174,20 @@ DOCBLOCK,
         // both between two schema properties and between a schema property and an always-present internal one
         $this->assertStringContainsString(
             <<<'PROPERTIES'
-    protected $tags;
+                protected $tags;
 
-    #[JsonPointer('/dependencies/tags/properties/category')]
-PROPERTIES,
+                #[JsonPointer('/dependencies/tags/properties/category')]
+            PROPERTIES,
             $classContent,
         );
         $this->assertStringContainsString(
             <<<'PROPERTIES'
-    protected array $_rawModelDataInput = [];
+                protected array $_rawModelDataInput = [];
 
-    #[Internal]
-    /** @var Meta|null */
-    private ?Meta $_metaAccessor = null;
-PROPERTIES,
+                #[Internal]
+                /** @var Meta|null */
+                private ?Meta $_metaAccessor = null;
+            PROPERTIES,
             $classContent,
         );
     }

--- a/tests/CodeQuality/GeneratedCodeFormattingTest.php
+++ b/tests/CodeQuality/GeneratedCodeFormattingTest.php
@@ -110,10 +110,11 @@ class GeneratedCodeFormattingTest extends AbstractPHPModelGeneratorTestCase
      * setSerialization(true) is required for the writeOnly exclusion hook to be generated at all.
      *
      * Also asserts the exact getter/setter docblock content for the "tags" property (which carries a
-     * description, a $comment and an example) and the "config" property (which carries none of them).
-     * phpcs's ruleset doesn't flag a blank docblock line missing its "*" prefix, or a run of several blank
-     * "*" lines in a row, so a phpcs-only assertion would not catch either shape regressing - only an exact
-     * string comparison does.
+     * description, a $comment and an example) and the "config" property (which carries none of them), and the
+     * exact blank-line spacing between declared properties (both schema properties, and a schema property
+     * followed by an always-present internal one). phpcs's ruleset doesn't flag a blank docblock line missing
+     * its "*" prefix, a run of several blank "*" lines in a row, or missing blank lines between properties, so
+     * a phpcs-only assertion would not catch any of these regressing - only an exact string comparison does.
      */
     public function testComprehensivePropertyTypesGenerateCodeMatchingTheCodingStandard(): void
     {
@@ -166,6 +167,27 @@ DOCBLOCK,
      * @return mixed
      */
 DOCBLOCK,
+            $classContent,
+        );
+
+        // exactly one blank line between each declared property, before the next property's own attributes -
+        // both between two schema properties and between a schema property and an always-present internal one
+        $this->assertStringContainsString(
+            <<<'PROPERTIES'
+    protected $tags;
+
+    #[JsonPointer('/dependencies/tags/properties/category')]
+PROPERTIES,
+            $classContent,
+        );
+        $this->assertStringContainsString(
+            <<<'PROPERTIES'
+    protected array $_rawModelDataInput = [];
+
+    #[Internal]
+    /** @var Meta|null */
+    private ?Meta $_metaAccessor = null;
+PROPERTIES,
             $classContent,
         );
     }

--- a/tests/CodeQuality/GeneratedCodeFormattingTest.php
+++ b/tests/CodeQuality/GeneratedCodeFormattingTest.php
@@ -16,6 +16,7 @@ use PHPModelGenerator\SchemaProcessor\PostProcessor\BuilderClassPostProcessor;
 use PHPModelGenerator\SchemaProcessor\PostProcessor\PopulatePostProcessor;
 use PHPModelGenerator\SchemaProcessor\PostProcessor\PostProcessor;
 use PHPModelGenerator\Tests\AbstractPHPModelGeneratorTestCase;
+use ReflectionClass;
 
 /**
  * Runs the dedicated generated-code PHPCS ruleset (tests/generated_code_phpcs.xml) against classes generated
@@ -107,6 +108,12 @@ class GeneratedCodeFormattingTest extends AbstractPHPModelGeneratorTestCase
      * PopulatePostProcessor's populate() method in one generation pass, since each construct is an independent
      * top-level schema keyword/property/post-processor that doesn't interact with the others.
      * setSerialization(true) is required for the writeOnly exclusion hook to be generated at all.
+     *
+     * Also asserts the exact getter/setter docblock content for the "tags" property (which carries a
+     * description, a $comment and an example) and the "config" property (which carries none of them).
+     * phpcs's ruleset doesn't flag a blank docblock line missing its "*" prefix, or a run of several blank
+     * "*" lines in a row, so a phpcs-only assertion would not catch either shape regressing - only an exact
+     * string comparison does.
      */
     public function testComprehensivePropertyTypesGenerateCodeMatchingTheCodingStandard(): void
     {
@@ -114,7 +121,7 @@ class GeneratedCodeFormattingTest extends AbstractPHPModelGeneratorTestCase
             $generator->addPostProcessor(new PopulatePostProcessor());
         };
 
-        $this->generateClassFromFile(
+        $className = $this->generateClassFromFile(
             'ComprehensiveFormatting.json',
             (new GeneratorConfiguration())
                 ->setNamespacePrefix('\\GeneratedCodeFormattingTest')
@@ -126,6 +133,41 @@ class GeneratedCodeFormattingTest extends AbstractPHPModelGeneratorTestCase
         $report = $this->runPhpcs($this->getGeneratedFiles());
 
         $this->assertSame([], $this->collectMessages($report), $this->formatReport($report));
+
+        $classContent = file_get_contents(
+            (new ReflectionClass('\\GeneratedCodeFormattingTest\\' . $className))->getFileName(),
+        );
+
+        // the nested item class name carries a per-run uniqid suffix, so match it as a wildcard instead of
+        // asserting an exact, unpredictable class name
+        $this->assertMatchesRegularExpression(
+            '/' . preg_quote(
+                <<<'DOCBLOCK'
+    /**
+     * Get the value of tags.
+     *
+     * The tags associated with this record
+     *
+     * internal: sourced from the tagging service
+     * @example ["urgent"]
+     *
+     * @return
+DOCBLOCK,
+                '/',
+            ) . ' \S+\[\]\|null' . preg_quote("\n     */", '/') . '/',
+            $classContent,
+        );
+
+        $this->assertStringContainsString(
+            <<<'DOCBLOCK'
+    /**
+     * Get the value of config.
+     *
+     * @return mixed
+     */
+DOCBLOCK,
+            $classContent,
+        );
     }
 
     /**
@@ -203,13 +245,13 @@ class GeneratedCodeFormattingTest extends AbstractPHPModelGeneratorTestCase
 
     /**
      * AdditionalPropertiesAccessorPostProcessor's additionalProperties() method is rendered through
-     * RenderedMethod, which - unlike most other rendering paths - enables php-micro-template's block dedent
-     * (blockIndentWidth 4), stripping one level of leading whitespace from a standalone {% if %}'s body before
-     * it is embedded. AdditionalPropertiesAccessorMethod.phptpl previously wrote the "not immutable" branch's
-     * body at the same column as the {% if %} tag itself instead of one level deeper as that convention
-     * requires, so the dedent stripped real indentation instead of a no-op decorative level, under-indenting
-     * the setter/remover arguments by one level. This only surfaces with setImmutable(false), since the whole
-     * branch is empty otherwise.
+     * RenderedMethod, which renders with autoIndent enabled (like every other rendering path in this library),
+     * dedenting a standalone {% if %}'s body by one level before it is embedded.
+     * AdditionalPropertiesAccessorMethod.phptpl previously wrote the "not immutable" branch's body at the same
+     * column as the {% if %} tag itself instead of one level deeper as that convention requires, so the dedent
+     * stripped real indentation instead of a no-op decorative level, under-indenting the setter/remover
+     * arguments by one level. This only surfaces with setImmutable(false), since the whole branch is empty
+     * otherwise.
      */
     public function testAdditionalPropertiesAccessorGeneratesCodeMatchingTheCodingStandard(): void
     {
@@ -319,15 +361,13 @@ class GeneratedCodeFormattingTest extends AbstractPHPModelGeneratorTestCase
      */
     private function runPhpcs(array $files): array
     {
-        $strippedFiles = array_map($this->stripIgnoreFileMarker(...), $files);
-
         // phpcs writes its "Time: ...; Memory: ..." summary to stderr even for machine-readable reports, so
         // stderr must stay separate from stdout - merging it would corrupt the JSON report on stdout
         $command = sprintf(
             '%s --standard=%s --report=json %s',
             escapeshellarg(__DIR__ . '/../../vendor/bin/phpcs'),
             escapeshellarg(__DIR__ . '/../generated_code_phpcs.xml'),
-            implode(' ', array_map('escapeshellarg', $strippedFiles)),
+            implode(' ', array_map('escapeshellarg', $files)),
         );
 
         $output = shell_exec($command);
@@ -336,24 +376,6 @@ class GeneratedCodeFormattingTest extends AbstractPHPModelGeneratorTestCase
         $this->assertIsArray($report, "phpcs didn't return a valid JSON report:\n" . $output);
 
         return $report;
-    }
-
-    /**
-     * Generated classes carry "// @codingStandardsIgnoreFile", which makes phpcs skip the file entirely. Strip
-     * it from a throwaway copy so the coding standard actually gets applied for this test, without touching the
-     * original file the rest of the test run still relies on (it has already been require()d by the generator).
-     */
-    private function stripIgnoreFileMarker(string $file): string
-    {
-        // keep the .php extension so phpcs' default extension filter still picks the copy up
-        $strippedFile = preg_replace('/\.php$/', '.phpcs-check.php', $file);
-
-        file_put_contents(
-            $strippedFile,
-            preg_replace('/^\/\/ @codingStandardsIgnoreFile\n/m', '', file_get_contents($file)),
-        );
-
-        return $strippedFile;
     }
 
     /**

--- a/tests/Schema/GeneratedCodeFormattingTest/ComposedVehicle.json
+++ b/tests/Schema/GeneratedCodeFormattingTest/ComposedVehicle.json
@@ -1,0 +1,32 @@
+{
+  "type": "object",
+  "properties": {
+    "specs": {
+      "allOf": [
+        {
+          "type": "object",
+          "properties": {
+            "wheels": {
+              "type": "integer",
+              "minimum": 1
+            }
+          },
+          "required": [
+            "wheels"
+          ]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "engine": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "engine"
+          ]
+        }
+      ]
+    }
+  }
+}

--- a/tests/Schema/GeneratedCodeFormattingTest/ComprehensiveFormatting.json
+++ b/tests/Schema/GeneratedCodeFormattingTest/ComprehensiveFormatting.json
@@ -3,6 +3,13 @@
   "properties": {
     "tags": {
       "type": "array",
+      "description": "The tags associated with this record",
+      "$comment": "internal: sourced from the tagging service",
+      "examples": [
+        [
+          "urgent"
+        ]
+      ],
       "items": {
         "type": "object",
         "properties": {

--- a/tests/Schema/GeneratedCodeFormattingTest/ComprehensiveFormatting.json
+++ b/tests/Schema/GeneratedCodeFormattingTest/ComprehensiveFormatting.json
@@ -1,0 +1,136 @@
+{
+  "type": "object",
+  "properties": {
+    "tags": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "label": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "label"
+        ]
+      }
+    },
+    "coordinates": {
+      "type": "array",
+      "items": [
+        {
+          "type": "number",
+          "minimum": 0
+        },
+        {
+          "type": "object",
+          "properties": {
+            "label": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "label"
+          ]
+        }
+      ]
+    },
+    "primaryTag": {
+      "type": "array",
+      "contains": {
+        "type": "object",
+        "properties": {
+          "label": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "label"
+        ]
+      }
+    },
+    "password": {
+      "type": "string",
+      "writeOnly": true
+    },
+    "config": {
+      "if": {
+        "type": "object",
+        "properties": {
+          "kind": {
+            "const": "advanced"
+          }
+        },
+        "required": [
+          "kind"
+        ]
+      },
+      "then": {
+        "type": "object",
+        "properties": {
+          "level": {
+            "type": "integer",
+            "minimum": 1
+          }
+        },
+        "required": [
+          "level"
+        ]
+      },
+      "else": {
+        "type": "object",
+        "properties": {
+          "label": {
+            "type": "string",
+            "minLength": 2
+          }
+        },
+        "required": [
+          "label"
+        ]
+      }
+    }
+  },
+  "patternProperties": {
+    "^x": {
+      "type": "object",
+      "properties": {
+        "value": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "value"
+      ]
+    },
+    "^secret_": false
+  },
+  "additionalProperties": {
+    "type": "object",
+    "properties": {
+      "value": {
+        "type": "string"
+      }
+    },
+    "required": [
+      "value"
+    ]
+  },
+  "propertyNames": {
+    "pattern": "^[a-zA-Z]+$"
+  },
+  "dependencies": {
+    "tags": {
+      "type": "object",
+      "properties": {
+        "category": {
+          "type": "string",
+          "minLength": 2
+        }
+      },
+      "required": [
+        "category"
+      ]
+    }
+  }
+}

--- a/tests/Schema/GeneratedCodeFormattingTest/FilterChain.json
+++ b/tests/Schema/GeneratedCodeFormattingTest/FilterChain.json
@@ -1,0 +1,12 @@
+{
+  "type": "object",
+  "properties": {
+    "createdAt": {
+      "type": "string",
+      "filter": [
+        "dateTime",
+        "stripTime"
+      ]
+    }
+  }
+}

--- a/tests/Schema/GeneratedCodeFormattingTest/PatternPropertyMatchingObjectProperty.json
+++ b/tests/Schema/GeneratedCodeFormattingTest/PatternPropertyMatchingObjectProperty.json
@@ -1,0 +1,16 @@
+{
+  "type": "object",
+  "properties": {
+    "aOne": {
+      "type": "integer"
+    },
+    "aTwo": {
+      "type": "integer"
+    }
+  },
+  "patternProperties": {
+    "^a": {
+      "type": "integer"
+    }
+  }
+}

--- a/tests/Schema/GeneratedCodeFormattingTest/RootLevelMutableComposition.json
+++ b/tests/Schema/GeneratedCodeFormattingTest/RootLevelMutableComposition.json
@@ -1,0 +1,22 @@
+{
+  "type": "object",
+  "oneOf": [
+    {
+      "properties": {
+        "age": {
+          "type": "integer"
+        }
+      },
+      "required": [
+        "age"
+      ]
+    },
+    {
+      "properties": {
+        "age": {
+          "type": "string"
+        }
+      }
+    }
+  ]
+}

--- a/tests/generated_code_phpcs.xml
+++ b/tests/generated_code_phpcs.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0"?>
+<ruleset name="php-json-schema-model-generator-generated-code">
+    <description>
+        PSR-12 based coding standard for asserting the formatting of generated model code. Extends the main
+        ruleset but relaxes three rules that flag deliberate properties of generated code rather than accidental
+        style violations: the underscore-prefix naming rules (internal properties/methods like $_errorRegistry,
+        _validateSpecs are prefixed with an underscore to guarantee no collision with user-defined or
+        schema-derived names), the soft line-length limit (exception constructors embed class names, property
+        names and JSON pointers verbatim, routinely pushing lines past 120 characters - unavoidable given what
+        the line documents, not a wrapping omission), and the mandatory-namespace rule (generating classes with
+        no namespace is an intentionally supported configuration - GeneratorConfiguration::setNamespacePrefix()
+        is optional - not a defect in the generated code).
+    </description>
+
+    <rule ref="../phpcs.xml">
+        <exclude name="PSR2.Classes.PropertyDeclaration.Underscore"/>
+        <exclude name="PSR2.Methods.MethodDeclaration.Underscore"/>
+        <exclude name="Generic.Files.LineLength.TooLong"/>
+        <exclude name="PSR1.Classes.ClassDeclaration.MissingNamespace"/>
+    </rule>
+</ruleset>


### PR DESCRIPTION
## Summary

Generated model classes are now reliably PSR-12 compliant. A new opt-in whole-suite generated-code phpcs audit (`tests/CodeQuality/GeneratedCodeAuditor.php`, `PHPCS_GENERATED_CODE_AUDIT=1`) copies every generated class from the whole test suite and runs a dedicated ruleset (`tests/generated_code_phpcs.xml`) against it, going from 64947 findings down to **0 findings across 4518 files**. Because the guarantee is now real, `// @codingStandardsIgnoreFile` and `// @codeCoverageIgnoreStart`/`End` are removed from every class-emitting template (`Model.phptpl`, `BuilderClass.phptpl`, both Companion templates) - a consumer's own coding standard and coverage tooling no longer needs to blanket-exclude generated output.

Getting there required:
- Wiring explicit `indentLevel` params through every remaining `renderValidator()`/`resolvePropertyDecorator()` call site in the main class template and its post-processor templates.
- Fixing several independent formatting/indentation bugs the audit surfaced (`CompositionValidation.phptpl`'s raw unindented embedding of a base composition validator, `SchemaHookResolver::resolveHook()`'s unconditional `"\n\n"` join corrupting indentation when a hook legitimately returns `''`, several hand-rolled multi-line PHP strings formatted at the wrong column, and more - see individual commits).
- Restructuring the two remaining "dual-depth" template limitations (`ComposedItem.phptpl`'s `isMutableBaseValidator` branch, `SchemaDependency.phptpl`/`Populate.phptpl`'s `collectErrors(false)` branch) by extracting each shared body into its own sub-template, rendered via a nested `Render::renderTemplate()` call and embedded with `viewHelper.indent()` - a pure rendering-mechanism change with no difference in the generated PHP.
- Migrating from an ad-hoc, locally-patched php-micro-template vendor copy to the library's real `RenderConfig`/`autoIndent` feature (`wol-soft/php-micro-template ^1.12.0`), which the whole formatting effort actually depends on for eliminating blank lines and getting correctly indented output from standalone `{% if %}`/`{% foreach %}` tags. Adds `RenderFactory` as the single point of truth for constructing `Render` instances with `autoIndent` enabled, caching by base path.
- Fixing a real formatting bug the `@codingStandardsIgnoreFile` removal surfaced: `Model.phptpl`'s getter docblock glued its optional description/comment/examples sections directly to the `*` prefix instead of using standalone `{% if %}` tags, so a property with none of them left behind blank docblock lines missing their `*` entirely - syntactically valid PHP, but malformed PHPDoc that no existing phpcs sniff caught. Restructured to standalone `{% if %}` blocks, with an exact-content regression test since phpcs alone doesn't catch this class of bug.

## Test plan

- [x] `./vendor/bin/phpunit` - full suite green (2903 tests, 7494 assertions)
- [x] `./vendor/bin/phpcs --standard=phpcs.xml` on all changed source files - clean
- [x] Whole-suite generated-code audit (`PHPCS_GENERATED_CODE_AUDIT=1`) - 64947 → 0 findings across 4518 files
- [x] Each individual fix additionally verified via scratch-schema generation + `phpcs --report=full` in isolation before being folded into the full suite run

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PL4k3uwbW6xC2SjKNyjxFT

---
_Generated by [Claude Code](https://claude.ai/code/session_01PL4k3uwbW6xC2SjKNyjxFT)_