### PR TITLE
Exclude internal bookkeeping properties from composition branch default helpers

### DIFF
--- a/src/Model/Validator/AbstractComposedPropertyValidator.php
+++ b/src/Model/Validator/AbstractComposedPropertyValidator.php
@@ -87,6 +87,14 @@ abstract class AbstractComposedPropertyValidator extends ExtractedMethodValidato
             }
 
             foreach ($compositionProperty->getNestedSchema()->getProperties() as $branchProperty) {
+                // Internal bookkeeping properties (eg. _skipNotProvidedPropertiesMap added by
+                // SerializationPostProcessor) are never real branch data - they don't get a
+                // getter generated, and their default values must not be misread as a branch
+                // default to track.
+                if ($branchProperty->isInternal()) {
+                    continue;
+                }
+
                 $propertyAccessors[$branchProperty->getName()] = 'get' . ucfirst($branchProperty->getAttribute());
 
                 if ($branchProperty->getDefaultValue() === null) {

--- a/tests/Issues/Issue/Issue179Test.php
+++ b/tests/Issues/Issue/Issue179Test.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PHPModelGenerator\Tests\Issues\Issue;
+
+use PHPModelGenerator\Model\GeneratorConfiguration;
+use PHPModelGenerator\Tests\Issues\AbstractIssueTestCase;
+use ReflectionClass;
+
+/**
+ * Issue #179: AbstractComposedPropertyValidator::setupBranchDefaultHelpers() iterates a
+ * composition branch's nested schema properties without excluding internal bookkeeping
+ * properties (isInternal() === true). When serialization is enabled and implicit null is
+ * disallowed, every generated branch class carries its own internal
+ * `_skipNotProvidedPropertiesMap` property with a non-null default value ([]), so it gets
+ * misread as a real branch property and leaks into both componentDefaultValueMap and
+ * propertyAccessors of the containing class's `_getModifiedValues_*` helper - even though no
+ * corresponding getter is ever generated for it.
+ *
+ * Issue169Test.php fixed the same class of bug for allBranchDefaultAttributeMap; this covers
+ * the residual gap in the two structures that fix did not cover.
+ */
+class Issue179Test extends AbstractIssueTestCase
+{
+    public function testGetModifiedValuesHelperExcludesInternalBookkeepingProperties(): void
+    {
+        $className = $this->generateClassFromFile(
+            'ComposedBranchSerialization.json',
+            (new GeneratorConfiguration())
+                ->setNamespacePrefix('\\Issue179Test')
+                ->setSerialization(true),
+            false,
+            false,
+        );
+
+        $classContent = file_get_contents(
+            (new ReflectionClass('\\Issue179Test\\' . $className))->getFileName(),
+        );
+
+        preg_match(
+            '/private function _getModifiedValues_\w+\([^)]*\): array \{.*?\n    \}/s',
+            $classContent,
+            $matches,
+        );
+
+        $this->assertNotEmpty($matches, 'Expected a _getModifiedValues_* helper method to be generated');
+
+        $this->assertStringNotContainsString(
+            'skipNotProvidedPropertiesMap',
+            $matches[0],
+            "The _getModifiedValues_* helper must not reference the internal bookkeeping property "
+                . "'_skipNotProvidedPropertiesMap' of a composition branch's own generated class - it is never "
+                . 'transferred onto the containing object and has no corresponding getter.',
+        );
+    }
+}

--- a/tests/Schema/Issues/179/ComposedBranchSerialization.json
+++ b/tests/Schema/Issues/179/ComposedBranchSerialization.json
@@ -1,0 +1,31 @@
+{
+  "type": "object",
+  "properties": {
+    "target": {
+      "oneOf": [
+        {
+          "type": "object",
+          "properties": {
+            "name": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "name"
+          ]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "value": {
+              "type": "integer"
+            }
+          },
+          "required": [
+            "value"
+          ]
+        }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- Fixes #179: `AbstractComposedPropertyValidator::setupBranchDefaultHelpers()` iterated a composition branch's nested schema properties without excluding internal bookkeeping properties (`isInternal() === true`).
- When serialization is enabled and implicit null is disallowed, every generated branch class carries its own internal `_skipNotProvidedPropertiesMap` property with a non-null default (`[]`), which was misread as real branch data and leaked into both `$componentDefaultValueMap` and `$propertyAccessors` of the generated `_getModifiedValues_*` helper — even though it's never transferred onto the containing object and no getter is ever generated for it.
- This is the same class of bug fixed for `allBranchDefaultAttributeMap` in #169, extended to cover the two structures that fix didn't reach. The fix skips internal properties at the top of the loop, before either structure is populated.
- Not a behavioral bug (`method_exists()` already no-ops the bogus entry at runtime), but it bloated generated code and leaked internal implementation detail into unrelated output.

## Test plan

- [x] New reproduction test `tests/Issues/Issue/Issue179Test.php` (`tests/Schema/Issues/179/ComposedBranchSerialization.json`) confirmed red before the fix, green after.
- [x] `tests/Issues/Issue/Issue169Test.php` (the sibling fix this one extends) still passes.
- [x] `tests/CodeQuality/GeneratedCodeFormattingTest.php` still passes.
- [x] Full test suite passes (2904 tests, 7498 assertions).
- [x] `phpcs --standard=phpcs.xml` clean on changed files.


---
_Generated by [Claude Code](https://claude.ai/code/session_01QL8i9sBrFNCQv4WdGwxfup)_