### PR TITLE
Draft-aware $ref+sibling handling (Draft 2019-09+)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -403,6 +403,17 @@ priority ordering, etc.), that is precisely the issue that needs solving. Open i
 topic if it cannot be addressed immediately, but keep the test in place and marked as expected to
 fail (`@expectedExceptionMessage`, `$this->expectException(...)`) until the fix lands.
 
+This applies equally to throwaway probes and exploratory reproduction scripts, not just formal
+in-suite tests. When a probe built to investigate one question triggers an unexpected result,
+resist the pull to edit the probe until the inconvenient result goes away. First determine whether
+the input was valid: if it's valid JSON Schema (or otherwise legitimate input) and the tool
+misbehaves, that is a real bug — document it with the exact reproduction and its output before
+moving on, even if it's unrelated to what you set out to investigate. Only revise the probe when
+the *input itself* was invalid or didn't match what you intended to test (e.g. malformed JSON, a
+typo, a config flag that doesn't mean what you assumed) — and say so explicitly, with the specific
+reason the original input was invalid, not just "adjusted the probe." A silently adjusted probe
+erases the evidence that a bug exists.
+
 #### No implementation-plan references in code
 
 Do not embed references to implementation-plan phases, issue numbers, or source-code line numbers

--- a/docs/source/generic/references.rst
+++ b/docs/source/generic/references.rst
@@ -147,3 +147,97 @@ Generated interface:
 If a base reference is used and the reference doesn't point to an object definition an Exception will be thrown during the model generation process:
 
 * A referenced schema on base level must provide an object definition [Citizen]
+
+$ref with sibling keywords
+--------------------------
+
+When additional keywords appear alongside ``$ref`` in the same schema object — such as
+``properties``, ``required``, ``type``, ``minLength``, ``enum``, or others — their treatment
+depends on the active JSON Schema draft.
+
+**Draft 2019-09+ (siblings applied)**
+    Sibling keywords take full effect alongside ``$ref``.  At the base/root level, sibling
+    ``properties`` and ``required`` are merged with the referenced object's own properties —
+    constraints from both sides apply (type intersection, required union).  At the property
+    level, sibling constraints (``type``, ``minLength``, ``enum``, etc.) narrow the referenced
+    type.
+
+**Draft 7 (siblings silently ignored)**
+    Sibling keywords are discarded.  Only the ``$ref`` is effective.  This matches the Draft 7
+    specification, where ``$ref`` is exclusive over all co-located keywords.
+
+    .. note::
+
+        If your schemas rely on siblings alongside ``$ref`` and you switch from Draft 7 to
+        Draft 2019-09 (or use ``AutoDetectionDraft`` with a ``$schema`` URI pointing to
+        2019-09), those siblings will start taking effect.  Review schemas that combine
+        ``$ref`` with extra keywords before upgrading.
+
+**Example — base-level $ref + sibling properties (Draft 2019-09+)**
+
+.. code-block:: json
+
+    {
+        "$schema": "https://json-schema.org/draft/2019-09/schema",
+        "$defs": {
+            "person": {
+                "type": "object",
+                "properties": {
+                    "name": {
+                        "type": "string"
+                    },
+                    "age": {
+                        "type": "integer"
+                    }
+                },
+                "required": ["name"]
+            }
+        },
+        "$ref": "#/$defs/person",
+        "properties": {
+            "street": {
+                "type": "string"
+            }
+        },
+        "required": ["name", "street"]
+    }
+
+The generated class exposes ``name`` and ``age`` (from the ref) together with ``street``
+(from the sibling ``properties``):
+
+.. code-block:: php
+
+    public function getName(): ?string;
+    public function getAge(): ?int;
+    public function getStreet(): ?string;
+
+When a property is declared by **both** the ``$ref``'d object and the sibling ``properties``
+block, the two declarations are merged with ``allOf`` semantics: types narrow to their
+intersection (for example, ``number`` ∩ ``integer`` → ``int``), and conflicting default
+values cause a generation-time ``SchemaException``.
+
+**Example — property-level $ref + sibling constraint (Draft 2019-09+)**
+
+A property schema with ``$ref`` pointing to a string definition and a sibling ``minLength``:
+
+.. code-block:: json
+
+    {
+        "$schema": "https://json-schema.org/draft/2019-09/schema",
+        "type": "object",
+        "properties": {
+            "code": {
+                "$ref": "#/$defs/shortString",
+                "minLength": 5
+            }
+        },
+        "$defs": {
+            "shortString": {
+                "type": "string",
+                "minLength": 1
+            }
+        }
+    }
+
+Both constraints are enforced: the effective minimum length is ``5`` (the sibling tightens
+the ref's ``minLength: 1``).

--- a/docs/source/generic/references.rst
+++ b/docs/source/generic/references.rst
@@ -6,6 +6,7 @@ References can be used to re-use parts/objects of JSON-Schema definitions.
 Supported reference types
 -------------------------
 
+* internal (in a single file) self-reference to the enclosing scope, for recursive schemas (example: `"$ref": ""`, equivalent to `"$ref": "#"`)
 * internal (in a single file) reference by id (example: `"$ref": "#IdOfMyObject"`)
 * internal (in a single file) reference by path using ``definitions`` (Draft 7, example: `"$ref": "#/definitions/myObject"`)
 * internal (in a single file) reference by path using ``$defs`` (Draft 2019-09, example: `"$ref": "#/$defs/myObject"`)
@@ -92,6 +93,40 @@ Draft 2019-09 introduced ``$defs`` as the standard replacement for ``definitions
         }
     }
 
+Self-reference (recursive schemas)
+-----------------------------------
+
+An empty ``$ref`` (``"$ref": ""``) references the enclosing document or ``$id`` scope itself,
+without needing to name it. This is the standard idiom for recursive schemas, e.g. an object that
+may contain further objects of its own type:
+
+.. code-block:: json
+
+    {
+        "$id": "#person",
+        "type": "object",
+        "properties": {
+            "name": {
+                "type": "string"
+            },
+            "children": {
+                "type": "array",
+                "items": {
+                    "$ref": ""
+                }
+            }
+        }
+    }
+
+``""`` resolves against the *nearest enclosing* ``$id`` (or the document root if none is in
+scope) — a ``$ref: ""`` written inside a ``$id``-scoped definition recurses into that definition,
+not into the top-level document. It behaves identically to explicitly writing the enclosing
+scope's own id (``"$ref": "#person"`` above), just without needing to name it.
+
+Using an empty (or ``"#"``) ``$ref`` at a schema's own base level (see `Base Reference`_ below)
+is rejected instead: it would ask the schema to be merged with itself, which has no fixed point
+to compute.
+
 Base Reference
 --------------
 
@@ -147,6 +182,11 @@ Generated interface:
 If a base reference is used and the reference doesn't point to an object definition an Exception will be thrown during the model generation process:
 
 * A referenced schema on base level must provide an object definition [Citizen]
+
+A base reference must also not reference the schema's own root (``"$ref": ""`` or ``"$ref": "#"``
+at base level) — an Exception will be thrown during the model generation process:
+
+* A referenced schema on base level must not reference itself [Citizen]
 
 $ref with sibling keywords
 --------------------------

--- a/docs/source/generic/references.rst
+++ b/docs/source/generic/references.rst
@@ -253,8 +253,11 @@ The generated class exposes ``name`` and ``age`` (from the ref) together with ``
 
 When a property is declared by **both** the ``$ref``'d object and the sibling ``properties``
 block, the two declarations are merged with ``allOf`` semantics: types narrow to their
-intersection (for example, ``number`` ∩ ``integer`` → ``int``), and conflicting default
-values cause a generation-time ``SchemaException``.
+intersection (for example, ``number`` ∩ ``integer`` → ``int``), narrowing never drops the
+``$ref``'d side's own constraints (e.g. ``minimum``) — they're re-applied against the narrowed
+type — and conflicting default values cause a generation-time ``SchemaException``. This merge
+behavior is uniform across every ``$ref``+sibling position: base level, a property-level
+``$ref`` to an object, and a property-level ``$ref`` to a scalar all merge the same way.
 
 **Example — property-level $ref + sibling constraint (Draft 2019-09+)**
 

--- a/src/Draft/Draft.php
+++ b/src/Draft/Draft.php
@@ -5,15 +5,46 @@ declare(strict_types=1);
 namespace PHPModelGenerator\Draft;
 
 use PHPModelGenerator\Draft\Element\Type;
+use PHPModelGenerator\Draft\Producer\PropertyProducerInterface;
 use PHPModelGenerator\Exception\SchemaException;
 
 final class Draft
 {
     /**
-     * @param Type[] $types
+     * @param Type[]                      $types
+     * @param PropertyProducerInterface[] $producers Keyed by keyword, in registry order
      */
-    public function __construct(private readonly array $types)
+    public function __construct(
+        private readonly array $types,
+        private readonly array $producers = [],
+    ) {
+    }
+
+    public function getProducerForKeyword(string $keyword): ?PropertyProducerInterface
     {
+        return $this->producers[$keyword] ?? null;
+    }
+
+    /**
+     * Returns every registered producer whose keyword is present in the given schema node, in
+     * registry order. With only the $ref producer registered today this yields 0 or 1 element,
+     * but the contract is N-producer capable for future co-occurring reference keywords.
+     *
+     * @param array<string, mixed> $json
+     *
+     * @return PropertyProducerInterface[]
+     */
+    public function getProducersForSchema(array $json): array
+    {
+        $producers = [];
+
+        foreach ($this->producers as $keyword => $producer) {
+            if (array_key_exists($keyword, $json)) {
+                $producers[] = $producer;
+            }
+        }
+
+        return $producers;
     }
 
     /**

--- a/src/Draft/Draft.php
+++ b/src/Draft/Draft.php
@@ -26,13 +26,15 @@ final class Draft
     }
 
     /**
-     * Returns every registered producer whose keyword is present in the given schema node, in
-     * registry order. With only the $ref producer registered today this yields 0 or 1 element,
-     * but the contract is N-producer capable for future co-occurring reference keywords.
+     * Returns every registered producer whose keyword is present in the given schema node, keyed
+     * by keyword and in registry order. With only the $ref producer registered today this yields
+     * 0 or 1 element, but the contract is N-producer capable for future co-occurring reference
+     * keywords. Keeping the keyword as the key lets callers name the offending keyword(s) when
+     * reporting a conflict (e.g. multiple mutually exclusive producers present on one node).
      *
      * @param array<string, mixed> $json
      *
-     * @return PropertyProducerInterface[]
+     * @return array<string, PropertyProducerInterface>
      */
     public function getProducersForSchema(array $json): array
     {
@@ -40,7 +42,7 @@ final class Draft
 
         foreach ($this->producers as $keyword => $producer) {
             if (array_key_exists($keyword, $json)) {
-                $producers[] = $producer;
+                $producers[$keyword] = $producer;
             }
         }
 

--- a/src/Draft/Draft.php
+++ b/src/Draft/Draft.php
@@ -82,6 +82,19 @@ final class Draft
     }
 
     /**
+     * Returns the schema keywords registered as validator factories for the given type (e.g.
+     * 'properties', 'required', 'additionalProperties', … for 'object'). Modifiers added via
+     * addModifier() (not keyed by keyword) are excluded, so this only surfaces keywords that
+     * actually drive validation for the type.
+     *
+     * @return string[]
+     */
+    public function getKeywordsForType(string $type): array
+    {
+        return array_values(array_filter(array_keys($this->types[$type]->getModifiers()), 'is_string'));
+    }
+
+    /**
      * Returns the Type entries whose modifiers apply to a property of the given type(s).
      * The special type 'any' always applies to every property; passing 'any' returns all types.
      *

--- a/src/Draft/DraftBuilder.php
+++ b/src/Draft/DraftBuilder.php
@@ -5,11 +5,15 @@ declare(strict_types=1);
 namespace PHPModelGenerator\Draft;
 
 use PHPModelGenerator\Draft\Element\Type;
+use PHPModelGenerator\Draft\Producer\PropertyProducerInterface;
 
 class DraftBuilder
 {
     /** @var Type[] */
     private array $types = [];
+
+    /** @var PropertyProducerInterface[] Keyed by keyword; insertion order preserved */
+    private array $producers = [];
 
     public function addType(Type $type): self
     {
@@ -23,8 +27,19 @@ class DraftBuilder
         return $this->types[$type] ?? null;
     }
 
+    /**
+     * Register a producer for a schema keyword. Re-registering a keyword overwrites the producer
+     * while keeping its registry position
+     */
+    public function addProducer(string $keyword, PropertyProducerInterface $producer): self
+    {
+        $this->producers[$keyword] = $producer;
+
+        return $this;
+    }
+
     public function build(): Draft
     {
-        return new Draft($this->types);
+        return new Draft($this->types, $this->producers);
     }
 }

--- a/src/Draft/DraftResolver.php
+++ b/src/Draft/DraftResolver.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PHPModelGenerator\Draft;
+
+use PHPModelGenerator\Model\SchemaDefinition\JsonSchema;
+
+/**
+ * Owns the built (immutable) Draft registry cache. Kept separate from GeneratorConfiguration,
+ * which is part of the public library interface, so this cache and its resolution logic don't
+ * live directly on that public surface - GeneratorConfiguration keeps the configured draft (or
+ * draft factory) itself and passes it in on each call, since the resolver has no way to be
+ * notified of a later setDraft() call otherwise.
+ */
+class DraftResolver
+{
+    /** @var Draft[] Built (immutable) Draft registries, keyed by draft class name */
+    private array $builtDraftCache = [];
+
+    /**
+     * Resolve the active draft for the given schema (via DraftFactoryInterface::getDraftForSchema
+     * when a factory is configured) and build its immutable Draft registry, caching the result by
+     * draft class so repeated calls for the same draft don't rebuild it.
+     */
+    public function getBuiltDraft(DraftInterface | DraftFactoryInterface $draft, JsonSchema $propertySchema): Draft
+    {
+        $draftInterface = $draft instanceof DraftFactoryInterface
+            ? $draft->getDraftForSchema($propertySchema)
+            : $draft;
+
+        return $this->builtDraftCache[$draftInterface::class] ??= $draftInterface->getDefinition()->build();
+    }
+}

--- a/src/Draft/Draft_07.php
+++ b/src/Draft/Draft_07.php
@@ -7,6 +7,8 @@ namespace PHPModelGenerator\Draft;
 use PHPModelGenerator\Draft\Element\Type;
 use PHPModelGenerator\Draft\Modifier\DefaultArrayToEmptyArrayModifier;
 use PHPModelGenerator\Draft\Modifier\MediaStringModifier;
+use PHPModelGenerator\Draft\Producer\ExclusiveProducer;
+use PHPModelGenerator\Draft\Producer\RefResolver;
 use PHPModelGenerator\Model\Validator\Factory\Composition\AllOfValidatorFactory;
 use PHPModelGenerator\Model\Validator\Factory\Composition\AnyOfValidatorFactory;
 use PHPModelGenerator\Model\Validator\Factory\Composition\IfValidatorFactory;
@@ -45,6 +47,7 @@ class Draft_07 implements DraftInterface
     public function getDefinition(): DraftBuilder
     {
         return (new DraftBuilder())
+            ->addProducer('$ref', new ExclusiveProducer(new RefResolver()))
             ->addType((new Type('object', false))
                 ->addValidator('properties', new PropertiesValidatorFactory())
                 ->addValidator('propertyNames', new PropertyNamesValidatorFactory())

--- a/src/Draft/Draft_2019_09.php
+++ b/src/Draft/Draft_2019_09.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace PHPModelGenerator\Draft;
 
+use PHPModelGenerator\Draft\Producer\RefResolver;
 use PHPModelGenerator\Model\Validator\Factory\Arrays\ContainsValidatorFactory;
 
 class Draft_2019_09 extends Draft_07
@@ -11,6 +12,10 @@ class Draft_2019_09 extends Draft_07
     public function getDefinition(): DraftBuilder
     {
         $builder = parent::getDefinition();
+
+        // From Draft 2019-09 onwards $ref is conjunctive: siblings apply alongside the reference.
+        // Overwrite the Draft-07 ExclusiveProducer with the bare resolver (keeping its position).
+        $builder->addProducer('$ref', new RefResolver());
 
         $builder->getType('array')
             ->addValidator('contains', new ContainsValidatorFactory());

--- a/src/Draft/Producer/ExclusiveProducer.php
+++ b/src/Draft/Producer/ExclusiveProducer.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PHPModelGenerator\Draft\Producer;
+
+use PHPModelGenerator\Model\Property\PropertyInterface;
+use PHPModelGenerator\Model\Schema;
+use PHPModelGenerator\Model\SchemaDefinition\JsonSchema;
+use PHPModelGenerator\SchemaProcessor\SchemaProcessor;
+
+/**
+ * Marks the wrapped producer as exclusive over sibling keywords: when a schema node carries this
+ * producer's keyword, every other keyword on the same node is suppressed. This models the Draft-07
+ * (and earlier) $ref semantics, where the presence of $ref means all sibling keywords are ignored.
+ *
+ * The decorator carries no behaviour of its own beyond delegating produce(); the exclusivity is a
+ * marker the caller detects (via instanceof) to decide whether to skip the sibling applicator loop.
+ * Keeping it a decorator rather than a flag on the interface keeps the producer contract a single
+ * method and makes the policy reusable for future exclusive keywords.
+ */
+final class ExclusiveProducer implements PropertyProducerInterface
+{
+    public function __construct(private readonly PropertyProducerInterface $producer)
+    {
+    }
+
+    public function produce(
+        SchemaProcessor $schemaProcessor,
+        Schema $schema,
+        string $propertyName,
+        JsonSchema $propertySchema,
+        bool $required,
+    ): PropertyInterface {
+        return $this->producer->produce($schemaProcessor, $schema, $propertyName, $propertySchema, $required);
+    }
+}

--- a/src/Draft/Producer/ExclusiveProducer.php
+++ b/src/Draft/Producer/ExclusiveProducer.php
@@ -31,7 +31,15 @@ final class ExclusiveProducer implements PropertyProducerInterface
         string $propertyName,
         JsonSchema $propertySchema,
         bool $required,
+        bool $isArrayItem = false,
     ): PropertyInterface {
-        return $this->producer->produce($schemaProcessor, $schema, $propertyName, $propertySchema, $required);
+        return $this->producer->produce(
+            $schemaProcessor,
+            $schema,
+            $propertyName,
+            $propertySchema,
+            $required,
+            $isArrayItem,
+        );
     }
 }

--- a/src/Draft/Producer/PropertyProducerInterface.php
+++ b/src/Draft/Producer/PropertyProducerInterface.php
@@ -27,5 +27,6 @@ interface PropertyProducerInterface
         string $propertyName,
         JsonSchema $propertySchema,
         bool $required,
+        bool $isArrayItem = false,
     ): PropertyInterface;
 }

--- a/src/Draft/Producer/PropertyProducerInterface.php
+++ b/src/Draft/Producer/PropertyProducerInterface.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PHPModelGenerator\Draft\Producer;
+
+use PHPModelGenerator\Model\Property\PropertyInterface;
+use PHPModelGenerator\Model\Schema;
+use PHPModelGenerator\Model\SchemaDefinition\JsonSchema;
+use PHPModelGenerator\SchemaProcessor\SchemaProcessor;
+
+/**
+ * A producer creates (resolves/replaces) the property for a schema keyword, in contrast to a
+ * {@see \PHPModelGenerator\Draft\Modifier\ModifierInterface}, which only augments an already
+ * built property. A producer is required for keywords such as $ref that must *return* the
+ * property object — something ModifierInterface::modify() cannot do, as it returns void.
+ *
+ * Producers are independent: produce() receives no incoming property and resolves only.
+ * Combining the output of multiple producers and applying sibling keywords is the caller's
+ * responsibility, never the producer's.
+ */
+interface PropertyProducerInterface
+{
+    public function produce(
+        SchemaProcessor $schemaProcessor,
+        Schema $schema,
+        string $propertyName,
+        JsonSchema $propertySchema,
+        bool $required,
+    ): PropertyInterface;
+}

--- a/src/Draft/Producer/RefResolver.php
+++ b/src/Draft/Producer/RefResolver.php
@@ -11,11 +11,9 @@ use PHPModelGenerator\Model\Attributes\PhpAttribute;
 use PHPModelGenerator\Model\Property\PropertyInterface;
 use PHPModelGenerator\Model\Schema;
 use PHPModelGenerator\Model\SchemaDefinition\JsonSchema;
-use PHPModelGenerator\Model\Validator\Factory\AbstractValidatorFactory;
 use PHPModelGenerator\Model\Validator\Factory\Composition\AllOfValidatorFactory;
 use PHPModelGenerator\PropertyProcessor\Decorator\SchemaNamespaceTransferDecorator;
 use PHPModelGenerator\SchemaProcessor\SchemaProcessor;
-use PHPModelGenerator\Utils\TypeConverter;
 
 /**
  * Resolves a $ref by looking it up in the definition dictionary and returning the referenced
@@ -184,68 +182,19 @@ class RefResolver implements PropertyProducerInterface
 
         foreach ($property->getNestedSchema()->getProperties() as $refProperty) {
             // Use allOf semantics when a sibling has already registered this property name so
-            // that type-intersection narrowing and default-conflict detection apply. For
-            // properties that only the ref defines, plain registration (null compositionProcessor)
-            // is correct — they become root-registered with no merge needed.
+            // that type-intersection narrowing and default-conflict detection apply, and pass
+            // the ref property's own JsonSchema as the constraint-reapplication source (see
+            // PropertyMerger::merge()) so narrowing doesn't silently drop the ref's type-specific
+            // constraints (minimum, maximum, …). For properties that only the ref defines, plain
+            // registration (null compositionProcessor) is correct — they become root-registered
+            // with no merge needed.
             $existingProperty     = $schema->getProperty($refProperty->getName());
             $compositionProcessor = $existingProperty !== null
                 ? AllOfValidatorFactory::class
                 : null;
-            $schema->addProperty($refProperty, $compositionProcessor);
-
-            if ($existingProperty !== null) {
-                $this->reapplyTypeSpecificRefConstraints($schemaProcessor, $schema, $existingProperty, $refProperty);
-            }
+            $schema->addProperty($refProperty, $compositionProcessor, $refProperty->getJsonSchema(), $schemaProcessor);
         }
 
         return $property;
-    }
-
-    /**
-     * After allOf-style type narrowing, re-apply type-specific modifiers from the ref
-     * property's JSON using the merged effective type. This restores the TypeCheckValidator
-     * (stripped by narrowToIntersection) and transfers constraints such as minimum/maximum
-     * using the correct type-check function for the narrowed type (e.g. is_int after
-     * narrowing from number to integer).
-     *
-     * Only operates for single scalar types. Multi-type and untyped results use different
-     * validation paths and are left untouched.
-     */
-    private function reapplyTypeSpecificRefConstraints(
-        SchemaProcessor $schemaProcessor,
-        Schema $schema,
-        PropertyInterface $existing,
-        PropertyInterface $refProperty,
-    ): void {
-        $effectiveType = $existing->getType(true);
-
-        if ($effectiveType === null || count($effectiveType->getNames()) !== 1) {
-            return;
-        }
-
-        $effectiveTypeName           = $effectiveType->getNames()[0];
-        $effectiveTypeJsonSchemaName = TypeConverter::phpToJsonSchema($effectiveTypeName);
-        $refJsonWithEffectiveType    = $refProperty->getJsonSchema()->withJson(
-            array_merge($refProperty->getJsonSchema()->getJson(), ['type' => $effectiveTypeJsonSchemaName]),
-        );
-
-        $builtDraft = $schemaProcessor->getGeneratorConfiguration()->getBuiltDraft($refJsonWithEffectiveType);
-
-        foreach ($builtDraft->getCoveredTypes($effectiveTypeJsonSchemaName) as $coveredType) {
-            if ($coveredType->getType() === 'any') {
-                continue;
-            }
-
-            foreach ($coveredType->getModifiers() as $modifier) {
-                $countBefore = count($existing->getValidators());
-                $modifier->modify($schemaProcessor, $schema, $existing, $refJsonWithEffectiveType);
-
-                if ($modifier instanceof AbstractValidatorFactory && ($modifierKey = $modifier->getKey()) !== null) {
-                    foreach (array_slice($existing->getValidators(), $countBefore) as $validatorWrapper) {
-                        $validatorWrapper->setSourceKey($modifierKey);
-                    }
-                }
-            }
-        }
     }
 }

--- a/src/Draft/Producer/RefResolver.php
+++ b/src/Draft/Producer/RefResolver.php
@@ -11,9 +11,11 @@ use PHPModelGenerator\Model\Attributes\PhpAttribute;
 use PHPModelGenerator\Model\Property\PropertyInterface;
 use PHPModelGenerator\Model\Schema;
 use PHPModelGenerator\Model\SchemaDefinition\JsonSchema;
+use PHPModelGenerator\Model\Validator\Factory\AbstractValidatorFactory;
 use PHPModelGenerator\Model\Validator\Factory\Composition\AllOfValidatorFactory;
 use PHPModelGenerator\PropertyProcessor\Decorator\SchemaNamespaceTransferDecorator;
 use PHPModelGenerator\SchemaProcessor\SchemaProcessor;
+use PHPModelGenerator\Utils\TypeConverter;
 
 /**
  * Resolves a $ref by looking it up in the definition dictionary and returning the referenced
@@ -142,12 +144,65 @@ class RefResolver implements PropertyProducerInterface
             // that type-intersection narrowing and default-conflict detection apply. For
             // properties that only the ref defines, plain registration (null compositionProcessor)
             // is correct — they become root-registered with no merge needed.
-            $compositionProcessor = $schema->getProperty($refProperty->getName()) !== null
+            $existingProperty     = $schema->getProperty($refProperty->getName());
+            $compositionProcessor = $existingProperty !== null
                 ? AllOfValidatorFactory::class
                 : null;
             $schema->addProperty($refProperty, $compositionProcessor);
+
+            if ($existingProperty !== null) {
+                $this->reapplyTypeSpecificRefConstraints($schemaProcessor, $schema, $existingProperty, $refProperty);
+            }
         }
 
         return $property;
+    }
+
+    /**
+     * After allOf-style type narrowing, re-apply type-specific modifiers from the ref
+     * property's JSON using the merged effective type. This restores the TypeCheckValidator
+     * (stripped by narrowToIntersection) and transfers constraints such as minimum/maximum
+     * using the correct type-check function for the narrowed type (e.g. is_int after
+     * narrowing from number to integer).
+     *
+     * Only operates for single scalar types. Multi-type and untyped results use different
+     * validation paths and are left untouched.
+     */
+    private function reapplyTypeSpecificRefConstraints(
+        SchemaProcessor $schemaProcessor,
+        Schema $schema,
+        PropertyInterface $existing,
+        PropertyInterface $refProperty,
+    ): void {
+        $effectiveType = $existing->getType(true);
+
+        if ($effectiveType === null || count($effectiveType->getNames()) !== 1) {
+            return;
+        }
+
+        $effectiveTypeName           = $effectiveType->getNames()[0];
+        $effectiveTypeJsonSchemaName = TypeConverter::phpToJsonSchema($effectiveTypeName);
+        $refJsonWithEffectiveType    = $refProperty->getJsonSchema()->withJson(
+            array_merge($refProperty->getJsonSchema()->getJson(), ['type' => $effectiveTypeJsonSchemaName]),
+        );
+
+        $builtDraft = $schemaProcessor->getGeneratorConfiguration()->getBuiltDraft($refJsonWithEffectiveType);
+
+        foreach ($builtDraft->getCoveredTypes($effectiveTypeJsonSchemaName) as $coveredType) {
+            if ($coveredType->getType() === 'any') {
+                continue;
+            }
+
+            foreach ($coveredType->getModifiers() as $modifier) {
+                $countBefore = count($existing->getValidators());
+                $modifier->modify($schemaProcessor, $schema, $existing, $refJsonWithEffectiveType);
+
+                if ($modifier instanceof AbstractValidatorFactory && ($modifierKey = $modifier->getKey()) !== null) {
+                    foreach (array_slice($existing->getValidators(), $countBefore) as $validatorWrapper) {
+                        $validatorWrapper->setSourceKey($modifierKey);
+                    }
+                }
+            }
+        }
     }
 }

--- a/src/Draft/Producer/RefResolver.php
+++ b/src/Draft/Producer/RefResolver.php
@@ -33,14 +33,29 @@ class RefResolver implements PropertyProducerInterface
         string $propertyName,
         JsonSchema $propertySchema,
         bool $required,
+        bool $isArrayItem = false,
     ): PropertyInterface {
         $json = $propertySchema->getJson();
 
         if (isset($json['type']) && $json['type'] === 'base') {
-            return $this->resolveBaseReference($schemaProcessor, $schema, $propertyName, $propertySchema, $required);
+            return $this->resolveBaseReference(
+                $schemaProcessor,
+                $schema,
+                $propertyName,
+                $propertySchema,
+                $required,
+                $isArrayItem,
+            );
         }
 
-        return $this->resolveReference($schemaProcessor, $schema, $propertyName, $propertySchema, $required);
+        return $this->resolveReference(
+            $schemaProcessor,
+            $schema,
+            $propertyName,
+            $propertySchema,
+            $required,
+            $isArrayItem,
+        );
     }
 
     /**
@@ -54,6 +69,7 @@ class RefResolver implements PropertyProducerInterface
         string $propertyName,
         JsonSchema $propertySchema,
         bool $required,
+        bool $isArrayItem = false,
     ): PropertyInterface {
         $path       = [];
         $reference  = $propertySchema->getJson()['$ref'];
@@ -91,6 +107,7 @@ class RefResolver implements PropertyProducerInterface
                     implode('/', $path),
                     $required,
                     $propertySchema->getJson()['_dependencies'] ?? null,
+                    $isArrayItem,
                 );
 
                 // Use the reference site's pointer (where $ref appears in the schema) rather
@@ -104,6 +121,7 @@ class RefResolver implements PropertyProducerInterface
         } catch (Exception $exception) {
             throw new SchemaException(
                 "Unresolved Reference $reference in file {$propertySchema->getFile()}",
+                null,
                 0,
                 $exception,
             );
@@ -124,10 +142,18 @@ class RefResolver implements PropertyProducerInterface
         string $propertyName,
         JsonSchema $propertySchema,
         bool $required,
+        bool $isArrayItem = false,
     ): PropertyInterface {
         $schema->getSchemaDictionary()->setUpDefinitionDictionary($schemaProcessor, $schema);
 
-        $property = $this->resolveReference($schemaProcessor, $schema, $propertyName, $propertySchema, $required);
+        $property = $this->resolveReference(
+            $schemaProcessor,
+            $schema,
+            $propertyName,
+            $propertySchema,
+            $required,
+            $isArrayItem,
+        );
 
         if (!$property->getNestedSchema()) {
             throw new SchemaException(

--- a/src/Draft/Producer/RefResolver.php
+++ b/src/Draft/Producer/RefResolver.php
@@ -1,0 +1,145 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PHPModelGenerator\Draft\Producer;
+
+use Exception;
+use PHPModelGenerator\Attributes\JsonPointer;
+use PHPModelGenerator\Exception\SchemaException;
+use PHPModelGenerator\Model\Attributes\PhpAttribute;
+use PHPModelGenerator\Model\Property\PropertyInterface;
+use PHPModelGenerator\Model\Schema;
+use PHPModelGenerator\Model\SchemaDefinition\JsonSchema;
+use PHPModelGenerator\PropertyProcessor\Decorator\SchemaNamespaceTransferDecorator;
+use PHPModelGenerator\SchemaProcessor\SchemaProcessor;
+
+/**
+ * Resolves a $ref by looking it up in the definition dictionary and returning the referenced
+ * property. The resolver only resolves: it holds no sibling policy (that is expressed per draft by
+ * wrapping it in an {@see ExclusiveProducer} or not) and does not merge with other producers.
+ */
+class RefResolver implements PropertyProducerInterface
+{
+    /**
+     * @throws SchemaException
+     */
+    public function produce(
+        SchemaProcessor $schemaProcessor,
+        Schema $schema,
+        string $propertyName,
+        JsonSchema $propertySchema,
+        bool $required,
+    ): PropertyInterface {
+        $json = $propertySchema->getJson();
+
+        if (isset($json['type']) && $json['type'] === 'base') {
+            return $this->resolveBaseReference($schemaProcessor, $schema, $propertyName, $propertySchema, $required);
+        }
+
+        return $this->resolveReference($schemaProcessor, $schema, $propertyName, $propertySchema, $required);
+    }
+
+    /**
+     * Resolve a $ref reference by looking it up in the definition dictionary.
+     *
+     * @throws SchemaException
+     */
+    private function resolveReference(
+        SchemaProcessor $schemaProcessor,
+        Schema $schema,
+        string $propertyName,
+        JsonSchema $propertySchema,
+        bool $required,
+    ): PropertyInterface {
+        $path       = [];
+        $reference  = $propertySchema->getJson()['$ref'];
+        $dictionary = $schema->getSchemaDictionary();
+
+        try {
+            $definition = $dictionary->getDefinition($reference, $schemaProcessor, $path);
+
+            if ($definition) {
+                $definitionSchema = $definition->getSchema();
+
+                if (
+                    $schema->getClassPath() !== $definitionSchema->getClassPath() ||
+                    $schema->getClassName() !== $definitionSchema->getClassName() ||
+                    (
+                        $schema->getClassName() === 'ExternalSchema' &&
+                        $definitionSchema->getClassName() === 'ExternalSchema'
+                    )
+                ) {
+                    $schema->addNamespaceTransferDecorator(
+                        new SchemaNamespaceTransferDecorator($definitionSchema),
+                    );
+
+                    if ($definitionSchema->getClassName() !== 'ExternalSchema') {
+                        $schema->addUsedClass(join('\\', array_filter([
+                            $schemaProcessor->getGeneratorConfiguration()->getNamespacePrefix(),
+                            $definitionSchema->getClassPath(),
+                            $definitionSchema->getClassName(),
+                        ])));
+                    }
+                }
+
+                $property = $definition->resolveReference(
+                    $propertyName,
+                    implode('/', $path),
+                    $required,
+                    $propertySchema->getJson()['_dependencies'] ?? null,
+                );
+
+                // Use the reference site's pointer (where $ref appears in the schema) rather
+                // than the definition's pointer. This is always meaningful and consistent with
+                // how inline properties work — both show WHERE IN THE SCHEMA the property is
+                // defined, not where the resolved type lives.
+                $property->overrideJsonPointer(new PhpAttribute(JsonPointer::class, [$propertySchema->getPointer()]));
+
+                return $property;
+            }
+        } catch (Exception $exception) {
+            throw new SchemaException(
+                "Unresolved Reference $reference in file {$propertySchema->getFile()}",
+                0,
+                $exception,
+            );
+        }
+
+        throw new SchemaException("Unresolved Reference $reference in file {$propertySchema->getFile()}");
+    }
+
+    /**
+     * Resolve a $ref on a base-level schema: set up definitions, delegate to resolveReference,
+     * then copy the referenced schema's properties to the parent schema.
+     *
+     * @throws SchemaException
+     */
+    private function resolveBaseReference(
+        SchemaProcessor $schemaProcessor,
+        Schema $schema,
+        string $propertyName,
+        JsonSchema $propertySchema,
+        bool $required,
+    ): PropertyInterface {
+        $schema->getSchemaDictionary()->setUpDefinitionDictionary($schemaProcessor, $schema);
+
+        $property = $this->resolveReference($schemaProcessor, $schema, $propertyName, $propertySchema, $required);
+
+        if (!$property->getNestedSchema()) {
+            throw new SchemaException(
+                sprintf(
+                    'A referenced schema on base level must provide an object definition for property %s in file %s',
+                    $propertyName,
+                    $propertySchema->getFile(),
+                )
+            );
+        }
+
+        foreach ($property->getNestedSchema()->getProperties() as $propertiesOfReferencedObject) {
+            $schema->addProperty($propertiesOfReferencedObject);
+        }
+
+        return $property;
+    }
+}

--- a/src/Draft/Producer/RefResolver.php
+++ b/src/Draft/Producer/RefResolver.php
@@ -11,6 +11,7 @@ use PHPModelGenerator\Model\Attributes\PhpAttribute;
 use PHPModelGenerator\Model\Property\PropertyInterface;
 use PHPModelGenerator\Model\Schema;
 use PHPModelGenerator\Model\SchemaDefinition\JsonSchema;
+use PHPModelGenerator\Model\Validator\Factory\Composition\AllOfValidatorFactory;
 use PHPModelGenerator\PropertyProcessor\Decorator\SchemaNamespaceTransferDecorator;
 use PHPModelGenerator\SchemaProcessor\SchemaProcessor;
 
@@ -136,8 +137,15 @@ class RefResolver implements PropertyProducerInterface
             );
         }
 
-        foreach ($property->getNestedSchema()->getProperties() as $propertiesOfReferencedObject) {
-            $schema->addProperty($propertiesOfReferencedObject);
+        foreach ($property->getNestedSchema()->getProperties() as $refProperty) {
+            // Use allOf semantics when a sibling has already registered this property name so
+            // that type-intersection narrowing and default-conflict detection apply. For
+            // properties that only the ref defines, plain registration (null compositionProcessor)
+            // is correct — they become root-registered with no merge needed.
+            $compositionProcessor = $schema->getProperty($refProperty->getName()) !== null
+                ? AllOfValidatorFactory::class
+                : null;
+            $schema->addProperty($refProperty, $compositionProcessor);
         }
 
         return $property;

--- a/src/Draft/Producer/RefResolver.php
+++ b/src/Draft/Producer/RefResolver.php
@@ -76,7 +76,7 @@ class RefResolver implements PropertyProducerInterface
         $dictionary = $schema->getSchemaDictionary();
 
         try {
-            $definition = $dictionary->getDefinition($reference, $schemaProcessor, $path);
+            $definition = $dictionary->getDefinition($reference, $schemaProcessor, $path, $propertySchema->getBaseId());
 
             if ($definition) {
                 $definitionSchema = $definition->getSchema();
@@ -144,6 +144,23 @@ class RefResolver implements PropertyProducerInterface
         bool $required,
         bool $isArrayItem = false,
     ): PropertyInterface {
+        $reference = $propertySchema->getJson()['$ref'];
+
+        // '' and '#' both resolve (RFC 3986 §5.2.2: empty path/fragment) to the enclosing
+        // document's own root. On base level that means the schema would be merged with itself -
+        // there is no fixed point to compute, so PropertyProxy::getNestedSchema() below would
+        // recurse into resolving the same schema forever instead of converging. Reject it
+        // explicitly rather than looping until the interpreter's guard aborts the process.
+        if ($reference === '' || $reference === '#') {
+            throw new SchemaException(
+                sprintf(
+                    "A referenced schema on base level must not reference itself for property '%s' in file %s",
+                    $propertyName,
+                    $propertySchema->getFile(),
+                ),
+            );
+        }
+
         $schema->getSchemaDictionary()->setUpDefinitionDictionary($schemaProcessor, $schema);
 
         $property = $this->resolveReference(

--- a/src/Model/GeneratorConfiguration.php
+++ b/src/Model/GeneratorConfiguration.php
@@ -10,6 +10,7 @@ use PHPModelGenerator\Draft\AutoDetectionDraft;
 use PHPModelGenerator\Draft\Draft;
 use PHPModelGenerator\Draft\DraftFactoryInterface;
 use PHPModelGenerator\Draft\DraftInterface;
+use PHPModelGenerator\Draft\DraftResolver;
 use PHPModelGenerator\Exception\ErrorRegistryException;
 use PHPModelGenerator\Exception\InvalidFilterException;
 use PHPModelGenerator\Filter\FilterInterface;
@@ -65,8 +66,7 @@ class GeneratorConfiguration
     /** @var DraftInterface | DraftFactoryInterface */
     protected $draft;
 
-    /** @var Draft[] Built (immutable) Draft registries, keyed by draft class name */
-    private array $builtDraftCache = [];
+    private DraftResolver $draftResolver;
 
     /** @var ClassNameGeneratorInterface */
     protected $classNameGenerator;
@@ -84,6 +84,7 @@ class GeneratorConfiguration
     public function __construct()
     {
         $this->draft = new AutoDetectionDraft();
+        $this->draftResolver = new DraftResolver();
         $this->classNameGenerator = new ClassNameGenerator();
         $this->logger = new EchoLogger();
 
@@ -369,17 +370,13 @@ class GeneratorConfiguration
     /**
      * Resolve the active draft for the given schema (via DraftFactoryInterface::getDraftForSchema
      * when a factory is configured) and build its immutable Draft registry, caching the result by
-     * draft class so repeated calls for the same draft don't rebuild it.
+     * draft class so repeated calls for the same draft don't rebuild it. The cache and the branch
+     * resolution live in DraftResolver, a private implementation detail not otherwise exposed on
+     * this class's public surface.
      */
     public function getBuiltDraft(JsonSchema $propertySchema): Draft
     {
-        $configDraft = $this->getDraft();
-
-        $draftInterface = $configDraft instanceof DraftFactoryInterface
-            ? $configDraft->getDraftForSchema($propertySchema)
-            : $configDraft;
-
-        return $this->builtDraftCache[$draftInterface::class] ??= $draftInterface->getDefinition()->build();
+        return $this->draftResolver->getBuiltDraft($this->getDraft(), $propertySchema);
     }
 
     public function isImplicitNullAllowed(): bool

--- a/src/Model/GeneratorConfiguration.php
+++ b/src/Model/GeneratorConfiguration.php
@@ -7,6 +7,7 @@ namespace PHPModelGenerator\Model;
 use Exception;
 use InvalidArgumentException;
 use PHPModelGenerator\Draft\AutoDetectionDraft;
+use PHPModelGenerator\Draft\Draft;
 use PHPModelGenerator\Draft\DraftFactoryInterface;
 use PHPModelGenerator\Draft\DraftInterface;
 use PHPModelGenerator\Exception\ErrorRegistryException;
@@ -23,6 +24,7 @@ use PHPModelGenerator\Format\UriFormatValidator;
 use PHPModelGenerator\Format\UriReferenceFormatValidator;
 use PHPModelGenerator\Format\UriTemplateFormatValidator;
 use PHPModelGenerator\Model\Attributes\PhpAttribute;
+use PHPModelGenerator\Model\SchemaDefinition\JsonSchema;
 use PHPModelGenerator\PropertyProcessor\Filter\DateTimeFilter;
 use PHPModelGenerator\PropertyProcessor\Filter\ImmutableMediaStringFilter;
 use PHPModelGenerator\PropertyProcessor\Filter\MediaStringFilter;
@@ -66,6 +68,9 @@ class GeneratorConfiguration
 
     /** @var DraftInterface | DraftFactoryInterface */
     protected $draft;
+
+    /** @var Draft[] Built (immutable) Draft registries, keyed by draft class name */
+    private array $builtDraftCache = [];
 
     /** @var ClassNameGeneratorInterface */
     protected $classNameGenerator;
@@ -358,6 +363,22 @@ class GeneratorConfiguration
         $this->draft = $draft;
 
         return $this;
+    }
+
+    /**
+     * Resolve the active draft for the given schema (via DraftFactoryInterface::getDraftForSchema
+     * when a factory is configured) and build its immutable Draft registry, caching the result by
+     * draft class so repeated calls for the same draft don't rebuild it.
+     */
+    public function getBuiltDraft(JsonSchema $propertySchema): Draft
+    {
+        $configDraft = $this->getDraft();
+
+        $draftInterface = $configDraft instanceof DraftFactoryInterface
+            ? $configDraft->getDraftForSchema($propertySchema)
+            : $configDraft;
+
+        return $this->builtDraftCache[$draftInterface::class] ??= $draftInterface->getDefinition()->build();
     }
 
     public function isImplicitNullAllowed(): bool

--- a/src/Model/Property/PropertyInterface.php
+++ b/src/Model/Property/PropertyInterface.php
@@ -181,7 +181,7 @@ interface PropertyInterface extends ResolvableInterface
 
     /**
      * Replace the JsonPointer attribute with one carrying the given pointer value.
-     * Used by processReference to set the reference site's pointer on a resolved property
+     * Used by the $ref resolver to set the reference site's pointer on a resolved property
      * rather than the definition's pointer.
      */
     public function overrideJsonPointer(PhpAttribute $attribute): static;

--- a/src/Model/Property/PropertyProxy.php
+++ b/src/Model/Property/PropertyProxy.php
@@ -25,7 +25,6 @@ class PropertyProxy extends AbstractProperty
 {
     private ?JsonSchema $overrideJsonSchema = null;
     private ?PhpAttribute $overrideJsonPointer = null;
-    private bool $isProxyArrayItem = false;
 
     /**
      * PropertyProxy constructor.
@@ -222,20 +221,15 @@ class PropertyProxy extends AbstractProperty
      */
     public function isRequired(): bool
     {
-        return $this->isProxyArrayItem || $this->getProperty()->isRequired();
+        return $this->getProperty()->isRequired();
     }
 
     /**
      * @inheritdoc
-     *
-     * Stores the array-item flag locally rather than delegating: the same $ref-resolved
-     * property can be reused as a plain property in one place and as an array item in
-     * another (each usage gets its own PropertyProxy), so the flag must not be shared via
-     * the underlying property.
      */
     public function setArrayItem(bool $isArrayItem): PropertyInterface
     {
-        $this->isProxyArrayItem = $isArrayItem;
+        $this->getProperty()->setArrayItem($isArrayItem);
 
         return $this;
     }
@@ -245,7 +239,7 @@ class PropertyProxy extends AbstractProperty
      */
     public function isArrayItem(): bool
     {
-        return $this->isProxyArrayItem;
+        return $this->getProperty()->isArrayItem();
     }
 
     /**

--- a/src/Model/Schema.php
+++ b/src/Model/Schema.php
@@ -22,6 +22,7 @@ use PHPModelGenerator\Model\Validator\SchemaDependencyValidator;
 use PHPModelGenerator\Model\Validator\Factory\Composition\AllOfValidatorFactory;
 use PHPModelGenerator\PropertyProcessor\Decorator\SchemaNamespaceTransferDecorator;
 use PHPModelGenerator\SchemaProcessor\Hook\SchemaHookInterface;
+use PHPModelGenerator\SchemaProcessor\SchemaProcessor;
 use PHPModelGenerator\Utils\PropertyMerger;
 
 class Schema
@@ -179,11 +180,17 @@ class Schema
     /**
      * @param string|null $compositionProcessor The FQCN of the composition processor transferring this property,
      *                                           or null when not called from a composition context.
+     * @param JsonSchema|null $rebuildFrom See PropertyMerger::merge()'s docblock. Only meaningful together with
+     *                                     $schemaProcessor; both are forwarded as-is.
      *
      * @throws SchemaException
      */
-    public function addProperty(PropertyInterface $property, ?string $compositionProcessor = null): self
-    {
+    public function addProperty(
+        PropertyInterface $property,
+        ?string $compositionProcessor = null,
+        ?JsonSchema $rebuildFrom = null,
+        ?SchemaProcessor $schemaProcessor = null,
+    ): self {
         if (!isset($this->properties[$property->getName()])) {
             // Register by name immediately — the name is always held locally on the property
             // or proxy, independent of whether the proxy's target is resolved yet.
@@ -239,6 +246,9 @@ class Schema
             $property,
             is_a($compositionProcessor, AllOfValidatorFactory::class, true),
             $this->isRootRegistered($property->getName()),
+            $rebuildFrom,
+            $schemaProcessor,
+            $this,
         );
 
         return $this;

--- a/src/Model/SchemaDefinition/JsonSchema.php
+++ b/src/Model/SchemaDefinition/JsonSchema.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace PHPModelGenerator\Model\SchemaDefinition;
 
-use PHPModelGenerator\Exception\GeneratorException;
 use PHPModelGenerator\Exception\SchemaException;
 use PHPModelGenerator\Utils\ArrayHash;
 
@@ -46,28 +45,6 @@ class JsonSchema
      */
     public function __construct(private string $file, array $json, private string $pointer = '')
     {
-        // wrap in an allOf to pass the processing to multiple handlers - ugly hack to be removed after rework
-        if (
-            isset($json['$ref']) &&
-            count(array_diff(
-                array_intersect(array_keys($json), self::SCHEMA_SIGNATURE_RELEVANT_FIELDS),
-                ['$ref', 'type'],
-            ))
-        ) {
-            $json = array_merge(
-                array_diff_key($json, array_fill_keys(self::SCHEMA_SIGNATURE_RELEVANT_FIELDS, null)),
-                [
-                    'allOf' => [
-                        ['$ref' => $json['$ref']],
-                        array_intersect_key(
-                            $json,
-                            array_fill_keys(array_diff(self::SCHEMA_SIGNATURE_RELEVANT_FIELDS, ['$ref']), null),
-                        ),
-                    ],
-                ],
-            );
-        }
-
         $this->json = $json;
     }
 

--- a/src/Model/SchemaDefinition/JsonSchema.php
+++ b/src/Model/SchemaDefinition/JsonSchema.php
@@ -32,6 +32,15 @@ class JsonSchema
     protected array $json;
 
     /**
+     * The nearest enclosing $id, normalized to always start with '#' (matching
+     * SchemaDefinitionDictionary's dictionary key format). Defaults to the document root ('#')
+     * and is updated by navigate() whenever it descends into a node carrying its own $id. Used to
+     * resolve an empty/fragment-only $ref (RFC 3986 §5.2.2: "" and "#" both resolve to the
+     * current base) against the correct scope instead of always the top-level document.
+     */
+    private string $baseId = '#';
+
+    /**
      * JsonSchema constructor.
      *
      * @param string $file the source file for the schema
@@ -48,6 +57,10 @@ class JsonSchema
         private ?string $rawSource = null,
     ) {
         $this->json = $json;
+
+        if (isset($json['$id'])) {
+            $this->baseId = self::normalizeId((string) $json['$id']);
+        }
     }
 
     public function getJson(): array
@@ -107,9 +120,23 @@ class JsonSchema
             }
 
             $jsonSchema->json = $jsonSchema->json[$decodedPathSegment];
+
+            if (is_array($jsonSchema->json) && isset($jsonSchema->json['$id'])) {
+                $jsonSchema->baseId = self::normalizeId((string) $jsonSchema->json['$id']);
+            }
         }
 
         return $jsonSchema;
+    }
+
+    public function getBaseId(): string
+    {
+        return $this->baseId;
+    }
+
+    public static function normalizeId(string $id): string
+    {
+        return str_starts_with($id, '#') ? $id : "#$id";
     }
 
     public function getFile(): string

--- a/src/Model/SchemaDefinition/SchemaDefinition.php
+++ b/src/Model/SchemaDefinition/SchemaDefinition.php
@@ -58,7 +58,10 @@ class SchemaDefinition
 
         // if the properties point to the same definition and share identical metadata the generated property can be
         // recycled. Otherwise, a new property must be generated as diverging metadata lead to different validators.
-        $key = implode('-', [$path, $required ? '1' : '0', md5(json_encode($dependencies))]);
+        // isArrayItem IS included because array-item usage must not have the implicit-null guard that optional object
+        // properties get: the TypeCheckValidator's check string is baked in at property creation time, so a shared
+        // underlying property cannot serve both use cases correctly.
+        $key = implode('-', [$path, $required ? '1' : '0', $isArrayItem ? '1' : '0', md5(json_encode($dependencies))]);
 
         if (!$this->resolvedPaths->offsetExists($key)) {
             // create a dummy entry for the path first. If the path is used recursive the recursive usages will point
@@ -92,12 +95,7 @@ class SchemaDefinition
             }
         }
 
-        // The cache key deliberately does not include $isArrayItem: the same $ref definition can
-        // be reused as a plain property in one place and as an array item in another. Each usage
-        // gets its own proxy, so the flag is set directly on the proxy rather than shared via the
-        // cached underlying property.
         $proxy = new PropertyProxy($propertyName, $this->source, $this->resolvedPaths, $key);
-        $proxy->setArrayItem($isArrayItem);
         $this->unresolvedProxies[$key][] = $proxy;
 
         if ($this->resolvedPaths->offsetGet($key)) {

--- a/src/Model/SchemaDefinition/SchemaDefinition.php
+++ b/src/Model/SchemaDefinition/SchemaDefinition.php
@@ -58,9 +58,17 @@ class SchemaDefinition
 
         // if the properties point to the same definition and share identical metadata the generated property can be
         // recycled. Otherwise, a new property must be generated as diverging metadata lead to different validators.
-        // isArrayItem IS included because array-item usage must not have the implicit-null guard that optional object
-        // properties get: the TypeCheckValidator's check string is baked in at property creation time, so a shared
-        // underlying property cannot serve both use cases correctly.
+        // isArrayItem IS included unconditionally, not only when implicit null is allowed. It looks tempting to gate
+        // it behind GeneratorConfiguration::isImplicitNullAllowed(), since TypeCheckValidator's own implicit-null
+        // guard (allowImplicitNull = isImplicitNullAllowed() && !isRequired()) is already false whenever implicit
+        // null is off, independent of isArrayItem. But RenderHelper::isPropertyNullable() computes getter (output)
+        // nullability as !isRequired() whenever outputType=true, regardless of isImplicitNullAllowed(). isRequired()
+        // is itself `isPropertyRequired || isPropertyArrayItem`, and a PropertyProxy delegates both isRequired() and
+        // isArrayItem() to the one shared underlying property. So gating would let an array-item usage and a plain
+        // optional-property usage of the same $ref collide onto one shared property when implicit null is disabled,
+        // and whichever wired isArrayItem=true would silently flip the other's getter to non-nullable. Confirmed via
+        // a $ref used both as `items` of an array and as a plain optional property: gating changed the optional
+        // property's generated getter from `?Item` to the incorrect `Item`.
         $key = implode('-', [$path, $required ? '1' : '0', $isArrayItem ? '1' : '0', md5(json_encode($dependencies))]);
 
         if (!$this->resolvedPaths->offsetExists($key)) {

--- a/src/Model/SchemaDefinition/SchemaDefinitionDictionary.php
+++ b/src/Model/SchemaDefinition/SchemaDefinitionDictionary.php
@@ -69,7 +69,7 @@ class SchemaDefinitionDictionary extends ArrayObject
 
         if (isset($json['$id'])) {
             $this->addDefinition(
-                str_starts_with((string) $json['$id'], '#') ? $json['$id'] : "#{$json['$id']}",
+                JsonSchema::normalizeId((string) $json['$id']),
                 new SchemaDefinition($jsonSchema, $schemaProcessor, $schema),
             );
         }
@@ -106,8 +106,20 @@ class SchemaDefinitionDictionary extends ArrayObject
     /**
      * @throws SchemaException
      */
-    public function getDefinition(string $key, SchemaProcessor $schemaProcessor, array &$path = []): ?SchemaDefinition
-    {
+    public function getDefinition(
+        string $key,
+        SchemaProcessor $schemaProcessor,
+        array &$path = [],
+        string $baseId = '#',
+    ): ?SchemaDefinition {
+        // An empty $ref is a URI-Reference with an empty path, which RFC 3986 §5.2.2 resolves
+        // against the current base URI to the base URI's own path. $baseId carries that base:
+        // the document root ('#') by default, or the nearest enclosing $id when the $ref is
+        // written inside a $id-scoped subschema (JsonSchema::getBaseId()).
+        if ($key === '') {
+            $key = $baseId;
+        }
+
         if (str_starts_with($key, '#') && strpos($key, '/')) {
             $path = explode('/', $key);
             array_shift($path);
@@ -132,7 +144,7 @@ class SchemaDefinitionDictionary extends ArrayObject
             }
 
             return $jsonSchemaFile
-                ? $this->parseExternalFile($jsonSchemaFile, "#$externalKey", $schemaProcessor, $path)
+                ? $this->parseExternalFile($jsonSchemaFile, "#$externalKey", $schemaProcessor, $path, $baseId)
                 : null;
         }
 
@@ -147,14 +159,22 @@ class SchemaDefinitionDictionary extends ArrayObject
         string $externalKey,
         SchemaProcessor $schemaProcessor,
         array &$path,
+        string $baseId = '#',
     ): ?SchemaDefinition {
         // Resolve the ref to obtain the canonical file path or URL via the provider.
         // Using $jsonSchema->getFile() as the key (not the raw $jsonSchemaFile argument) ensures
         // that relative refs from different directories pointing to the same file share one entry,
         // and that network URLs resolved via $id are handled correctly.
+        //
+        // $baseId (the nearest enclosing $id, see JsonSchema::getBaseId()) rather than always
+        // this file's own top-level $id: a relative $ref written inside a $id-scoped subschema
+        // resolves against that scope's own $id, not the document's. Strip the '#' normalization
+        // prefix back off - getRef() only builds a network URL from it when it's itself a full
+        // URL, so a plain internal id (e.g. '#person') falls through to local-path resolution
+        // exactly as no $id at all would.
         $jsonSchema = $schemaProcessor->getSchemaProvider()->getRef(
             $this->schema->getFile(),
-            $this->schema->getJson()['$id'] ?? null,
+            $baseId === '#' ? null : substr($baseId, 1),
             $jsonSchemaFile,
         );
 

--- a/src/PropertyProcessor/Filter/FilterProcessor.php
+++ b/src/PropertyProcessor/Filter/FilterProcessor.php
@@ -5,9 +5,6 @@ declare(strict_types=1);
 namespace PHPModelGenerator\PropertyProcessor\Filter;
 
 use Exception;
-use LogicException;
-use PHPModelGenerator\Draft\Draft;
-use PHPModelGenerator\Draft\DraftFactoryInterface;
 use PHPModelGenerator\Exception\InvalidFilterException;
 use PHPModelGenerator\Exception\Object\InvalidInstanceOfException;
 use PHPModelGenerator\Exception\SchemaException;
@@ -150,7 +147,7 @@ class FilterProcessor
                 // called externally multiple times on the same property; the null-coalescing
                 // assignment ensures we do not rebuild when called from a MediaStringModifier
                 // followed by a FilterValidatorFactory invocation.
-                $builtDraft ??= $this->resolveBuiltDraft($generatorConfiguration, $property);
+                $builtDraft ??= $generatorConfiguration->getBuiltDraft($property->getJsonSchema());
                 $classifier = new CompositionBranchClassifier($builtDraft, $inputTypeNames, $returnTypeNames);
                 $checker = new CompositionCompatibilityChecker($classifier, $property);
                 $checker->checkTransformingFilterCompositionConflicts($property->getJsonSchema()->getJson());
@@ -673,26 +670,6 @@ class FilterProcessor
                 $schema->addUsedClass($typeName);
             }
         }
-    }
-
-    /**
-     * Build and return the Draft instance for the given property's schema.
-     *
-     * Resolves DraftFactoryInterface vs DraftInterface from the GeneratorConfiguration
-     * and builds the immutable Draft registry. Callers should cache the result rather
-     * than calling this method more than once per process() invocation.
-     */
-    private function resolveBuiltDraft(
-        GeneratorConfiguration $generatorConfiguration,
-        PropertyInterface $property,
-    ): Draft {
-        $configDraft = $generatorConfiguration->getDraft();
-
-        $draftInterface = $configDraft instanceof DraftFactoryInterface
-            ? $configDraft->getDraftForSchema($property->getJsonSchema())
-            : $configDraft;
-
-        return $draftInterface->getDefinition()->build();
     }
 
     /**

--- a/src/PropertyProcessor/PropertyFactory.php
+++ b/src/PropertyProcessor/PropertyFactory.php
@@ -22,12 +22,14 @@ use PHPModelGenerator\Model\Property\PropertyInterface;
 use PHPModelGenerator\Model\Property\PropertyType;
 use PHPModelGenerator\Model\Schema;
 use PHPModelGenerator\Model\SchemaDefinition\JsonSchema;
-use PHPModelGenerator\Model\Validator\Factory\AbstractValidatorFactory;
 use PHPModelGenerator\Draft\Modifier\TypeCheckModifier;
+use PHPModelGenerator\Model\Validator\Factory\AbstractValidatorFactory;
+use PHPModelGenerator\Model\Validator\Factory\Composition\AllOfValidatorFactory;
 use PHPModelGenerator\Model\Validator\MultiTypeCheckValidator;
 use PHPModelGenerator\Model\Validator\RequiredPropertyValidator;
 use PHPModelGenerator\Model\Validator\TypeCheckInterface;
 use PHPModelGenerator\PropertyProcessor\Decorator\Property\PropertyTransferDecorator;
+use PHPModelGenerator\PropertyProcessor\Decorator\SchemaNamespaceTransferDecorator;
 use PHPModelGenerator\PropertyProcessor\Decorator\TypeHint\TypeHintDecorator;
 use PHPModelGenerator\SchemaProcessor\SchemaProcessor;
 use PHPModelGenerator\Utils\TypeConverter;
@@ -205,24 +207,46 @@ class PropertyFactory
     }
 
     /**
-     * Produce the property from the producer keyword ($ref), then asynchronously merge it
-     * with any sibling keywords present on the same schema node.
+     * Keywords that, when present in the sibling JSON alongside a $ref, indicate that the
+     * $ref's resolved type must be an object and the two should be merged into a new nested
+     * class (object×object merge). Non-structural siblings (default, enum, const, …) take
+     * the scalar/array merge path or the object-with-any-only-modifiers fallback instead.
+     */
+    private const OBJECT_STRUCTURAL_KEYWORDS = [
+        'properties',
+        'required',
+        'additionalProperties',
+        'patternProperties',
+        'propertyNames',
+        'minProperties',
+        'maxProperties',
+        'unevaluatedProperties',
+        'dependentSchemas',
+        'dependentRequired',
+    ];
+
+    /**
+     * Produce the property from the producer keyword ($ref), then merge it with any sibling
+     * keywords present on the same schema node.
      *
      * Builds an untyped placeholder property to return immediately (required for recursive
      * $ref support, where the backing property is not yet available when produce() returns).
      * The actual type and validators are wired in the onResolve callback once the ref
      * property has resolved.
      *
-     * Object×object merge — when the ref property resolves to an object schema AND either
-     * (a) siblings include structural object keywords like 'properties', or (b) a second
-     * producer keyword is present and also resolves to an object — requires processSchema()
-     * to be called for the merged object. However, processSchema() mutates
-     * SchemaProcessor::currentClassPath as a side effect. Calling it inside an onResolve
-     * callback (which fires mid-resolveReference) would corrupt the class-path context for
-     * subsequent properties in the parent schema. This case is therefore not yet supported
-     * and falls back to wiring the ref property's nested schema onto the target property
-     * while ignoring sibling structural keywords. A future change adding save/restore of
-     * class context to SchemaProcessor will unblock this.
+     * Three distinct merge paths, chosen before produce() is called:
+     *
+     * 1. Object×object (structural sibling keywords + ref→object): a merged Schema is
+     *    pre-created and sibling properties are processed into it synchronously; once the
+     *    ref resolves, ref properties are transferred into the merged Schema with allOf
+     *    semantics (type intersection, default-conflict detection) for name collisions.
+     *
+     * 2. Object with non-structural siblings (ref→object + default/enum/const/…): the ref's
+     *    nested Schema is wired directly; non-structural siblings are applied as any-type
+     *    modifiers on the outer property.
+     *
+     * 3. Scalar/array merge (ref→non-object): a fresh property is built from the sibling
+     *    schema and the ref's type and validators are merged into it non-mutably.
      *
      * @param array<string, PropertyProducerInterface> $producers
      *
@@ -237,7 +261,7 @@ class PropertyFactory
         array $producers,
         array $siblingJson,
     ): PropertyInterface {
-        $siblingSchema  = $propertySchema->withJson($siblingJson);
+        $siblingSchema = $propertySchema->withJson($siblingJson);
         $targetProperty = $this->buildProperty(
             $schemaProcessor,
             $propertyName,
@@ -245,6 +269,24 @@ class PropertyFactory
             $siblingSchema,
             $required,
         );
+
+        // Detect object structural siblings before producing the ref so the merged Schema can
+        // be created synchronously (avoiding processSchema() inside an onResolve callback).
+        $hasObjectStructuralSiblings = !empty(
+            array_intersect(array_keys($siblingJson), self::OBJECT_STRUCTURAL_KEYWORDS)
+        );
+
+        // Pre-create the merged Schema when siblings contain structural object keywords.
+        // Sibling content is processed into the Schema now; ref properties are added later
+        // inside onResolve via allOf semantics.
+        $mergedSchema = $hasObjectStructuralSiblings
+            ? $schemaProcessor->createObjectRefSiblingMergedSchema(
+                $schema,
+                $propertyName,
+                $propertySchema,
+                $siblingJson,
+            )
+            : null;
 
         $refProperty = array_values($producers)[0]->produce(
             $schemaProcessor,
@@ -261,18 +303,52 @@ class PropertyFactory
             $schemaProcessor,
             $schema,
             $propertyName,
+            $mergedSchema,
         ): void {
             if ($refProperty->getNestedSchema() !== null) {
-                // Object×object: not yet supported — fall back to the ref property as-is.
-                // Sibling structural keywords (properties, required, etc.) are ignored for
-                // this case. See method docblock for the underlying constraint.
-                $targetProperty->setNestedSchema($refProperty->getNestedSchema());
+                if ($mergedSchema !== null) {
+                    // Object×object merge path (path 1): transfer ref properties into the
+                    // pre-created merged Schema with allOf semantics for collisions.
+                    foreach ($refProperty->getNestedSchema()->getProperties() as $refProp) {
+                        $compositionProcessor = $mergedSchema->getProperty($refProp->getName()) !== null
+                            ? AllOfValidatorFactory::class
+                            : null;
+                        $mergedSchema->addProperty($refProp, $compositionProcessor);
+                    }
+
+                    // Ensure the merged Schema's class can resolve all types used by the
+                    // ref's properties (e.g. when those properties reference nested classes).
+                    $mergedSchema->addNamespaceTransferDecorator(
+                        new SchemaNamespaceTransferDecorator($refProperty->getNestedSchema()),
+                    );
+
+                    $targetProperty->setNestedSchema($mergedSchema);
+                    $schemaProcessor->generateClassFile($mergedSchema);
+                } else {
+                    // Object with non-structural siblings (path 2): wire ref's nested Schema
+                    // directly; non-structural siblings are applied as any-type modifiers.
+                    $targetProperty->setNestedSchema($refProperty->getNestedSchema());
+                }
+
                 $this->wireObjectProperty($schemaProcessor, $schema, $targetProperty, $siblingSchema);
                 $this->applyModifiers($schemaProcessor, $schema, $targetProperty, $siblingSchema, anyOnly: true);
 
                 return;
             }
 
+            if ($mergedSchema !== null) {
+                // Structural object siblings were detected but the $ref resolved to a
+                // non-object type — these are contradictory constraints.
+                throw new SchemaException(sprintf(
+                    "Property '%s' in file '%s': sibling structural object keywords"
+                        . " ('properties', 'required', …) require the \$ref to resolve to an object,"
+                        . " but it resolved to a non-object type",
+                    $propertyName,
+                    $siblingSchema->getFile(),
+                ));
+            }
+
+            // Scalar/array merge path (path 3).
             $this->applyScalarSiblingMerge(
                 $targetProperty,
                 $refProperty,
@@ -326,20 +402,49 @@ class PropertyFactory
             $propertyName,
         );
 
+        // A concrete (non-array) sibling type that does not include null narrows away the
+        // ref's nullability — the intersection of "string|null" and "string" is "string".
+        // When no sibling type is present or the sibling type is an array, the ref's
+        // nullable is preserved unchanged.
+        $siblingJson      = $siblingSchema->getJson();
+        $effectiveNullable = $producedType->isNullable();
+
+        if (isset($siblingJson['type']) && !is_array($siblingJson['type']) && $siblingJson['type'] !== 'null') {
+            $effectiveNullable = false;
+        }
+
         $targetProperty->setType(
-            new PropertyType($effectivePhpTypeNames, $producedType->isNullable()),
-            new PropertyType($effectivePhpTypeNames, $producedType->isNullable()),
+            new PropertyType($effectivePhpTypeNames, $effectiveNullable),
+            new PropertyType($effectivePhpTypeNames, $effectiveNullable),
         );
 
-        $siblingJson = $siblingSchema->getJson();
         if (count($effectivePhpTypeNames) === 1) {
-            // Single effective type: apply type-specific sibling modifiers (adds TypeCheck +
-            // type-keyed validators like minLength, pattern, minimum, etc.). These run on the
-            // sibling schema; the TypeCheck added here is the one that validates the final
-            // effective type, not the ref property's potentially broader type.
+            $effectiveTypeJsonSchemaName = TypeConverter::phpToJsonSchema($effectivePhpTypeNames[0]);
+
+            // Apply type-specific validators from the ref's definition with the effective
+            // (narrowed) type substituted. This re-derives range validators (minimum, maximum,
+            // etc.) using the correct PHP type-check function for the effective type (e.g.,
+            // is_int instead of is_float when narrowing from number to integer). TypeCheck
+            // deduplication in TypeCheckModifier ensures only one TypeCheck is added.
+            $refJsonWithEffectiveType = array_merge(
+                $refProperty->getJsonSchema()->getJson(),
+                ['type' => $effectiveTypeJsonSchemaName],
+            );
+            $this->applyModifiers(
+                $schemaProcessor,
+                $schema,
+                $targetProperty,
+                $siblingSchema->withJson($refJsonWithEffectiveType),
+                anyOnly: false,
+                typeOnly: true,
+            );
+
+            // Apply type-specific validators from the sibling schema. TypeCheck is already
+            // present (dedup no-op); sibling constraints like minLength, pattern, and
+            // additional range bounds are added here.
             $siblingWithType = array_merge(
                 $siblingJson,
-                ['type' => TypeConverter::phpToJsonSchema($effectivePhpTypeNames[0])],
+                ['type' => $effectiveTypeJsonSchemaName],
             );
             $this->applyModifiers(
                 $schemaProcessor,
@@ -361,9 +466,14 @@ class PropertyFactory
             anyOnly: true,
         );
 
-        // Transfer constraints that originate from the $ref'd definition (e.g. minLength on
-        // the referenced string schema). Skip TypeCheck (added above with the effective type)
-        // and RequiredPropertyValidator (already on targetProperty from buildProperty).
+        // Transfer any validators from the $ref'd definition that were not covered by the
+        // type-specific modifier passes above (e.g. enum, const, or filter validators on
+        // the referenced definition). TypeCheck validators are skipped (one is already added
+        // above with the effective type); RequiredPropertyValidator is also skipped (added
+        // by buildProperty). Type-specific validators transferred here may duplicate those
+        // added by the ref modifier pass, but the duplicates are harmless: the ones with
+        // wrong type-check functions (e.g. is_float on a narrowed int property) silently
+        // skip at runtime because the type-guard condition never matches.
         // Decorators are intentionally NOT transferred: type-conversion decorators on the
         // ref property (e.g. IntToFloatCastDecorator on a number $ref) target the produced
         // type, not the narrowed effective type. Transferring them would corrupt the value

--- a/src/PropertyProcessor/PropertyFactory.php
+++ b/src/PropertyProcessor/PropertyFactory.php
@@ -11,10 +11,9 @@ use PHPModelGenerator\Attributes\ReadOnlyProperty;
 use PHPModelGenerator\Attributes\Required;
 use PHPModelGenerator\Attributes\SchemaName;
 use PHPModelGenerator\Attributes\WriteOnlyProperty;
-use PHPModelGenerator\Draft\Draft;
-use PHPModelGenerator\Draft\DraftFactoryInterface;
 use PHPModelGenerator\Draft\Modifier\ObjectType\ObjectModifier;
-use PHPModelGenerator\Draft\Producer\RefResolver;
+use PHPModelGenerator\Draft\Producer\ExclusiveProducer;
+use PHPModelGenerator\Draft\Producer\PropertyProducerInterface;
 use PHPModelGenerator\Model\Validator\Factory\AbstractValidatorFactory;
 use PHPModelGenerator\Draft\Modifier\TypeCheckModifier;
 use PHPModelGenerator\Exception\SchemaException;
@@ -40,9 +39,6 @@ use PHPModelGenerator\Utils\TypeConverter;
  */
 class PropertyFactory
 {
-    /** @var Draft[] Keyed by draft class name */
-    private array $draftCache = [];
-
     /**
      * Create a property, applying all applicable Draft modifiers.
      *
@@ -55,10 +51,20 @@ class PropertyFactory
         JsonSchema $propertySchema,
         bool $required = false,
     ): PropertyInterface {
-        $json = $propertySchema->getJson();
+        $json      = $propertySchema->getJson();
+        $producers = $schemaProcessor->getGeneratorConfiguration()
+            ->getBuiltDraft($propertySchema)
+            ->getProducersForSchema($json);
 
-        if (isset($json['$ref'])) {
-            return (new RefResolver())->produce($schemaProcessor, $schema, $propertyName, $propertySchema, $required);
+        if ($producers) {
+            return $this->produceProperty(
+                $schemaProcessor,
+                $schema,
+                $propertyName,
+                $propertySchema,
+                $required,
+                $producers,
+            );
         }
 
         $resolvedType = $json['type'] ?? 'any';
@@ -94,6 +100,73 @@ class PropertyFactory
                 $required,
             ),
         };
+    }
+
+    /**
+     * Resolve every producer keyword present on the schema (today only $ref) and combine their
+     * output.
+     *
+     * An exclusive producer (Draft-07's $ref) suppresses every other keyword on this schema node
+     * -- both sibling modifiers and any other present producer -- so only its own output is used
+     * and no other producer is even invoked.
+     *
+     * Otherwise, producers are independent: each resolves on its own with no incoming
+     * property. Today only one producer is ever registered per keyword, so $produced always has
+     * exactly one element and no combination is needed; a second co-occurring producer (e.g. a
+     * future $dynamicRef) will need to merge its output here via the allOf path.
+     *
+     * Sibling keywords are not applied here: the produced property may be shared across multiple
+     * reference sites (SchemaDefinition caches by path/required/dependencies and hands out a
+     * PropertyProxy onto the same underlying property for every site after the first), so adding
+     * site-specific sibling validators directly to it would leak them into unrelated sites. Safe
+     * sibling application needs a non-mutating merge and is wired in alongside that merge.
+     *
+     * @param array<string, PropertyProducerInterface> $producers Keyed by keyword
+     *
+     * @throws SchemaException
+     */
+    private function produceProperty(
+        SchemaProcessor $schemaProcessor,
+        Schema $schema,
+        string $propertyName,
+        JsonSchema $propertySchema,
+        bool $required,
+        array $producers,
+    ): PropertyInterface {
+        $exclusiveKeywords = array_keys(array_filter(
+            $producers,
+            static fn(PropertyProducerInterface $producer): bool => $producer instanceof ExclusiveProducer,
+        ));
+
+        if (count($exclusiveKeywords) > 1) {
+            throw new SchemaException(
+                sprintf(
+                    "Mutually exclusive keywords '%s' cannot be combined on property '%s' in file '%s'",
+                    implode("', '", $exclusiveKeywords),
+                    $propertyName,
+                    $propertySchema->getFile(),
+                ),
+            );
+        }
+
+        if ($exclusiveKeywords) {
+            $exclusiveProducer = $producers[$exclusiveKeywords[0]];
+
+            return $exclusiveProducer->produce($schemaProcessor, $schema, $propertyName, $propertySchema, $required);
+        }
+
+        $produced = array_map(
+            static fn(PropertyProducerInterface $producer): PropertyInterface => $producer->produce(
+                $schemaProcessor,
+                $schema,
+                $propertyName,
+                $propertySchema,
+                $required,
+            ),
+            $producers,
+        );
+
+        return array_values($produced)[0];
     }
 
     /**
@@ -495,7 +568,7 @@ class PropertyFactory
         bool $typeOnly = false,
     ): void {
         $type       = $propertySchema->getJson()['type'] ?? 'any';
-        $builtDraft = $this->resolveBuiltDraft($schemaProcessor, $propertySchema);
+        $builtDraft = $schemaProcessor->getGeneratorConfiguration()->getBuiltDraft($propertySchema);
 
         // For untyped properties ('any'), only run the 'any' entry — getCoveredTypes('any')
         // returns all types, which would incorrectly apply type-specific modifiers.
@@ -550,16 +623,5 @@ class PropertyFactory
                 $schema->getJsonSchema()->getFile(),
             )
         );
-    }
-
-    private function resolveBuiltDraft(SchemaProcessor $schemaProcessor, JsonSchema $propertySchema): Draft
-    {
-        $configDraft = $schemaProcessor->getGeneratorConfiguration()->getDraft();
-
-        $draft = $configDraft instanceof DraftFactoryInterface
-            ? $configDraft->getDraftForSchema($propertySchema)
-            : $configDraft;
-
-        return $this->draftCache[$draft::class] ??= $draft->getDefinition()->build();
     }
 }

--- a/src/PropertyProcessor/PropertyFactory.php
+++ b/src/PropertyProcessor/PropertyFactory.php
@@ -31,6 +31,7 @@ use PHPModelGenerator\PropertyProcessor\Decorator\Property\PropertyTransferDecor
 use PHPModelGenerator\PropertyProcessor\Decorator\SchemaNamespaceTransferDecorator;
 use PHPModelGenerator\PropertyProcessor\Decorator\TypeHint\TypeHintDecorator;
 use PHPModelGenerator\SchemaProcessor\SchemaProcessor;
+use PHPModelGenerator\Utils\PropertyMerger;
 use PHPModelGenerator\Utils\TypeConverter;
 use PHPModelGenerator\Utils\TypeIntersection;
 
@@ -320,12 +321,20 @@ class PropertyFactory
             if ($refProperty->getNestedSchema() !== null) {
                 if ($mergedSchema !== null) {
                     // Object×object merge path (path 1): transfer ref properties into the
-                    // pre-created merged Schema with allOf semantics for collisions.
+                    // pre-created merged Schema with allOf semantics for collisions. Pass the ref
+                    // property's own JsonSchema as the constraint-reapplication source (see
+                    // PropertyMerger::merge()) so a colliding property that narrows type doesn't
+                    // silently lose the ref's type-specific constraints (minimum, maximum, …).
                     foreach ($refProperty->getNestedSchema()->getProperties() as $refProp) {
                         $compositionProcessor = $mergedSchema->getProperty($refProp->getName()) !== null
                             ? AllOfValidatorFactory::class
                             : null;
-                        $mergedSchema->addProperty($refProp, $compositionProcessor);
+                        $mergedSchema->addProperty(
+                            $refProp,
+                            $compositionProcessor,
+                            $refProp->getJsonSchema(),
+                            $schemaProcessor,
+                        );
                     }
 
                     // Ensure the merged Schema's class can resolve all types used by the
@@ -379,13 +388,23 @@ class PropertyFactory
      * determined by the producer ($ref).
      *
      * Steps:
-     * 1. Resolve the effective PHP type as the intersection of the produced type and any
-     *    explicit sibling 'type' keyword. An empty intersection is a schema error.
-     * 2. Set that type on the target property.
-     * 3. Apply type-specific sibling modifiers (minLength, minimum, pattern, …).
-     * 4. Apply 'any' sibling modifiers (default, enum, const).
-     * 5. Transfer non-TypeCheck, non-Required validators from the ref property so that
-     *    constraints from the $ref definition are preserved.
+     * 1. Populate $targetProperty (built as a blank placeholder by the caller — see
+     *    mergeProducedPropertyWithSiblings) with the sibling's own declared type, if it declares
+     *    a single concrete one, and 'any' sibling modifiers (default, enum, const). PropertyMerger
+     *    below merges two fully-built sides; without this step $targetProperty would still be the
+     *    blank placeholder, and the merge would have nothing of the sibling's own to merge the
+     *    ref's contribution into — including no default of its own to compare the ref's against,
+     *    which would silently defeat PropertyMerger's default-conflict detection in step 3.
+     * 2. Pre-validate the sibling's declared type (if any) against the ref's produced type,
+     *    for a SchemaException naming both sides' declared JSON Schema type names.
+     * 3. Delegate the actual type-intersection, type-specific-validator rebuild, and
+     *    default-conflict reconciliation to PropertyMerger — the same mechanism the base-level
+     *    and object×object property-level $ref+sibling merge paths use, so a colliding type or
+     *    default doesn't silently drop the ref's constraints in this path specifically.
+     * 4. Re-apply the sibling's own type-specific modifiers (minLength, pattern, …) against the
+     *    merged effective type, so a sibling that never declared "type" itself still gets them.
+     * 5. Transfer non-TypeCheck validators from the ref property that PropertyMerger didn't
+     *    already cover (e.g. enum, const, or filter validators on the referenced definition).
      *
      * @throws SchemaException
      */
@@ -407,118 +426,106 @@ class PropertyFactory
             return;
         }
 
-        $producedPhpTypeNames  = $producedType->getNames();
-        $effectivePhpTypeNames = $this->resolveEffectiveSiblingType(
-            $producedPhpTypeNames,
-            $siblingSchema,
-            $propertyName,
-        );
+        $siblingJson = $siblingSchema->getJson();
+        $siblingType = $siblingJson['type'] ?? null;
 
-        // A concrete (non-array) sibling type that does not include null narrows away the
-        // ref's nullability — the intersection of "string|null" and "string" is "string".
-        // When no sibling type is present or the sibling type is an array, the ref's
-        // nullable is preserved unchanged.
-        $siblingJson      = $siblingSchema->getJson();
-        $effectiveNullable = $producedType->isNullable();
-
-        if (isset($siblingJson['type']) && !is_array($siblingJson['type']) && $siblingJson['type'] !== 'null') {
-            $effectiveNullable = false;
+        if (is_string($siblingType)) {
+            // Sibling declares a concrete type: assign it directly (mirrors
+            // createTypedProperty()). PropertyMerger below then narrows it to the intersection
+            // with the ref's type.
+            $siblingPhpType = new PropertyType(TypeConverter::jsonSchemaToPHP($siblingType));
+            $targetProperty->setType($siblingPhpType, $siblingPhpType);
+        } else {
+            // No sibling type (or a multi-type sibling — not resolvable to one concrete PHP type
+            // here, and the ref's own type is used as-is in that case too, same as this path
+            // always did). There is nothing of the sibling's own to narrow against, so start
+            // from the ref's own type instead of leaving $targetProperty genuinely untyped:
+            // PropertyMerger's existing-has-no-type handling treats a genuinely-untyped existing
+            // as intentionally unbounded ("any") and deliberately leaves it untouched, which is
+            // wrong here — $targetProperty is a blank placeholder, not a schema that actually
+            // declares no type constraint.
+            $targetProperty->setType($producedType, $producedType);
         }
 
-        $targetProperty->setType(
-            new PropertyType($effectivePhpTypeNames, $effectiveNullable),
-            new PropertyType($effectivePhpTypeNames, $effectiveNullable),
-        );
+        // Apply any-type sibling keywords (default, enum, const) before merging: PropertyMerger's
+        // default-conflict reconciliation compares $existing's (this property's) own default
+        // against the ref's, so $existing needs its default set from the sibling's JSON first —
+        // applying it after the merge instead would silently overwrite whatever the merge
+        // resolved rather than ever being compared against it.
+        $this->applyModifiers($schemaProcessor, $schema, $targetProperty, $siblingSchema, anyOnly: true);
 
-        if (count($effectivePhpTypeNames) === 1) {
-            $effectiveTypeJsonSchemaName = TypeConverter::phpToJsonSchema($effectivePhpTypeNames[0]);
+        $this->assertSiblingTypeCompatibleWithRef($producedType->getNames(), $siblingSchema, $propertyName);
 
-            // Apply type-specific validators from the ref's definition with the effective
-            // (narrowed) type substituted. This re-derives range validators (minimum, maximum,
-            // etc.) using the correct PHP type-check function for the effective type (e.g.,
-            // is_int instead of is_float when narrowing from number to integer). TypeCheck
-            // deduplication in TypeCheckModifier ensures only one TypeCheck is added.
-            $refJsonWithEffectiveType = array_merge(
-                $refProperty->getJsonSchema()->getJson(),
-                ['type' => $effectiveTypeJsonSchemaName],
-            );
-            $this->applyModifiers(
-                $schemaProcessor,
-                $schema,
-                $targetProperty,
-                $siblingSchema->withJson($refJsonWithEffectiveType),
-                anyOnly: false,
-                typeOnly: true,
-            );
-
-            // Apply type-specific validators from the sibling schema. TypeCheck is already
-            // present (dedup no-op); sibling constraints like minLength, pattern, and
-            // additional range bounds are added here.
-            $siblingWithType = array_merge(
-                $siblingJson,
-                ['type' => $effectiveTypeJsonSchemaName],
-            );
-            $this->applyModifiers(
-                $schemaProcessor,
-                $schema,
-                $targetProperty,
-                $siblingSchema->withJson($siblingWithType),
-                anyOnly: false,
-                typeOnly: true,
-            );
-        }
-
-        // Apply any-type sibling keywords (default, enum, const) that were not yet applied
-        // during the type-specific modifier pass above.
-        $this->applyModifiers(
+        (new PropertyMerger($schemaProcessor->getGeneratorConfiguration()))->merge(
+            $targetProperty,
+            $refProperty,
+            true,
+            false,
+            $refProperty->getJsonSchema(),
             $schemaProcessor,
             $schema,
-            $targetProperty,
-            $siblingSchema,
-            anyOnly: true,
         );
 
-        // Transfer any validators from the $ref'd definition that were not covered by the
-        // type-specific modifier passes above (e.g. enum, const, or filter validators on
-        // the referenced definition). TypeCheck validators are skipped (one is already added
-        // above with the effective type). Type-specific validators transferred here may duplicate those
-        // added by the ref modifier pass, but the duplicates are harmless: the ones with
-        // wrong type-check functions (e.g. is_float on a narrowed int property) silently
-        // skip at runtime because the type-guard condition never matches.
-        // Decorators are intentionally NOT transferred: type-conversion decorators on the
-        // ref property (e.g. IntToFloatCastDecorator on a number $ref) target the produced
-        // type, not the narrowed effective type. Transferring them would corrupt the value
-        // before the effective-type TypeCheck can inspect it.
+        // Re-apply the sibling's own type-specific constraints (minLength, pattern, additional
+        // range bounds, …) against the merged effective type. Needed even for a sibling that
+        // never declared "type" itself (only, say, "minLength"): applyModifiers() dispatches by
+        // the JSON's own "type" keyword, so without this override a type-less sibling's range
+        // keywords are never interpreted as belonging to any type and silently do nothing -
+        // mirrors PropertyMerger's own reapply step, which does the equivalent for the ref side.
+        $effectiveType = $targetProperty->getType(true);
+
+        if ($effectiveType !== null && count($effectiveType->getNames()) === 1) {
+            $effectiveTypeJsonSchemaName = TypeConverter::phpToJsonSchema($effectiveType->getNames()[0]);
+            $this->applyModifiers(
+                $schemaProcessor,
+                $schema,
+                $targetProperty,
+                $siblingSchema->withJson(array_merge($siblingJson, ['type' => $effectiveTypeJsonSchemaName])),
+                typeOnly: true,
+            );
+        }
+
+        // Transfer any validators from the $ref'd definition that PropertyMerger's constraint
+        // reapplication didn't already cover (e.g. enum, const, or filter validators on the
+        // referenced definition). TypeCheck validators are skipped (PropertyMerger already added
+        // one with the effective type). Type-specific validators transferred here may duplicate
+        // those PropertyMerger added, but the duplicates are harmless: the ones with wrong
+        // type-check functions (e.g. is_float on a narrowed int property) silently skip at
+        // runtime because the type-guard condition never matches.
+        // Decorators are intentionally NOT transferred: type-conversion decorators on the ref
+        // property (e.g. IntToFloatCastDecorator on a number $ref) target the produced type, not
+        // the narrowed effective type. Transferring them would corrupt the value before the
+        // effective-type TypeCheck can inspect it.
         $this->transferProducedValidators($targetProperty, $refProperty, skipTypeCheck: true);
     }
 
     /**
-     * Resolve the effective PHP type set for a property-level sibling merge.
+     * Pre-validate a property-level sibling merge's declared type against the ref's produced
+     * type, before PropertyMerger performs the actual (equivalent) intersection check. This
+     * exists only to name both sides' declared JSON Schema type names in the exception message —
+     * PropertyMerger's own conflict message is generic and has no access to the sibling's raw
+     * JSON Schema type keyword.
      *
-     * If the sibling specifies no 'type' keyword, the produced type is used as-is.
-     * If the sibling specifies a 'type', its PHP equivalent is intersected with the produced
-     * type set (JSON Schema: integer is a subtype of number). An empty intersection means the
-     * sibling type and the $ref type are incompatible; SchemaException is thrown.
+     * If the sibling specifies no 'type' keyword, or specifies an array of types, there is
+     * nothing to pre-validate — PropertyMerger's own (name-set) intersection check covers it.
      *
      * @param string[] $producedPhpTypeNames
-     * @return string[]
      *
      * @throws SchemaException
      */
-    private function resolveEffectiveSiblingType(
+    private function assertSiblingTypeCompatibleWithRef(
         array $producedPhpTypeNames,
         JsonSchema $siblingSchema,
         string $propertyName,
-    ): array {
+    ): void {
         $siblingJson = $siblingSchema->getJson();
         if (!isset($siblingJson['type']) || is_array($siblingJson['type'])) {
-            return $producedPhpTypeNames;
+            return;
         }
 
         $siblingPhpTypeName = TypeConverter::jsonSchemaToPHP($siblingJson['type']);
-        $intersection       = TypeIntersection::compute([$siblingPhpTypeName], $producedPhpTypeNames);
 
-        if (empty($intersection)) {
+        if (empty(TypeIntersection::compute([$siblingPhpTypeName], $producedPhpTypeNames))) {
             throw new SchemaException(sprintf(
                 "Property '%s' in file '%s': \$ref resolves to type '%s' but sibling 'type' "
                     . "declares '%s'; the types are incompatible",
@@ -528,8 +535,6 @@ class PropertyFactory
                 $siblingJson['type'],
             ));
         }
-
-        return $intersection;
     }
 
     /**

--- a/src/PropertyProcessor/PropertyFactory.php
+++ b/src/PropertyProcessor/PropertyFactory.php
@@ -14,8 +14,6 @@ use PHPModelGenerator\Attributes\WriteOnlyProperty;
 use PHPModelGenerator\Draft\Modifier\ObjectType\ObjectModifier;
 use PHPModelGenerator\Draft\Producer\ExclusiveProducer;
 use PHPModelGenerator\Draft\Producer\PropertyProducerInterface;
-use PHPModelGenerator\Model\Validator\Factory\AbstractValidatorFactory;
-use PHPModelGenerator\Draft\Modifier\TypeCheckModifier;
 use PHPModelGenerator\Exception\SchemaException;
 use PHPModelGenerator\Model\Attributes\PhpAttribute;
 use PHPModelGenerator\Model\Property\BaseProperty;
@@ -24,6 +22,8 @@ use PHPModelGenerator\Model\Property\PropertyInterface;
 use PHPModelGenerator\Model\Property\PropertyType;
 use PHPModelGenerator\Model\Schema;
 use PHPModelGenerator\Model\SchemaDefinition\JsonSchema;
+use PHPModelGenerator\Model\Validator\Factory\AbstractValidatorFactory;
+use PHPModelGenerator\Draft\Modifier\TypeCheckModifier;
 use PHPModelGenerator\Model\Validator\MultiTypeCheckValidator;
 use PHPModelGenerator\Model\Validator\RequiredPropertyValidator;
 use PHPModelGenerator\Model\Validator\TypeCheckInterface;
@@ -31,6 +31,7 @@ use PHPModelGenerator\PropertyProcessor\Decorator\Property\PropertyTransferDecor
 use PHPModelGenerator\PropertyProcessor\Decorator\TypeHint\TypeHintDecorator;
 use PHPModelGenerator\SchemaProcessor\SchemaProcessor;
 use PHPModelGenerator\Utils\TypeConverter;
+use PHPModelGenerator\Utils\TypeIntersection;
 
 /**
  * Class PropertyFactory
@@ -155,14 +156,17 @@ class PropertyFactory
             return $exclusiveProducer->produce($schemaProcessor, $schema, $propertyName, $propertySchema, $required);
         }
 
-        // For non-exclusive producers at base level, process sibling content first so that
-        // sibling properties are root-registered before the producer contributes its properties.
-        // Producer properties that collide with already-registered sibling names are then merged
-        // with allOf semantics (type intersection, default-conflict detection) by the producer.
-        // Producer keywords themselves are excluded so only true sibling keywords remain.
-        $json = $propertySchema->getJson();
+        // For non-exclusive producers, strip producer keywords so only sibling keywords remain.
+        $json        = $propertySchema->getJson();
+        $siblingJson = array_diff_key($json, $producers);
+
         if (isset($json['type']) && $json['type'] === 'base') {
-            $siblingJson = array_diff_key($json, $producers);
+            // Base level: process sibling content first so that sibling properties are
+            // root-registered before the producer contributes its properties. Producer
+            // properties that collide with already-registered sibling names are then merged
+            // with allOf semantics (type intersection, default-conflict detection) by the
+            // producer. The base-level marker 'type':'base' counts as one entry, so we only
+            // create a base property when additional sibling keywords are present (count > 1).
             if (count($siblingJson) > 1) {
                 $this->createBaseProperty(
                     $schemaProcessor,
@@ -171,6 +175,19 @@ class PropertyFactory
                     $propertySchema->withJson($siblingJson),
                 );
             }
+        } elseif (!empty($siblingJson)) {
+            // Property level: there are sibling keywords alongside the producer (e.g. $ref).
+            // Draft 2019-09+ applies all siblings simultaneously with the $ref; earlier drafts
+            // suppress them via ExclusiveProducer, so this branch is only reached for 2019-09+.
+            return $this->mergeProducedPropertyWithSiblings(
+                $schemaProcessor,
+                $schema,
+                $propertyName,
+                $propertySchema,
+                $required,
+                $producers,
+                $siblingJson,
+            );
         }
 
         $produced = array_map(
@@ -185,6 +202,252 @@ class PropertyFactory
         );
 
         return array_values($produced)[0];
+    }
+
+    /**
+     * Produce the property from the producer keyword ($ref), then asynchronously merge it
+     * with any sibling keywords present on the same schema node.
+     *
+     * Builds an untyped placeholder property to return immediately (required for recursive
+     * $ref support, where the backing property is not yet available when produce() returns).
+     * The actual type and validators are wired in the onResolve callback once the ref
+     * property has resolved.
+     *
+     * Object×object merge — when the ref property resolves to an object schema AND either
+     * (a) siblings include structural object keywords like 'properties', or (b) a second
+     * producer keyword is present and also resolves to an object — requires processSchema()
+     * to be called for the merged object. However, processSchema() mutates
+     * SchemaProcessor::currentClassPath as a side effect. Calling it inside an onResolve
+     * callback (which fires mid-resolveReference) would corrupt the class-path context for
+     * subsequent properties in the parent schema. This case is therefore not yet supported
+     * and falls back to wiring the ref property's nested schema onto the target property
+     * while ignoring sibling structural keywords. A future change adding save/restore of
+     * class context to SchemaProcessor will unblock this.
+     *
+     * @param array<string, PropertyProducerInterface> $producers
+     *
+     * @throws SchemaException
+     */
+    private function mergeProducedPropertyWithSiblings(
+        SchemaProcessor $schemaProcessor,
+        Schema $schema,
+        string $propertyName,
+        JsonSchema $propertySchema,
+        bool $required,
+        array $producers,
+        array $siblingJson,
+    ): PropertyInterface {
+        $siblingSchema  = $propertySchema->withJson($siblingJson);
+        $targetProperty = $this->buildProperty(
+            $schemaProcessor,
+            $propertyName,
+            null,
+            $siblingSchema,
+            $required,
+        );
+
+        $refProperty = array_values($producers)[0]->produce(
+            $schemaProcessor,
+            $schema,
+            $propertyName,
+            $propertySchema,
+            $required,
+        );
+
+        $refProperty->onResolve(function () use (
+            $targetProperty,
+            $refProperty,
+            $siblingSchema,
+            $schemaProcessor,
+            $schema,
+            $propertyName,
+        ): void {
+            if ($refProperty->getNestedSchema() !== null) {
+                // Object×object: not yet supported — fall back to the ref property as-is.
+                // Sibling structural keywords (properties, required, etc.) are ignored for
+                // this case. See method docblock for the underlying constraint.
+                $targetProperty->setNestedSchema($refProperty->getNestedSchema());
+                $this->wireObjectProperty($schemaProcessor, $schema, $targetProperty, $siblingSchema);
+                $this->applyModifiers($schemaProcessor, $schema, $targetProperty, $siblingSchema, anyOnly: true);
+
+                return;
+            }
+
+            $this->applyScalarSiblingMerge(
+                $targetProperty,
+                $refProperty,
+                $siblingSchema,
+                $schemaProcessor,
+                $schema,
+                $propertyName,
+            );
+        });
+
+        return $targetProperty;
+    }
+
+    /**
+     * Merge sibling keywords onto a freshly built scalar/array property whose type was
+     * determined by the producer ($ref).
+     *
+     * Steps:
+     * 1. Resolve the effective PHP type as the intersection of the produced type and any
+     *    explicit sibling 'type' keyword. An empty intersection is a schema error.
+     * 2. Set that type on the target property.
+     * 3. Apply type-specific sibling modifiers (minLength, minimum, pattern, …).
+     * 4. Apply 'any' sibling modifiers (default, enum, const).
+     * 5. Transfer non-TypeCheck, non-Required validators from the ref property so that
+     *    constraints from the $ref definition are preserved.
+     *
+     * @throws SchemaException
+     */
+    private function applyScalarSiblingMerge(
+        PropertyInterface $targetProperty,
+        PropertyInterface $refProperty,
+        JsonSchema $siblingSchema,
+        SchemaProcessor $schemaProcessor,
+        Schema $schema,
+        string $propertyName,
+    ): void {
+        $producedType = $refProperty->getType(true);
+
+        if ($producedType === null) {
+            // Truly untyped ref property: transfer validators directly; skip type-conversion
+            // decorators for the same reason as the typed path.
+            $this->transferProducedValidators($targetProperty, $refProperty, skipTypeCheck: false);
+
+            return;
+        }
+
+        $producedPhpTypeNames  = $producedType->getNames();
+        $effectivePhpTypeNames = $this->resolveEffectiveSiblingType(
+            $producedPhpTypeNames,
+            $siblingSchema,
+            $propertyName,
+        );
+
+        $targetProperty->setType(
+            new PropertyType($effectivePhpTypeNames, $producedType->isNullable()),
+            new PropertyType($effectivePhpTypeNames, $producedType->isNullable()),
+        );
+
+        $siblingJson = $siblingSchema->getJson();
+        if (count($effectivePhpTypeNames) === 1) {
+            // Single effective type: apply type-specific sibling modifiers (adds TypeCheck +
+            // type-keyed validators like minLength, pattern, minimum, etc.). These run on the
+            // sibling schema; the TypeCheck added here is the one that validates the final
+            // effective type, not the ref property's potentially broader type.
+            $siblingWithType = array_merge(
+                $siblingJson,
+                ['type' => TypeConverter::phpToJsonSchema($effectivePhpTypeNames[0])],
+            );
+            $this->applyModifiers(
+                $schemaProcessor,
+                $schema,
+                $targetProperty,
+                $siblingSchema->withJson($siblingWithType),
+                anyOnly: false,
+                typeOnly: true,
+            );
+        }
+
+        // Apply any-type sibling keywords (default, enum, const) that were not yet applied
+        // during the type-specific modifier pass above.
+        $this->applyModifiers(
+            $schemaProcessor,
+            $schema,
+            $targetProperty,
+            $siblingSchema,
+            anyOnly: true,
+        );
+
+        // Transfer constraints that originate from the $ref'd definition (e.g. minLength on
+        // the referenced string schema). Skip TypeCheck (added above with the effective type)
+        // and RequiredPropertyValidator (already on targetProperty from buildProperty).
+        // Decorators are intentionally NOT transferred: type-conversion decorators on the
+        // ref property (e.g. IntToFloatCastDecorator on a number $ref) target the produced
+        // type, not the narrowed effective type. Transferring them would corrupt the value
+        // before the effective-type TypeCheck can inspect it.
+        $this->transferProducedValidators($targetProperty, $refProperty, skipTypeCheck: true);
+    }
+
+    /**
+     * Resolve the effective PHP type set for a property-level sibling merge.
+     *
+     * If the sibling specifies no 'type' keyword, the produced type is used as-is.
+     * If the sibling specifies a 'type', its PHP equivalent is intersected with the produced
+     * type set (JSON Schema: integer is a subtype of number). An empty intersection means the
+     * sibling type and the $ref type are incompatible; SchemaException is thrown.
+     *
+     * @param string[] $producedPhpTypeNames
+     * @return string[]
+     *
+     * @throws SchemaException
+     */
+    private function resolveEffectiveSiblingType(
+        array $producedPhpTypeNames,
+        JsonSchema $siblingSchema,
+        string $propertyName,
+    ): array {
+        $siblingJson = $siblingSchema->getJson();
+        if (!isset($siblingJson['type']) || is_array($siblingJson['type'])) {
+            return $producedPhpTypeNames;
+        }
+
+        $siblingPhpTypeName = TypeConverter::jsonSchemaToPHP($siblingJson['type']);
+        $intersection       = TypeIntersection::compute([$siblingPhpTypeName], $producedPhpTypeNames);
+
+        if (empty($intersection)) {
+            throw new SchemaException(sprintf(
+                "Property '%s' in file '%s': \$ref resolves to type '%s' but sibling 'type' "
+                    . "declares '%s'; the types are incompatible",
+                $propertyName,
+                $siblingSchema->getFile(),
+                implode(' | ', $producedPhpTypeNames),
+                $siblingJson['type'],
+            ));
+        }
+
+        return $intersection;
+    }
+
+    /**
+     * Transfer validators (but NOT decorators) from a $ref property to a target property.
+     *
+     * When $skipTypeCheck is true, TypeCheckInterface validators are excluded (they were
+     * already added to the target property with the resolved effective type). When false,
+     * all validators including TypeCheck are transferred (used for truly-untyped ref
+     * properties where no separate type resolution step ran).
+     *
+     * RequiredPropertyValidator is always excluded: it is added to the target property by
+     * buildProperty() and must not be duplicated.
+     *
+     * Decorators are deliberately excluded here: type-conversion decorators on the ref
+     * property (e.g. IntToFloatCastDecorator on a number $ref) target the produced type and
+     * must not be applied after the type has been narrowed to a different effective type.
+     */
+    private function transferProducedValidators(
+        PropertyInterface $targetProperty,
+        PropertyInterface $refProperty,
+        bool $skipTypeCheck,
+    ): void {
+        foreach ($refProperty->getValidators() as $validatorWrapper) {
+            $validator = $validatorWrapper->getValidator();
+
+            if ($validator instanceof RequiredPropertyValidator) {
+                continue;
+            }
+
+            if ($skipTypeCheck && $validator instanceof TypeCheckInterface) {
+                continue;
+            }
+
+            $targetProperty->addValidator(
+                $validator,
+                $validatorWrapper->getPriority(),
+                $validatorWrapper->getSourceKey(),
+            );
+        }
     }
 
     /**

--- a/src/PropertyProcessor/PropertyFactory.php
+++ b/src/PropertyProcessor/PropertyFactory.php
@@ -11,10 +11,10 @@ use PHPModelGenerator\Attributes\ReadOnlyProperty;
 use PHPModelGenerator\Attributes\Required;
 use PHPModelGenerator\Attributes\SchemaName;
 use PHPModelGenerator\Attributes\WriteOnlyProperty;
-use Exception;
 use PHPModelGenerator\Draft\Draft;
 use PHPModelGenerator\Draft\DraftFactoryInterface;
 use PHPModelGenerator\Draft\Modifier\ObjectType\ObjectModifier;
+use PHPModelGenerator\Draft\Producer\RefResolver;
 use PHPModelGenerator\Model\Validator\Factory\AbstractValidatorFactory;
 use PHPModelGenerator\Draft\Modifier\TypeCheckModifier;
 use PHPModelGenerator\Exception\SchemaException;
@@ -29,7 +29,6 @@ use PHPModelGenerator\Model\Validator\MultiTypeCheckValidator;
 use PHPModelGenerator\Model\Validator\RequiredPropertyValidator;
 use PHPModelGenerator\Model\Validator\TypeCheckInterface;
 use PHPModelGenerator\PropertyProcessor\Decorator\Property\PropertyTransferDecorator;
-use PHPModelGenerator\PropertyProcessor\Decorator\SchemaNamespaceTransferDecorator;
 use PHPModelGenerator\PropertyProcessor\Decorator\TypeHint\TypeHintDecorator;
 use PHPModelGenerator\SchemaProcessor\SchemaProcessor;
 use PHPModelGenerator\Utils\TypeConverter;
@@ -58,21 +57,8 @@ class PropertyFactory
     ): PropertyInterface {
         $json = $propertySchema->getJson();
 
-        // $ref: replace the property entirely via the definition dictionary.
-        // This is a schema-identity primitive — it cannot be a Draft modifier because
-        // ModifierInterface::modify returns void and cannot replace the property object.
         if (isset($json['$ref'])) {
-            if (isset($json['type']) && $json['type'] === 'base') {
-                return $this->processBaseReference(
-                    $schemaProcessor,
-                    $schema,
-                    $propertyName,
-                    $propertySchema,
-                    $required,
-                );
-            }
-
-            return $this->processReference($schemaProcessor, $schema, $propertyName, $propertySchema, $required);
+            return (new RefResolver())->produce($schemaProcessor, $schema, $propertyName, $propertySchema, $required);
         }
 
         $resolvedType = $json['type'] ?? 'any';
@@ -295,109 +281,6 @@ class PropertyFactory
 
         if (isset($json['deprecated']) && $json['deprecated'] === true) {
             $property->addAttribute(new PhpAttribute(Deprecated::class), $configuration, PhpAttribute::DEPRECATED);
-        }
-
-        return $property;
-    }
-
-    /**
-     * Resolve a $ref reference by looking it up in the definition dictionary.
-     *
-     * @throws SchemaException
-     */
-    private function processReference(
-        SchemaProcessor $schemaProcessor,
-        Schema $schema,
-        string $propertyName,
-        JsonSchema $propertySchema,
-        bool $required,
-    ): PropertyInterface {
-        $path       = [];
-        $reference  = $propertySchema->getJson()['$ref'];
-        $dictionary = $schema->getSchemaDictionary();
-
-        try {
-            $definition = $dictionary->getDefinition($reference, $schemaProcessor, $path);
-
-            if ($definition) {
-                $definitionSchema = $definition->getSchema();
-
-                if (
-                    $schema->getClassPath() !== $definitionSchema->getClassPath() ||
-                    $schema->getClassName() !== $definitionSchema->getClassName() ||
-                    (
-                        $schema->getClassName() === 'ExternalSchema' &&
-                        $definitionSchema->getClassName() === 'ExternalSchema'
-                    )
-                ) {
-                    $schema->addNamespaceTransferDecorator(
-                        new SchemaNamespaceTransferDecorator($definitionSchema),
-                    );
-
-                    if ($definitionSchema->getClassName() !== 'ExternalSchema') {
-                        $schema->addUsedClass(join('\\', array_filter([
-                            $schemaProcessor->getGeneratorConfiguration()->getNamespacePrefix(),
-                            $definitionSchema->getClassPath(),
-                            $definitionSchema->getClassName(),
-                        ])));
-                    }
-                }
-
-                $property = $definition->resolveReference(
-                    $propertyName,
-                    implode('/', $path),
-                    $required,
-                    $propertySchema->getJson()['_dependencies'] ?? null,
-                );
-
-                // Use the reference site's pointer (where $ref appears in the schema) rather
-                // than the definition's pointer. This is always meaningful and consistent with
-                // how inline properties work — both show WHERE IN THE SCHEMA the property is
-                // defined, not where the resolved type lives.
-                $property->overrideJsonPointer(new PhpAttribute(JsonPointer::class, [$propertySchema->getPointer()]));
-
-                return $property;
-            }
-        } catch (Exception $exception) {
-            throw new SchemaException(
-                "Unresolved Reference $reference in file {$propertySchema->getFile()}",
-                0,
-                $exception,
-            );
-        }
-
-        throw new SchemaException("Unresolved Reference $reference in file {$propertySchema->getFile()}");
-    }
-
-    /**
-     * Resolve a $ref on a base-level schema: set up definitions, delegate to processReference,
-     * then copy the referenced schema's properties to the parent schema.
-     *
-     * @throws SchemaException
-     */
-    private function processBaseReference(
-        SchemaProcessor $schemaProcessor,
-        Schema $schema,
-        string $propertyName,
-        JsonSchema $propertySchema,
-        bool $required,
-    ): PropertyInterface {
-        $schema->getSchemaDictionary()->setUpDefinitionDictionary($schemaProcessor, $schema);
-
-        $property = $this->processReference($schemaProcessor, $schema, $propertyName, $propertySchema, $required);
-
-        if (!$property->getNestedSchema()) {
-            throw new SchemaException(
-                sprintf(
-                    'A referenced schema on base level must provide an object definition for property %s in file %s',
-                    $propertyName,
-                    $propertySchema->getFile(),
-                )
-            );
-        }
-
-        foreach ($property->getNestedSchema()->getProperties() as $propertiesOfReferencedObject) {
-            $schema->addProperty($propertiesOfReferencedObject);
         }
 
         return $property;

--- a/src/PropertyProcessor/PropertyFactory.php
+++ b/src/PropertyProcessor/PropertyFactory.php
@@ -63,6 +63,7 @@ class PropertyFactory
                 $propertySchema,
                 $required,
                 $producers,
+                $isArrayItem,
             );
         }
 
@@ -134,6 +135,7 @@ class PropertyFactory
         JsonSchema $propertySchema,
         bool $required,
         array $producers,
+        bool $isArrayItem = false,
     ): PropertyInterface {
         $exclusiveKeywords = array_keys(array_filter(
             $producers,
@@ -154,7 +156,14 @@ class PropertyFactory
         if ($exclusiveKeywords) {
             $exclusiveProducer = $producers[$exclusiveKeywords[0]];
 
-            return $exclusiveProducer->produce($schemaProcessor, $schema, $propertyName, $propertySchema, $required);
+            return $exclusiveProducer->produce(
+                $schemaProcessor,
+                $schema,
+                $propertyName,
+                $propertySchema,
+                $required,
+                $isArrayItem,
+            );
         }
 
         // For non-exclusive producers, strip producer keywords so only sibling keywords remain.
@@ -188,6 +197,7 @@ class PropertyFactory
                 $required,
                 $producers,
                 $siblingJson,
+                $isArrayItem,
             );
         }
 
@@ -198,6 +208,7 @@ class PropertyFactory
                 $propertyName,
                 $propertySchema,
                 $required,
+                $isArrayItem,
             ),
             $producers,
         );
@@ -259,6 +270,7 @@ class PropertyFactory
         bool $required,
         array $producers,
         array $siblingJson,
+        bool $isArrayItem = false,
     ): PropertyInterface {
         $siblingSchema = $propertySchema->withJson($siblingJson);
         $targetProperty = $this->buildProperty(
@@ -267,6 +279,7 @@ class PropertyFactory
             null,
             $siblingSchema,
             $required,
+            $isArrayItem,
         );
 
         // Detect object structural siblings before producing the ref so the merged Schema can
@@ -293,6 +306,7 @@ class PropertyFactory
             $propertyName,
             $propertySchema,
             $required,
+            $isArrayItem,
         );
 
         $refProperty->onResolve(function () use (

--- a/src/PropertyProcessor/PropertyFactory.php
+++ b/src/PropertyProcessor/PropertyFactory.php
@@ -155,6 +155,24 @@ class PropertyFactory
             return $exclusiveProducer->produce($schemaProcessor, $schema, $propertyName, $propertySchema, $required);
         }
 
+        // For non-exclusive producers at base level, process sibling content first so that
+        // sibling properties are root-registered before the producer contributes its properties.
+        // Producer properties that collide with already-registered sibling names are then merged
+        // with allOf semantics (type intersection, default-conflict detection) by the producer.
+        // Producer keywords themselves are excluded so only true sibling keywords remain.
+        $json = $propertySchema->getJson();
+        if (isset($json['type']) && $json['type'] === 'base') {
+            $siblingJson = array_diff_key($json, $producers);
+            if (count($siblingJson) > 1) {
+                $this->createBaseProperty(
+                    $schemaProcessor,
+                    $schema,
+                    $propertyName,
+                    $propertySchema->withJson($siblingJson),
+                );
+            }
+        }
+
         $produced = array_map(
             static fn(PropertyProducerInterface $producer): PropertyInterface => $producer->produce(
                 $schemaProcessor,

--- a/src/PropertyProcessor/PropertyFactory.php
+++ b/src/PropertyProcessor/PropertyFactory.php
@@ -481,8 +481,7 @@ class PropertyFactory
         // Transfer any validators from the $ref'd definition that were not covered by the
         // type-specific modifier passes above (e.g. enum, const, or filter validators on
         // the referenced definition). TypeCheck validators are skipped (one is already added
-        // above with the effective type); RequiredPropertyValidator is also skipped (added
-        // by buildProperty). Type-specific validators transferred here may duplicate those
+        // above with the effective type). Type-specific validators transferred here may duplicate those
         // added by the ref modifier pass, but the duplicates are harmless: the ones with
         // wrong type-check functions (e.g. is_float on a narrowed int property) silently
         // skip at runtime because the type-guard condition never matches.
@@ -541,9 +540,6 @@ class PropertyFactory
      * all validators including TypeCheck are transferred (used for truly-untyped ref
      * properties where no separate type resolution step ran).
      *
-     * RequiredPropertyValidator is always excluded: it is added to the target property by
-     * buildProperty() and must not be duplicated.
-     *
      * Decorators are deliberately excluded here: type-conversion decorators on the ref
      * property (e.g. IntToFloatCastDecorator on a number $ref) target the produced type and
      * must not be applied after the type has been narrowed to a different effective type.
@@ -555,10 +551,6 @@ class PropertyFactory
     ): void {
         foreach ($refProperty->getValidators() as $validatorWrapper) {
             $validator = $validatorWrapper->getValidator();
-
-            if ($validator instanceof RequiredPropertyValidator) {
-                continue;
-            }
 
             if ($skipTypeCheck && $validator instanceof TypeCheckInterface) {
                 continue;

--- a/src/PropertyProcessor/PropertyFactory.php
+++ b/src/PropertyProcessor/PropertyFactory.php
@@ -217,25 +217,6 @@ class PropertyFactory
     }
 
     /**
-     * Keywords that, when present in the sibling JSON alongside a $ref, indicate that the
-     * $ref's resolved type must be an object and the two should be merged into a new nested
-     * class (object×object merge). Non-structural siblings (default, enum, const, …) take
-     * the scalar/array merge path or the object-with-any-only-modifiers fallback instead.
-     */
-    private const OBJECT_STRUCTURAL_KEYWORDS = [
-        'properties',
-        'required',
-        'additionalProperties',
-        'patternProperties',
-        'propertyNames',
-        'minProperties',
-        'maxProperties',
-        'unevaluatedProperties',
-        'dependentSchemas',
-        'dependentRequired',
-    ];
-
-    /**
      * Produce the property from the producer keyword ($ref), then merge it with any sibling
      * keywords present on the same schema node.
      *
@@ -284,9 +265,13 @@ class PropertyFactory
 
         // Detect object structural siblings before producing the ref so the merged Schema can
         // be created synchronously (avoiding processSchema() inside an onResolve callback).
-        $hasObjectStructuralSiblings = !empty(
-            array_intersect(array_keys($siblingJson), self::OBJECT_STRUCTURAL_KEYWORDS)
-        );
+        // The structural keyword list is derived from the draft's own 'object' validator
+        // registrations rather than hardcoded, so it stays in sync as drafts add keywords.
+        $objectStructuralKeywords = $schemaProcessor->getGeneratorConfiguration()
+            ->getBuiltDraft($propertySchema)
+            ->getKeywordsForType('object');
+
+        $hasObjectStructuralSiblings = !empty(array_intersect(array_keys($siblingJson), $objectStructuralKeywords));
 
         // Pre-create the merged Schema when siblings contain structural object keywords.
         // Sibling content is processed into the Schema now; ref properties are added later

--- a/src/SchemaProcessor/SchemaProcessor.php
+++ b/src/SchemaProcessor/SchemaProcessor.php
@@ -199,6 +199,63 @@ class SchemaProcessor
     }
 
     /**
+     * Create the merged Schema for a property-level $ref+object-sibling merge (Draft 2019-09+).
+     *
+     * Processes the sibling structural keywords (properties, required, additionalProperties, …)
+     * directly into the merged Schema via a base-property pass. The caller is responsible for
+     * transferring the $ref's nested Schema's properties into the merged Schema (with allOf
+     * semantics for name collisions) inside an onResolve callback, and for calling
+     * generateClassFile() once the ref has resolved.
+     *
+     * @throws SchemaException
+     */
+    public function createObjectRefSiblingMergedSchema(
+        Schema $parentSchema,
+        string $propertyName,
+        JsonSchema $propertySchema,
+        array $siblingJson,
+    ): Schema {
+        $mergedClassName = $this->generatorConfiguration->getClassNameGenerator()->getClassName(
+            $propertyName,
+            $propertySchema,
+            true,
+            $this->currentClassName,
+        );
+
+        // Exclude keywords that belong to the outer property (not the merged class body).
+        // Mirrors the exclusions that createObjectProperty() applies before passing the schema
+        // to processSchema().
+        $mergedBaseJson = $siblingJson;
+        unset($mergedBaseJson['filter'], $mergedBaseJson['enum'], $mergedBaseJson['default']);
+        $mergedBaseJson['type'] = 'base';
+
+        $mergedSchemaJson = $propertySchema->withJson($mergedBaseJson);
+
+        $mergedSchema = new Schema(
+            $this->getTargetFileName($parentSchema->getClassPath(), $mergedClassName),
+            $parentSchema->getClassPath(),
+            $mergedClassName,
+            $mergedSchemaJson,
+            $parentSchema->getSchemaDictionary(),
+            false,
+            $this->generatorConfiguration,
+        );
+
+        // Process the sibling structural keywords directly into the merged Schema as a base
+        // property. This registers sibling-defined properties (via PropertiesValidatorFactory,
+        // RequiredPropertyValidator, etc.) on the merged Schema before the $ref's properties
+        // are wired in with allOf semantics.
+        (new PropertyFactory())->create(
+            $this,
+            $mergedSchema,
+            $mergedClassName,
+            $mergedSchemaJson,
+        );
+
+        return $mergedSchema;
+    }
+
+    /**
      * Attach a new class file render job to the render proxy
      */
     public function generateClassFile(Schema $schema): void

--- a/src/Utils/PropertyMerger.php
+++ b/src/Utils/PropertyMerger.php
@@ -19,7 +19,7 @@ use PHPModelGenerator\PropertyProcessor\Decorator\Property\IntToFloatCastDecorat
  *  - Root-precedence guard (anyOf/oneOf must not widen a root-registered property)
  *  - Nullable-branch merge (incoming has no scalar type)
  *  - Existing-null promotion (existing slot is a null/untyped placeholder)
- *  - allOf intersection (narrow to the common type set)
+ *  - allOf intersection (narrow to the common type set) + default reconciliation
  *  - anyOf/oneOf union (widen to the combined type set)
  */
 class PropertyMerger
@@ -44,7 +44,7 @@ class PropertyMerger
      * - Either property has a nested schema (object merging is handled elsewhere)
      * - Root-precedence guard blocks a non-allOf composition branch
      *
-     * @throws SchemaException when allOf branches define conflicting types
+     * @throws SchemaException when allOf branches define conflicting types or conflicting defaults
      */
     public function merge(
         PropertyInterface $existing,
@@ -67,16 +67,20 @@ class PropertyMerger
         // For allOf: a truly-untyped incoming branch (no type keyword, not an explicit null-type
         // branch) adds no type constraint — all allOf branches apply simultaneously, so the
         // existing type is unaffected. Skip mergeNullableBranch in that case to avoid wrongly
-        // wiping the existing type.
+        // wiping the existing type. Defaults still need reconciliation even for untyped branches.
         if (
             $isAllOf
             && $incoming->getType(true) === null
             && !str_contains($incoming->getTypeHint(), 'null')
         ) {
+            $this->reconcileAllOfDefaults($existing, $incoming);
             return;
         }
 
         if ($this->mergeNullableBranch($existing, $incoming) || $this->mergeIntoExistingNull($existing, $incoming)) {
+            if ($isAllOf) {
+                $this->reconcileAllOfDefaults($existing, $incoming);
+            }
             return;
         }
 
@@ -90,10 +94,51 @@ class PropertyMerger
                     $incoming->getName(),
                 ),
             );
+            $this->reconcileAllOfDefaults($existing, $incoming);
             return;
         }
 
         $this->applyAnyOfOneOfUnion($existing, $incoming);
+    }
+
+    /**
+     * Detect and reconcile default values for direct allOf-style property merges.
+     *
+     * For composition-branch merges via SchemaProcessor::transferComposedPropertiesToSchema,
+     * branch property defaults are cleared to null before addProperty is called (so this
+     * check is a no-op for those paths — the composition validator handles branch defaults
+     * separately). This method has effect only for direct allOf merges that bypass the
+     * composition machinery: $ref + sibling at base level and object×object property-level
+     * merges in PropertyFactory.
+     *
+     * When both sides declare non-identical non-null defaults the schema is contradictory.
+     * When only the incoming side carries a default it is propagated to the existing slot.
+     *
+     * @throws SchemaException when both sides declare non-identical non-null defaults
+     */
+    private function reconcileAllOfDefaults(
+        PropertyInterface $existing,
+        PropertyInterface $incoming,
+    ): void {
+        $existingDefault = $existing->getDefaultValue();
+        $incomingDefault = $incoming->getDefaultValue();
+
+        if ($existingDefault !== null && $incomingDefault !== null && $existingDefault !== $incomingDefault) {
+            throw new SchemaException(sprintf(
+                "Conflicting default values for property '%s': '%s' declared at '%s'"
+                    . " conflicts with '%s' declared at '%s' in file '%s'",
+                $existing->getName(),
+                $existingDefault,
+                $existing->getJsonSchema()->getPointer(),
+                $incomingDefault,
+                $incoming->getJsonSchema()->getPointer(),
+                $existing->getJsonSchema()->getFile(),
+            ));
+        }
+
+        if ($existingDefault === null && $incomingDefault !== null) {
+            $existing->setDefaultValue($incomingDefault, true);
+        }
     }
 
     /**

--- a/src/Utils/PropertyMerger.php
+++ b/src/Utils/PropertyMerger.php
@@ -8,10 +8,13 @@ use PHPModelGenerator\Exception\SchemaException;
 use PHPModelGenerator\Model\GeneratorConfiguration;
 use PHPModelGenerator\Model\Property\PropertyInterface;
 use PHPModelGenerator\Model\Property\PropertyType;
+use PHPModelGenerator\Model\Schema;
 use PHPModelGenerator\Model\SchemaDefinition\JsonSchema;
 use PHPModelGenerator\Model\Validator;
+use PHPModelGenerator\Model\Validator\Factory\AbstractValidatorFactory;
 use PHPModelGenerator\Model\Validator\TypeCheckInterface;
 use PHPModelGenerator\PropertyProcessor\Decorator\Property\IntToFloatCastDecorator;
+use PHPModelGenerator\SchemaProcessor\SchemaProcessor;
 
 /**
  * Merges an incoming property into an already-registered slot on a Schema.
@@ -45,6 +48,15 @@ class PropertyMerger
      * - Either property has a nested schema (object merging is handled elsewhere)
      * - Root-precedence guard blocks a non-allOf composition branch
      *
+     * $rebuildFrom, $schemaProcessor, and $schema are only needed for $ref-driven allOf merges
+     * (base-level and property-level $ref+sibling merging): whenever a branch below strips
+     * $existing's type-check validator because the merge changed its effective type,
+     * $rebuildFrom's JSON (typically $incoming's own JsonSchema) is re-run through the draft's
+     * type-specific modifiers to rebuild it and re-transfer range constraints (minimum, maximum,
+     * …) using the narrowed type's own comparison function. Leave all three null for merges with
+     * no such single, re-derivable source (composition-branch arrays validate each branch
+     * independently at runtime instead, so they don't need this).
+     *
      * @throws SchemaException when allOf branches define conflicting types or conflicting defaults
      */
     public function merge(
@@ -52,6 +64,9 @@ class PropertyMerger
         PropertyInterface $incoming,
         bool $isAllOf,
         bool $isRootRegistered = false,
+        ?JsonSchema $rebuildFrom = null,
+        ?SchemaProcessor $schemaProcessor = null,
+        ?Schema $schema = null,
     ): void {
         // Nested-object merging is owned by the merged-property system; don't interfere.
         if (
@@ -69,18 +84,25 @@ class PropertyMerger
         // branch) adds no type constraint — all allOf branches apply simultaneously, so the
         // existing type is unaffected. Skip mergeNullableBranch in that case to avoid wrongly
         // wiping the existing type. Defaults still need reconciliation even for untyped branches.
+        // reapplyTypeSpecificConstraintsIfNeeded() is still called here (even though $existing's
+        // type-check validator itself is untouched): $incoming may carry range constraints
+        // (minimum, minLength, …) that $existing never received, since $existing was built
+        // independently from the sibling's own JSON with no knowledge of $incoming's. Its own
+        // effective-type guard makes this a no-op whenever there's nothing to reapply.
         if (
             $isAllOf
             && $incoming->getType(true) === null
             && !str_contains($incoming->getTypeHint(), 'null')
         ) {
             $this->reconcileAllOfDefaults($existing, $incoming);
+            $this->reapplyTypeSpecificConstraintsIfNeeded($existing, $rebuildFrom, $schemaProcessor, $schema);
             return;
         }
 
         if ($this->mergeNullableBranch($existing, $incoming) || $this->mergeIntoExistingNull($existing, $incoming)) {
             if ($isAllOf) {
                 $this->reconcileAllOfDefaults($existing, $incoming);
+                $this->reapplyTypeSpecificConstraintsIfNeeded($existing, $rebuildFrom, $schemaProcessor, $schema);
             }
             return;
         }
@@ -94,6 +116,9 @@ class PropertyMerger
                     "allOf requires all constraints to hold simultaneously, making this schema unsatisfiable.",
                     $incoming->getName(),
                 ),
+                $rebuildFrom,
+                $schemaProcessor,
+                $schema,
             );
             $this->reconcileAllOfDefaults($existing, $incoming);
             return;
@@ -295,12 +320,17 @@ class PropertyMerger
      * Throws SchemaException with $conflictMessage when the declared intersection is empty
      * (the schema is unsatisfiable).
      *
+     * See merge()'s docblock for $rebuildFrom/$schemaProcessor/$schema.
+     *
      * @throws SchemaException
      */
     public function narrowToIntersection(
         PropertyInterface $existing,
         PropertyInterface $incoming,
         string $conflictMessage,
+        ?JsonSchema $rebuildFrom = null,
+        ?SchemaProcessor $schemaProcessor = null,
+        ?Schema $schema = null,
     ): void {
         $existingOutput = $existing->getType(true);
         $incomingOutput = $incoming->getType(true);
@@ -314,7 +344,15 @@ class PropertyMerger
             $existing->getJsonSchema(),
         );
 
+        // Reapply even when the intersection is a no-op (returns null: the effective type set
+        // is already correct, nothing to narrow): $incoming may still carry range constraints
+        // (minimum, minLength, …) that were never transferred onto $existing, since $existing
+        // was built independently from its own JSON with no knowledge of $incoming's. Guarded by
+        // reapplyTypeSpecificConstraints()'s own effective-type check, so this is a no-op
+        // whenever there's genuinely nothing to reapply.
         if ($intersection === null) {
+            $this->reapplyTypeSpecificConstraintsIfNeeded($existing, $rebuildFrom, $schemaProcessor, $schema);
+
             return;
         }
 
@@ -327,6 +365,7 @@ class PropertyMerger
         }
 
         $this->applyNarrowedType($existing, $existingOutput, $intersection, $hasNull);
+        $this->reapplyTypeSpecificConstraintsIfNeeded($existing, $rebuildFrom, $schemaProcessor, $schema);
     }
 
     /**
@@ -434,6 +473,68 @@ class PropertyMerger
             $existing->filterDecorators(
                 static fn($decorator): bool => !($decorator instanceof IntToFloatCastDecorator),
             );
+        }
+    }
+
+    private function reapplyTypeSpecificConstraintsIfNeeded(
+        PropertyInterface $existing,
+        ?JsonSchema $rebuildFrom,
+        ?SchemaProcessor $schemaProcessor,
+        ?Schema $schema,
+    ): void {
+        if ($rebuildFrom === null || $schemaProcessor === null || $schema === null) {
+            return;
+        }
+
+        $this->reapplyTypeSpecificConstraints($existing, $rebuildFrom, $schemaProcessor, $schema);
+    }
+
+    /**
+     * After allOf-style type narrowing strips $existing's TypeCheckValidator (it no longer
+     * reflects the merged, possibly-narrower type), re-run the draft's type-specific modifiers
+     * from $rebuildFrom's JSON with 'type' overridden to $existing's merged effective type. This
+     * rebuilds the TypeCheckValidator and re-transfers range constraints (minimum, maximum, …)
+     * using the correct type-check function for the effective type (e.g. is_int after narrowing
+     * from number to integer).
+     *
+     * Only operates for single scalar types. Multi-type and untyped results use different
+     * validation paths and are left untouched.
+     */
+    private function reapplyTypeSpecificConstraints(
+        PropertyInterface $existing,
+        JsonSchema $rebuildFrom,
+        SchemaProcessor $schemaProcessor,
+        Schema $schema,
+    ): void {
+        $effectiveType = $existing->getType(true);
+
+        if ($effectiveType === null || count($effectiveType->getNames()) !== 1) {
+            return;
+        }
+
+        $effectiveTypeName           = $effectiveType->getNames()[0];
+        $effectiveTypeJsonSchemaName = TypeConverter::phpToJsonSchema($effectiveTypeName);
+        $rebuildFromWithEffectiveType = $rebuildFrom->withJson(
+            array_merge($rebuildFrom->getJson(), ['type' => $effectiveTypeJsonSchemaName]),
+        );
+
+        $builtDraft = $schemaProcessor->getGeneratorConfiguration()->getBuiltDraft($rebuildFromWithEffectiveType);
+
+        foreach ($builtDraft->getCoveredTypes($effectiveTypeJsonSchemaName) as $coveredType) {
+            if ($coveredType->getType() === 'any') {
+                continue;
+            }
+
+            foreach ($coveredType->getModifiers() as $modifier) {
+                $countBefore = count($existing->getValidators());
+                $modifier->modify($schemaProcessor, $schema, $existing, $rebuildFromWithEffectiveType);
+
+                if ($modifier instanceof AbstractValidatorFactory && ($modifierKey = $modifier->getKey()) !== null) {
+                    foreach (array_slice($existing->getValidators(), $countBefore) as $validatorWrapper) {
+                        $validatorWrapper->setSourceKey($modifierKey);
+                    }
+                }
+            }
         }
     }
 

--- a/src/Utils/TypeConverter.php
+++ b/src/Utils/TypeConverter.php
@@ -24,4 +24,13 @@ class TypeConverter
             'boolean' => 'bool',
         ][$type] ?? $type;
     }
+
+    public static function phpToJsonSchema(string $phpType): string
+    {
+        return [
+            'int'  => 'integer',
+            'float' => 'number',
+            'bool' => 'boolean',
+        ][$phpType] ?? $phpType;
+    }
 }

--- a/tests/Draft/ArrayContainsTest.php
+++ b/tests/Draft/ArrayContainsTest.php
@@ -59,7 +59,7 @@ class ArrayContainsTest extends AbstractPHPModelGeneratorTestCase
         GeneratorConfiguration $configuration,
         array $propertyValue,
     ): void {
-        $this->expectValidationError($configuration, 'No item in array property matches contains constraint');
+        $this->expectValidationError($configuration, "No item in array 'property' matches the 'contains' constraint");
 
         $className = $this->generateClassFromFile('Contains.json', $configuration);
 
@@ -107,7 +107,7 @@ class ArrayContainsTest extends AbstractPHPModelGeneratorTestCase
             $this->fail('Expected an exception for array with no matching items');
         } catch (Exception $exception) {
             $this->assertStringContainsString(
-                'No item in array property matches contains constraint',
+                "No item in array 'property' matches the 'contains' constraint",
                 $exception->getMessage(),
             );
             if ($config->collectErrors()) {
@@ -164,7 +164,7 @@ class ArrayContainsTest extends AbstractPHPModelGeneratorTestCase
             $this->fail('Expected ContainsException for array with no matching items');
         } catch (Exception $exception) {
             $this->assertStringContainsString(
-                'No item in array property matches contains constraint',
+                "No item in array 'property' matches the 'contains' constraint",
                 $exception->getMessage(),
             );
             if ($config->collectErrors()) {
@@ -218,7 +218,7 @@ class ArrayContainsTest extends AbstractPHPModelGeneratorTestCase
             $this->fail('Expected an exception for array with no matching items');
         } catch (Exception $exception) {
             $this->assertStringContainsString(
-                'No item in array property matches contains constraint',
+                "No item in array 'property' matches the 'contains' constraint",
                 $exception->getMessage(),
             );
             if ($config->collectErrors()) {

--- a/tests/Draft/DraftExtensibilityTest.php
+++ b/tests/Draft/DraftExtensibilityTest.php
@@ -8,6 +8,8 @@ use PHPModelGenerator\Draft\DraftBuilder;
 use PHPModelGenerator\Draft\DraftInterface;
 use PHPModelGenerator\Draft\Draft_07;
 use PHPModelGenerator\Draft\Element\Type;
+use PHPModelGenerator\Draft\Producer\ExclusiveProducer;
+use PHPModelGenerator\Draft\Producer\RefResolver;
 use PHPModelGenerator\Exception\SchemaException;
 use PHPModelGenerator\Exception\String\MinLengthException;
 use PHPModelGenerator\Exception\ValidationException;
@@ -234,5 +236,38 @@ class DraftExtensibilityTest extends AbstractPHPModelGeneratorTestCase
 
         $object = new $className(['value' => 'longer string']);
         $this->assertSame('longer string', $object->getValue());
+    }
+
+    /**
+     * A schema node carrying two keywords that both resolve to an ExclusiveProducer (each
+     * declaring itself exclusive over every other keyword on the node) is contradictory: there is
+     * no well-defined way to pick a winner, so generation must fail loudly rather than silently
+     * using whichever producer happens to be registered first.
+     */
+    public function testMultipleExclusiveProducersOnOneNodeThrowsSchemaException(): void
+    {
+        $customDraft = new class implements DraftInterface {
+            public function getDefinition(): DraftBuilder
+            {
+                $builder = (new Draft_07())->getDefinition();
+                // Register a second, independent exclusive producer alongside Draft_07's own
+                // $ref producer, so the test schema's '$ref' + '$secondRef' node carries two.
+                $builder->addProducer('$secondRef', new ExclusiveProducer(new RefResolver()));
+
+                return $builder;
+            }
+        };
+
+        $config = (new GeneratorConfiguration())
+            ->setCollectErrors(false)
+            ->setDraft($customDraft);
+
+        $this->expectException(SchemaException::class);
+        $this->expectExceptionMessageMatches(
+            "/^Mutually exclusive keywords '\\\$ref', '\\\$secondRef' cannot be combined on property " .
+            "'value' in file '.+'$/",
+        );
+
+        $this->generateClassFromFile('MutuallyExclusiveProducers.json', $config);
     }
 }

--- a/tests/Draft/DraftTest.php
+++ b/tests/Draft/DraftTest.php
@@ -8,6 +8,7 @@ use PHPModelGenerator\Draft\AutoDetectionDraft;
 use PHPModelGenerator\Draft\Draft_07;
 use PHPModelGenerator\Draft\Draft_2019_09;
 use PHPModelGenerator\Draft\Element\Type;
+use PHPModelGenerator\Draft\Producer\PropertyProducerInterface;
 use PHPModelGenerator\Exception\SchemaException;
 use PHPModelGenerator\Exception\String\MinLengthException;
 use PHPModelGenerator\Model\GeneratorConfiguration;
@@ -21,6 +22,22 @@ use PHPUnit\Framework\TestCase;
 
 class DraftTest extends TestCase
 {
+    // --- Draft::getProducerForKeyword ---
+
+    public function testGetProducerForKeywordReturnsRegisteredProducer(): void
+    {
+        $draft = (new Draft_07())->getDefinition()->build();
+
+        $this->assertInstanceOf(PropertyProducerInterface::class, $draft->getProducerForKeyword('$ref'));
+    }
+
+    public function testGetProducerForKeywordReturnsNullForUnknownKeyword(): void
+    {
+        $draft = (new Draft_07())->getDefinition()->build();
+
+        $this->assertNull($draft->getProducerForKeyword('nonexistent'));
+    }
+
     // --- DraftBuilder::getType ---
 
     public function testDraftBuilderGetTypeReturnsExistingType(): void

--- a/tests/Issues/Issue/Issue168Test.php
+++ b/tests/Issues/Issue/Issue168Test.php
@@ -48,12 +48,12 @@ class Issue168Test extends AbstractIssueTestCase
             // the fix keeps the value as the raw (still-array) input whenever it fails the
             // `array_is_list()` gate, the existing TypeCheckValidator for "object"
             // (`!is_object($value)`) is the one that fires, producing the same
-            // "Requires object, got array" wording already used for a directly-passed scalar
+            // "requires 'object', got 'array'" wording already used for a directly-passed scalar
             // mismatch (see ObjectPropertyTest).
             'permissive object property rejects a JSON array' => [
                 'ObjectTypePermissive.json',
                 ['Hello', 'World'],
-                'Invalid type for target. Requires object, got array',
+                "Invalid type for 'target': requires 'object', got 'array'",
             ],
             // Same as above with `additionalProperties: false` on the nested schema. Before the
             // fix this incidentally rejected the array too, but through the additionalProperties
@@ -66,7 +66,7 @@ class Issue168Test extends AbstractIssueTestCase
             'restrictive object property (additionalProperties: false) rejects with the same clean message' => [
                 'ObjectTypeRestrictive.json',
                 ['Hello', 'World'],
-                'Invalid type for target. Requires object, got array',
+                "Invalid type for 'target': requires 'object', got 'array'",
             ],
             // `additionalProperties: <schema>` (as opposed to `true`/`false`) must not let a JSON
             // array masquerade as a fully legitimate `additionalProperties` bag keyed by its own
@@ -79,7 +79,7 @@ class Issue168Test extends AbstractIssueTestCase
             'object property with schema-typed additionalProperties rejects instead of absorbing a JSON array' => [
                 'AdditionalPropertiesSchemaAbsorbsArray.json',
                 ['Hello', 'World'],
-                'Invalid type for target. Requires object, got array',
+                "Invalid type for 'target': requires 'object', got 'array'",
             ],
             // Same absorption bug as above, but via a digit-matching `patternProperties` pattern
             // instead of a schema-typed `additionalProperties` - and, unlike the restrictive case
@@ -92,7 +92,7 @@ class Issue168Test extends AbstractIssueTestCase
             'object property with numeric patternProperties rejects instead of absorbing a JSON array' => [
                 'PatternPropertiesNumericAbsorbsArray.json',
                 ['Hello', 'World'],
-                'Invalid type for target. Requires object, got array',
+                "Invalid type for 'target': requires 'object', got 'array'",
             ],
         ];
     }
@@ -104,7 +104,7 @@ class Issue168Test extends AbstractIssueTestCase
      * from arrayOrObjectTypeMismatchDataProvider() above because it targets a differently-named
      * property ("tags", declared as "array" rather than "object") in its own schema file.
      *
-     * The resulting message ("Requires array, got array") is not very informative - `gettype()`
+     * The resulting message ("requires 'array', got 'array'") is not very informative - `gettype()`
      * reports "array" for both a JSON array and a JSON object once decoded, so it cannot itself
      * distinguish which shape was actually provided. That is an existing message-formatting
      * limitation shared with every other `InvalidTypeException`, not something this fix
@@ -115,7 +115,7 @@ class Issue168Test extends AbstractIssueTestCase
         $className = $this->generateClassFromFile('ArrayTypeAcceptsObject.json');
 
         $this->expectException(InvalidTypeException::class);
-        $this->expectExceptionMessage('Invalid type for tags. Requires array, got array');
+        $this->expectExceptionMessage("Invalid type for 'tags': requires 'array', got 'array'");
 
         new $className(['tags' => ['a' => 'x', 'b' => 'y']]);
     }

--- a/tests/Issues/Issue/Issue79Test.php
+++ b/tests/Issues/Issue/Issue79Test.php
@@ -26,6 +26,12 @@ class Issue79Test extends AbstractIssueTestCase
         $this->assertSame('A28', $object->getStreet());
         $this->assertNull($object->getAge());
         $this->assertNull($object->getZip());
+
+        // Properties must carry their authored JSON pointers — no synthetic /allOf/N segment.
+        $this->assertPropertyHasJsonPointer($object, 'name', '/properties/name');
+        $this->assertPropertyHasJsonPointer($object, 'age', '/properties/age');
+        $this->assertPropertyHasJsonPointer($object, 'street', '/definitions/location/properties/street');
+        $this->assertPropertyHasJsonPointer($object, 'zip', '/definitions/location/properties/zip');
     }
 
     #[ApplicableDrafts(from: JsonSchemaDraft::DRAFT_2019_09)]

--- a/tests/Issues/Issue/Issue79Test.php
+++ b/tests/Issues/Issue/Issue79Test.php
@@ -8,11 +8,14 @@ use PHPModelGenerator\Exception\ErrorRegistryException;
 use PHPModelGenerator\Model\GeneratorConfiguration;
 use PHPModelGenerator\Tests\Issues\AbstractIssueTestCase;
 use PHPModelGenerator\Tests\Support\ApplicableDrafts;
+use PHPModelGenerator\Tests\Support\JsonSchemaDraft;
 use PHPUnit\Framework\Attributes\DataProvider;
 
-#[ApplicableDrafts]
 class Issue79Test extends AbstractIssueTestCase
 {
+    // Draft 2019-09+: $ref siblings apply — all four properties (from ref and from sibling
+    // properties/required) must appear on the generated class.
+    #[ApplicableDrafts(from: JsonSchemaDraft::DRAFT_2019_09)]
     public function testCombinedReferenceAndObjectDefinition(): void
     {
         $className = $this->generateClassFromFile('person.json');
@@ -25,6 +28,7 @@ class Issue79Test extends AbstractIssueTestCase
         $this->assertNull($object->getZip());
     }
 
+    #[ApplicableDrafts(from: JsonSchemaDraft::DRAFT_2019_09)]
     #[DataProvider('invalidInputDataProvider')]
     public function testCombinedReferenceAndObjectDefinitionWithInvalidDataThrowsAnException(array $data): void
     {
@@ -46,6 +50,44 @@ class Issue79Test extends AbstractIssueTestCase
             'empty object'      => [['street' => 'A28']],
             'invalid reference' => [['name' => 'Hans', 'street' => 'A28', 'zip' => 'ABC']],
             'invalid object'    => [['name' => 'Hans', 'street' => 'A28', 'age' => 'ABC']],
+        ];
+    }
+
+    // Draft 07: $ref siblings are silently ignored. Only the referenced schema's properties
+    // (street + zip from the location definition) appear on the generated class.
+    #[ApplicableDrafts(until: JsonSchemaDraft::DRAFT_07)]
+    public function testDraft07SiblingsIgnoredRefOnlyPropertiesPresent(): void
+    {
+        $className = $this->generateClassFromFile('person.json');
+
+        $object = new $className(['street' => 'A28']);
+
+        $this->assertSame('A28', $object->getStreet());
+        $this->assertNull($object->getZip());
+        $this->assertFalse(method_exists($object, 'getName'));
+        $this->assertFalse(method_exists($object, 'getAge'));
+    }
+
+    #[ApplicableDrafts(until: JsonSchemaDraft::DRAFT_07)]
+    #[DataProvider('invalidInputDraft07DataProvider')]
+    public function testDraft07WithInvalidDataThrowsAnException(array $data): void
+    {
+        $className = $this->generateClassFromFile(
+            'person.json',
+            (new GeneratorConfiguration())->setCollectErrors(true),
+        );
+
+        $this->expectException(ErrorRegistryException::class);
+
+        new $className($data);
+    }
+
+    public static function invalidInputDraft07DataProvider(): array
+    {
+        return [
+            // Only the ref's properties exist: street is required, zip is optional
+            'missing required street' => [[]],
+            'invalid zip type'        => [['street' => 'A28', 'zip' => 'ABC']],
         ];
     }
 }

--- a/tests/Objects/RefSiblingsPropertyLevelTest.php
+++ b/tests/Objects/RefSiblingsPropertyLevelTest.php
@@ -1,0 +1,144 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PHPModelGenerator\Tests\Objects;
+
+use PHPModelGenerator\Exception\ErrorRegistryException;
+use PHPModelGenerator\Exception\SchemaException;
+use PHPModelGenerator\Model\GeneratorConfiguration;
+use PHPModelGenerator\Tests\AbstractPHPModelGeneratorTestCase;
+use PHPModelGenerator\Tests\Support\ApplicableDrafts;
+use PHPModelGenerator\Tests\Support\JsonSchemaDraft;
+use PHPUnit\Framework\Attributes\DataProvider;
+
+/**
+ * Tests for property-level $ref + sibling merge behavior.
+ *
+ * For Draft 2019-09+, structural sibling keywords alongside $ref produce a merged nested
+ * class that combines the referenced schema's properties with the sibling's properties.
+ * For Draft 07, siblings are silently ignored (ExclusiveProducer).
+ */
+class RefSiblingsPropertyLevelTest extends AbstractPHPModelGeneratorTestCase
+{
+    // -------------------------------------------------------------------------
+    // Property-level object×object merge (Draft 2019-09+)
+    // -------------------------------------------------------------------------
+
+    /**
+     * Draft 2019-09+: a property-level {$ref→object, properties: {city}} merges into a single
+     * nested class containing all properties from the ref (street, zip) and the sibling (city).
+     * Both 'street' (from ref) and 'city' (from sibling required) must be present.
+     */
+    #[ApplicableDrafts(from: JsonSchemaDraft::DRAFT_2019_09)]
+    public function testPropertyLevelObjectRefAndSiblingPropertiesMerged(): void
+    {
+        $className = $this->generateClassFromFile('PropertyLevelObjectMerge.json');
+
+        $object = new $className(['address' => ['street' => 'Main St', 'city' => 'Berlin']]);
+
+        $address = $object->getAddress();
+        $this->assertSame('Main St', $address->getStreet());
+        $this->assertNull($address->getZip());
+        $this->assertSame('Berlin', $address->getCity());
+
+        // Properties from the ref keep their definition pointers; properties from the sibling
+        // keep the authored property-path pointer. None should contain /allOf/N.
+        $this->assertPropertyHasJsonPointer(
+            $address,
+            'street',
+            '/definitions/location/properties/street',
+        );
+        $this->assertPropertyHasJsonPointer(
+            $address,
+            'zip',
+            '/definitions/location/properties/zip',
+        );
+        $this->assertPropertyHasJsonPointer(
+            $address,
+            'city',
+            '/properties/address/properties/city',
+        );
+    }
+
+    /**
+     * Draft 2019-09+: supplying zip fills that property from the ref side of the merged class.
+     */
+    #[ApplicableDrafts(from: JsonSchemaDraft::DRAFT_2019_09)]
+    public function testPropertyLevelObjectMergedClassHoldsAllProperties(): void
+    {
+        $className = $this->generateClassFromFile('PropertyLevelObjectMerge.json');
+
+        $object = new $className(['address' => ['street' => 'Oak Ave', 'zip' => 10115, 'city' => 'Berlin']]);
+
+        $address = $object->getAddress();
+        $this->assertSame('Oak Ave', $address->getStreet());
+        $this->assertSame(10115, $address->getZip());
+        $this->assertSame('Berlin', $address->getCity());
+    }
+
+    /**
+     * Draft 2019-09+: validation from the ref side (required 'street') is still enforced in the
+     * merged class.
+     */
+    #[ApplicableDrafts(from: JsonSchemaDraft::DRAFT_2019_09)]
+    #[DataProvider('propertyLevelMergeInvalidInputProvider')]
+    public function testPropertyLevelObjectMergedClassEnforcesValidation(array $addressData): void
+    {
+        $className = $this->generateClassFromFile(
+            'PropertyLevelObjectMerge.json',
+            (new GeneratorConfiguration())->setCollectErrors(true),
+        );
+
+        $this->expectException(ErrorRegistryException::class);
+
+        new $className(['address' => $addressData]);
+    }
+
+    public static function propertyLevelMergeInvalidInputProvider(): array
+    {
+        return [
+            'missing required street from ref'    => [['city' => 'Berlin']],
+            'missing required city from sibling'  => [['street' => 'Main St']],
+            'missing both required properties'    => [[]],
+            'invalid zip type from ref'           => [['street' => 'Main St', 'city' => 'Berlin', 'zip' => 'ABC']],
+        ];
+    }
+
+    // -------------------------------------------------------------------------
+    // Property-level object ref with structural siblings — Draft 07 ignores siblings
+    // -------------------------------------------------------------------------
+
+    /**
+     * Draft 07: sibling 'properties' and 'required' are silently ignored. The generated property
+     * uses only the $ref's schema — so 'city' does not exist on the address object, and only
+     * 'street' (from the ref) is required.
+     */
+    #[ApplicableDrafts(until: JsonSchemaDraft::DRAFT_07)]
+    public function testPropertyLevelObjectDraft07SiblingPropertiesIgnored(): void
+    {
+        $className = $this->generateClassFromFile('PropertyLevelObjectMerge.json');
+
+        // Only the ref's properties exist: street (required), zip (optional). No city.
+        $object = new $className(['address' => ['street' => 'Main St']]);
+
+        $address = $object->getAddress();
+        $this->assertSame('Main St', $address->getStreet());
+        $this->assertNull($address->getZip());
+        $this->assertFalse(method_exists($address, 'getCity'));
+    }
+
+    #[ApplicableDrafts(until: JsonSchemaDraft::DRAFT_07)]
+    public function testPropertyLevelObjectDraft07MissingRequiredRefFieldThrows(): void
+    {
+        $className = $this->generateClassFromFile(
+            'PropertyLevelObjectMerge.json',
+            (new GeneratorConfiguration())->setCollectErrors(true),
+        );
+
+        $this->expectException(ErrorRegistryException::class);
+
+        // 'street' is still required (from the ref) even when siblings are ignored.
+        new $className(['address' => ['city' => 'Berlin']]);
+    }
+}

--- a/tests/Objects/RefSiblingsPropertyLevelTest.php
+++ b/tests/Objects/RefSiblingsPropertyLevelTest.php
@@ -6,6 +6,7 @@ namespace PHPModelGenerator\Tests\Objects;
 
 use PHPModelGenerator\Exception\ErrorRegistryException;
 use PHPModelGenerator\Exception\SchemaException;
+use PHPModelGenerator\Exception\ValidationException;
 use PHPModelGenerator\Model\GeneratorConfiguration;
 use PHPModelGenerator\Tests\AbstractPHPModelGeneratorTestCase;
 use PHPModelGenerator\Tests\Support\ApplicableDrafts;
@@ -144,6 +145,40 @@ class RefSiblingsPropertyLevelTest extends AbstractPHPModelGeneratorTestCase
 
         // 'AB' is 2 chars — violates sibling minLength: 3
         new $className(['address' => ['street' => 'AB', 'city' => 'Berlin']]);
+    }
+
+    /**
+     * Draft 2019-09+: when the colliding property's type narrows (ref: number, sibling:
+     * integer), the ref's own range constraint (minimum: 0) must still be enforced against the
+     * narrowed type — narrowing must not silently drop constraints the ref side declared.
+     */
+    #[ApplicableDrafts(from: JsonSchemaDraft::DRAFT_2019_09)]
+    public function testPropertyLevelObjectCollisionTypeNarrowingPreservesRefConstraints(): void
+    {
+        $className = $this->generateClassFromFile('PropertyLevelObjectCollisionTypeNarrowing.json');
+
+        $object = new $className(['address' => ['zip' => 5]]);
+        $this->assertSame(5, $object->getAddress()->getZip());
+
+        // float not accepted after narrowing to integer
+        $this->expectException(ValidationException::class);
+
+        new $className(['address' => ['zip' => 1.5]]);
+    }
+
+    /**
+     * Draft 2019-09+: the ref's minimum: 0 constraint is preserved after the integer
+     * narrowing above — a separate test since testPropertyLevelObjectCollisionTypeNarrowingPreservesRefConstraints()
+     * already asserts on the type-check exception and can't also assert on the minimum one.
+     */
+    #[ApplicableDrafts(from: JsonSchemaDraft::DRAFT_2019_09)]
+    public function testPropertyLevelObjectCollisionTypeNarrowingEnforcesRefMinimum(): void
+    {
+        $className = $this->generateClassFromFile('PropertyLevelObjectCollisionTypeNarrowing.json');
+
+        $this->expectException(ValidationException::class);
+
+        new $className(['address' => ['zip' => -1]]); // violates ref minimum: 0
     }
 
     // -------------------------------------------------------------------------

--- a/tests/Objects/RefSiblingsPropertyLevelTest.php
+++ b/tests/Objects/RefSiblingsPropertyLevelTest.php
@@ -149,8 +149,9 @@ class RefSiblingsPropertyLevelTest extends AbstractPHPModelGeneratorTestCase
 
     /**
      * Draft 2019-09+: when the colliding property's type narrows (ref: number, sibling:
-     * integer), the ref's own range constraint (minimum: 0) must still be enforced against the
-     * narrowed type — narrowing must not silently drop constraints the ref side declared.
+     * integer), both the narrowed type itself and the ref's own range constraint (minimum: 0)
+     * must still be enforced — narrowing must not silently drop constraints the ref side
+     * declared. The narrowed type must also be reflected in the generated getter's type hint.
      */
     #[ApplicableDrafts(from: JsonSchemaDraft::DRAFT_2019_09)]
     public function testPropertyLevelObjectCollisionTypeNarrowingPreservesRefConstraints(): void
@@ -158,27 +159,37 @@ class RefSiblingsPropertyLevelTest extends AbstractPHPModelGeneratorTestCase
         $className = $this->generateClassFromFile('PropertyLevelObjectCollisionTypeNarrowing.json');
 
         $object = new $className(['address' => ['zip' => 5]]);
-        $this->assertSame(5, $object->getAddress()->getZip());
+        $address = $object->getAddress();
+        $this->assertSame(5, $address->getZip());
 
-        // float not accepted after narrowing to integer
+        // the merged getter is typed as the narrowed integer, not the ref's original number
+        $this->assertSame(['int', 'null'], $this->getReturnTypeNames($address, 'getZip'));
+
+        // float not accepted after narrowing to integer — checked here (not test-ending) so the
+        // ref's minimum constraint can still be asserted below on the same generated class
+        try {
+            new $className(['address' => ['zip' => 1.5]]);
+            $this->fail('Expected a ValidationException for a float value after integer narrowing');
+        } catch (ValidationException $exception) {
+            $this->assertSame(
+                <<<'MESSAGE'
+                Invalid nested object for property 'address':
+                  - Invalid type for 'zip': requires 'int', got 'double'
+                MESSAGE,
+                $exception->getMessage(),
+            );
+        }
+
+        // the ref's minimum: 0 constraint is preserved after the integer narrowing above
         $this->expectException(ValidationException::class);
+        $this->expectExceptionMessage(
+            <<<'MESSAGE'
+            Invalid nested object for property 'address':
+              - Value for 'zip' must not be smaller than 0
+            MESSAGE,
+        );
 
-        new $className(['address' => ['zip' => 1.5]]);
-    }
-
-    /**
-     * Draft 2019-09+: the ref's minimum: 0 constraint is preserved after the integer
-     * narrowing above — a separate test since testPropertyLevelObjectCollisionTypeNarrowingPreservesRefConstraints()
-     * already asserts on the type-check exception and can't also assert on the minimum one.
-     */
-    #[ApplicableDrafts(from: JsonSchemaDraft::DRAFT_2019_09)]
-    public function testPropertyLevelObjectCollisionTypeNarrowingEnforcesRefMinimum(): void
-    {
-        $className = $this->generateClassFromFile('PropertyLevelObjectCollisionTypeNarrowing.json');
-
-        $this->expectException(ValidationException::class);
-
-        new $className(['address' => ['zip' => -1]]); // violates ref minimum: 0
+        new $className(['address' => ['zip' => -1]]);
     }
 
     // -------------------------------------------------------------------------

--- a/tests/Objects/RefSiblingsPropertyLevelTest.php
+++ b/tests/Objects/RefSiblingsPropertyLevelTest.php
@@ -106,6 +106,68 @@ class RefSiblingsPropertyLevelTest extends AbstractPHPModelGeneratorTestCase
     }
 
     // -------------------------------------------------------------------------
+    // Property-level object×object merge with colliding property name (Draft 2019-09+)
+    // -------------------------------------------------------------------------
+
+    /**
+     * Draft 2019-09+: when a property-level $ref→object and sibling 'properties' both declare
+     * a property with the same name ('street'), they are merged with allOf semantics. The
+     * result is a class that enforces both the ref's type constraint (string) and the sibling's
+     * additional constraints (minLength: 3).
+     */
+    #[ApplicableDrafts(from: JsonSchemaDraft::DRAFT_2019_09)]
+    public function testPropertyLevelObjectMergeWithCollidingPropertyName(): void
+    {
+        $className = $this->generateClassFromFile('PropertyLevelObjectCollision.json');
+
+        $object = new $className(['address' => ['street' => 'Oak', 'city' => 'Berlin']]);
+
+        $address = $object->getAddress();
+        $this->assertSame('Oak', $address->getStreet());
+        $this->assertNull($address->getZip());
+        $this->assertSame('Berlin', $address->getCity());
+    }
+
+    /**
+     * Draft 2019-09+: the allOf intersection for the colliding 'street' property enforces
+     * the sibling's minLength: 3 constraint.
+     */
+    #[ApplicableDrafts(from: JsonSchemaDraft::DRAFT_2019_09)]
+    public function testPropertyLevelObjectCollisionEnforcesMergedConstraints(): void
+    {
+        $className = $this->generateClassFromFile(
+            'PropertyLevelObjectCollision.json',
+            (new GeneratorConfiguration())->setCollectErrors(true),
+        );
+
+        $this->expectException(ErrorRegistryException::class);
+
+        // 'AB' is 2 chars — violates sibling minLength: 3
+        new $className(['address' => ['street' => 'AB', 'city' => 'Berlin']]);
+    }
+
+    // -------------------------------------------------------------------------
+    // Structural siblings require $ref to resolve to object — SchemaException
+    // -------------------------------------------------------------------------
+
+    /**
+     * Draft 2019-09+: when a property-level schema has structural sibling keywords
+     * ('properties') alongside a $ref that resolves to a non-object type (string),
+     * schema generation must fail with a SchemaException: these are contradictory constraints.
+     */
+    #[ApplicableDrafts(from: JsonSchemaDraft::DRAFT_2019_09)]
+    public function testPropertyLevelStructuralSiblingWithNonObjectRefThrowsSchemaException(): void
+    {
+        $this->expectException(SchemaException::class);
+        $this->expectExceptionMessageMatches(
+            "/Property 'person' in file '.*': sibling structural object keywords"
+            . ".*require the \\\$ref to resolve to an object/s",
+        );
+
+        $this->generateClassFromFile('PropertyLevelStructuralSiblingNonObjectRef.json');
+    }
+
+    // -------------------------------------------------------------------------
     // Property-level object ref with structural siblings — Draft 07 ignores siblings
     // -------------------------------------------------------------------------
 

--- a/tests/Objects/RefSiblingsTest.php
+++ b/tests/Objects/RefSiblingsTest.php
@@ -1,0 +1,338 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PHPModelGenerator\Tests\Objects;
+
+use PHPModelGenerator\Exception\ErrorRegistryException;
+use PHPModelGenerator\Exception\SchemaException;
+use PHPModelGenerator\Exception\ValidationException;
+use PHPModelGenerator\Model\GeneratorConfiguration;
+use PHPModelGenerator\Tests\AbstractPHPModelGeneratorTestCase;
+use PHPModelGenerator\Tests\Support\ApplicableDrafts;
+use PHPModelGenerator\Tests\Support\JsonSchemaDraft;
+use PHPUnit\Framework\Attributes\DataProvider;
+
+/**
+ * Tests for property-level $ref + non-structural sibling keywords, type parity, and pointer
+ * correctness. Structural sibling tests (properties, required, object×object merge) live in
+ * RefSiblingsPropertyLevelTest and Issue79Test.
+ */
+class RefSiblingsTest extends AbstractPHPModelGeneratorTestCase
+{
+    // -------------------------------------------------------------------------
+    // $ref alone — unchanged behavior across all drafts
+    // -------------------------------------------------------------------------
+
+    /**
+     * A bare $ref with no siblings behaves identically in all drafts: the referenced schema's
+     * constraints are applied and the property type matches.
+     */
+    public function testRefAloneUnchangedAllDrafts(): void
+    {
+        $className = $this->generateClassFromFile(
+            'RefAlone.json',
+            (new GeneratorConfiguration())->setCollectErrors(false),
+        );
+
+        $object = new $className(['name' => 'Hi']);
+        $this->assertSame('Hi', $object->getName());
+        $this->assertNull($object->getName() === 'Hi' ? null : 'unexpected');
+    }
+
+    public function testRefAloneEnforcesRefConstraints(): void
+    {
+        $className = $this->generateClassFromFile(
+            'RefAlone.json',
+            (new GeneratorConfiguration())->setCollectErrors(false),
+        );
+
+        $this->expectException(ValidationException::class);
+
+        new $className(['name' => 'x']); // minLength: 2 from ref
+    }
+
+    // -------------------------------------------------------------------------
+    // Non-structural property siblings (Draft 2019-09+: applied; Draft 07: ignored)
+    // -------------------------------------------------------------------------
+
+    /**
+     * Draft 2019-09+: sibling minLength alongside $ref→string narrows the minimum length.
+     * The effective minimum is max(ref minLength, sibling minLength) because both constraints
+     * are added to the property.
+     */
+    #[ApplicableDrafts(from: JsonSchemaDraft::DRAFT_2019_09)]
+    public function testNonStructuralMinLengthSiblingApplied(): void
+    {
+        $className = $this->generateClassFromFile('NonStructuralPropertySiblings.json');
+
+        // Exactly 5 characters: satisfies both ref minLength:1 and sibling minLength:5
+        $object = new $className(['withMinLength' => 'Hello', 'withEnum' => 'Alice', 'withConst' => 'fixed']);
+        $this->assertSame('Hello', $object->getWithMinLength());
+
+        // 4 characters: fails sibling minLength:5
+        $className2 = $this->generateClassFromFile(
+            'NonStructuralPropertySiblings.json',
+            (new GeneratorConfiguration())->setCollectErrors(true),
+        );
+
+        $this->expectException(ErrorRegistryException::class);
+
+        new $className2(['withMinLength' => 'Hi!']);
+    }
+
+    /**
+     * Draft 2019-09+: sibling enum alongside $ref→string constrains the allowed values.
+     */
+    #[ApplicableDrafts(from: JsonSchemaDraft::DRAFT_2019_09)]
+    public function testNonStructuralEnumSiblingApplied(): void
+    {
+        $className = $this->generateClassFromFile('NonStructuralPropertySiblings.json');
+
+        // Valid enum value
+        $object = new $className(['withMinLength' => 'Hello', 'withEnum' => 'Bob', 'withConst' => 'fixed']);
+        $this->assertSame('Bob', $object->getWithEnum());
+
+        // Not in enum: rejected
+        $className2 = $this->generateClassFromFile(
+            'NonStructuralPropertySiblings.json',
+            (new GeneratorConfiguration())->setCollectErrors(true),
+        );
+
+        $this->expectException(ErrorRegistryException::class);
+
+        new $className2(['withMinLength' => 'Hello', 'withEnum' => 'Dave', 'withConst' => 'fixed']);
+    }
+
+    /**
+     * Draft 2019-09+: sibling const alongside $ref→string constrains the property to one exact
+     * value.
+     */
+    #[ApplicableDrafts(from: JsonSchemaDraft::DRAFT_2019_09)]
+    public function testNonStructuralConstSiblingApplied(): void
+    {
+        $className = $this->generateClassFromFile('NonStructuralPropertySiblings.json');
+
+        // Correct const value
+        $object = new $className(['withMinLength' => 'Hello', 'withEnum' => 'Alice', 'withConst' => 'fixed']);
+        $this->assertSame('fixed', $object->getWithConst());
+
+        // Wrong value: rejected
+        $className2 = $this->generateClassFromFile(
+            'NonStructuralPropertySiblings.json',
+            (new GeneratorConfiguration())->setCollectErrors(true),
+        );
+
+        $this->expectException(ErrorRegistryException::class);
+
+        new $className2(['withMinLength' => 'Hello', 'withEnum' => 'Alice', 'withConst' => 'other']);
+    }
+
+    /**
+     * Draft 07: non-structural sibling keywords (minLength, enum, const) alongside $ref are
+     * silently ignored. Only the ref's constraints apply, so any string satisfying minLength:1
+     * is valid regardless of the siblings.
+     */
+    #[ApplicableDrafts(until: JsonSchemaDraft::DRAFT_07)]
+    public function testNonStructuralSiblingsDraft07Ignored(): void
+    {
+        $className = $this->generateClassFromFile('NonStructuralPropertySiblings.json');
+
+        // 'xx' satisfies ref minLength:1; it is not in the enum but siblings are ignored.
+        $object = new $className([
+            'withMinLength' => 'xx',  // only 2 chars: passes ref minLength:1, no sibling minLength:5
+            'withEnum'      => 'Dave', // not in sibling enum, but enum is ignored
+            'withConst'     => 'other', // not the const value, but const is ignored
+        ]);
+
+        $this->assertSame('xx', $object->getWithMinLength());
+        $this->assertSame('Dave', $object->getWithEnum());
+        $this->assertSame('other', $object->getWithConst());
+    }
+
+    /**
+     * Draft 07: the ref's own constraints (minLength:1) are still enforced.
+     */
+    #[ApplicableDrafts(until: JsonSchemaDraft::DRAFT_07)]
+    public function testNonStructuralSiblingsDraft07RefConstraintsStillEnforced(): void
+    {
+        $className = $this->generateClassFromFile(
+            'NonStructuralPropertySiblings.json',
+            (new GeneratorConfiguration())->setCollectErrors(true),
+        );
+
+        $this->expectException(ErrorRegistryException::class);
+
+        // Empty string violates ref's minLength:1
+        new $className(['withMinLength' => '']);
+    }
+
+    // -------------------------------------------------------------------------
+    // Scalar type narrowing — Draft 2019-09+
+    // -------------------------------------------------------------------------
+
+    /**
+     * Draft 2019-09+: when $ref resolves to number (float) and the sibling specifies
+     * type: integer, the effective PHP type is int (integer is a subtype of number).
+     * The ref's minimum: 0 constraint is also preserved.
+     */
+    #[ApplicableDrafts(from: JsonSchemaDraft::DRAFT_2019_09)]
+    public function testScalarTypeNarrowsToSubtype(): void
+    {
+        $className = $this->generateClassFromFile(
+            'ScalarTypeMerge.json',
+            (new GeneratorConfiguration())->setCollectErrors(false),
+        );
+
+        $object = new $className(['count' => 5]);
+        $this->assertSame(5, $object->getCount());
+
+        // float not accepted when narrowed to int
+        $this->expectException(ValidationException::class);
+
+        new $className(['count' => 1.5]);
+    }
+
+    /**
+     * Draft 2019-09+: the ref's constraints (minimum: 0) are still enforced after narrowing.
+     */
+    #[ApplicableDrafts(from: JsonSchemaDraft::DRAFT_2019_09)]
+    public function testScalarTypeNarrowingPreservesRefConstraints(): void
+    {
+        $className = $this->generateClassFromFile(
+            'ScalarTypeMerge.json',
+            (new GeneratorConfiguration())->setCollectErrors(false),
+        );
+
+        $this->expectException(ValidationException::class);
+
+        new $className(['count' => -1]); // violates ref's minimum: 0
+    }
+
+    /**
+     * Draft 2019-09+: when $ref resolves to a nullable string (string|null) and the sibling
+     * specifies type: string (non-null), null is rejected when implicitNull is disabled
+     * (the sibling narrows away the ref's nullability). With implicitNull enabled (the
+     * default), the generator still accepts null for absent optional properties — this
+     * is the global implicit-null contract, not overridden by type narrowing.
+     */
+    #[ApplicableDrafts(from: JsonSchemaDraft::DRAFT_2019_09)]
+    public function testNullableRefNarrowedToNonNullBySibling(): void
+    {
+        // String value is always accepted.
+        $className = $this->generateClassFromFile(
+            'ScalarTypeMerge.json',
+            (new GeneratorConfiguration())->setCollectErrors(false),
+        );
+
+        $object = new $className(['count' => 1, 'label' => 'hello']);
+        $this->assertSame('hello', $object->getLabel());
+
+        // With implicitNull disabled, null is no longer valid after the sibling narrows
+        // away the ref's nullability: the TypeCheck for 'string' does not allow null.
+        $strictClassName = $this->generateClassFromFile(
+            'ScalarTypeMerge.json',
+            (new GeneratorConfiguration())->setCollectErrors(false),
+            implicitNull: false,
+        );
+
+        $this->expectException(ValidationException::class);
+
+        new $strictClassName(['count' => 1, 'label' => null]);
+    }
+
+    /**
+     * Draft 07: sibling type is ignored. The property keeps the ref's original type (number /
+     * float), so floating-point values are accepted and ref constraints still apply.
+     */
+    #[ApplicableDrafts(until: JsonSchemaDraft::DRAFT_07)]
+    public function testScalarTypeSiblingIgnoredDraft07(): void
+    {
+        $className = $this->generateClassFromFile(
+            'ScalarTypeMerge.json',
+            (new GeneratorConfiguration())->setCollectErrors(false),
+        );
+
+        // Sibling type: integer is ignored; float (number) is still accepted
+        $object = new $className(['count' => 1.5]);
+        $this->assertSame(1.5, $object->getCount());
+    }
+
+    /**
+     * Draft 07: ref's nullable string remains nullable (sibling type: string is ignored).
+     */
+    #[ApplicableDrafts(until: JsonSchemaDraft::DRAFT_07)]
+    public function testNullableRefRemainsNullableDraft07(): void
+    {
+        $className = $this->generateClassFromFile(
+            'ScalarTypeMerge.json',
+            (new GeneratorConfiguration())->setCollectErrors(false),
+        );
+
+        // null accepted: sibling type: string is ignored, ref stays string|null
+        $object = new $className(['count' => 0, 'label' => null]);
+        $this->assertNull($object->getLabel());
+    }
+
+    // -------------------------------------------------------------------------
+    // Scalar type contradiction (Draft 2019-09+ → SchemaException)
+    // -------------------------------------------------------------------------
+
+    /**
+     * Draft 2019-09+: when the sibling type is incompatible with the $ref's resolved type,
+     * schema generation must fail with a SchemaException citing the incompatibility.
+     */
+    #[ApplicableDrafts(from: JsonSchemaDraft::DRAFT_2019_09)]
+    public function testScalarTypeContradictionThrowsSchemaException(): void
+    {
+        $this->expectException(SchemaException::class);
+
+        $this->generateClassFromFile('ScalarTypeConflict.json');
+    }
+
+    /**
+     * Draft 07: the contradictory sibling type is silently ignored, so no SchemaException is
+     * thrown and the ref's type (string) applies.
+     */
+    #[ApplicableDrafts(until: JsonSchemaDraft::DRAFT_07)]
+    public function testScalarTypeContradictionIgnoredDraft07(): void
+    {
+        $className = $this->generateClassFromFile(
+            'ScalarTypeConflict.json',
+            (new GeneratorConfiguration())->setCollectErrors(false),
+        );
+
+        // Sibling type: integer is ignored, so string is accepted
+        $object = new $className(['value' => 'hello']);
+        $this->assertSame('hello', $object->getValue());
+    }
+
+    // -------------------------------------------------------------------------
+    // Root-level pointer assertions (no /allOf/ segment)
+    // -------------------------------------------------------------------------
+
+    /**
+     * Draft 2019-09+: properties contributed by a root-level $ref+siblings schema carry their
+     * authored JSON pointers, not synthetic /allOf/N paths.
+     */
+    #[ApplicableDrafts(from: JsonSchemaDraft::DRAFT_2019_09)]
+    public function testRootLevelRefSiblingPropertyPointersAreAuthored(): void
+    {
+        $className = $this->generateClassFromFile(
+            'NonStructuralPropertySiblings.json',
+            (new GeneratorConfiguration())->setCollectErrors(false),
+        );
+
+        $object = new $className([
+            'withMinLength' => 'Hello',
+            'withEnum'      => 'Alice',
+            'withConst'     => 'fixed',
+        ]);
+
+        // Each property's pointer must reflect its authored location in the schema, not a
+        // synthetic /allOf/N path that the old constructor wrap used to generate.
+        $this->assertPropertyHasJsonPointer($object, 'withMinLength', '/properties/withMinLength');
+        $this->assertPropertyHasJsonPointer($object, 'withEnum', '/properties/withEnum');
+        $this->assertPropertyHasJsonPointer($object, 'withConst', '/properties/withConst');
+    }
+}

--- a/tests/Objects/RefSiblingsTest.php
+++ b/tests/Objects/RefSiblingsTest.php
@@ -481,6 +481,21 @@ class RefSiblingsTest extends AbstractPHPModelGeneratorTestCase
         $this->assertSame('Alice', $object->getName());
     }
 
+    /**
+     * Draft 2019-09+: analogous to testDefaultValuesConflictThrowsSchemaException() above, but
+     * for a plain (non-structural, scalar) property-level $ref+sibling merge instead of a
+     * base-level one — both the ref's definition and the sibling declare conflicting defaults
+     * for the same scalar property, which must be detected the same way at this merge path too.
+     */
+    #[ApplicableDrafts(from: JsonSchemaDraft::DRAFT_2019_09)]
+    public function testPropertyLevelDefaultValuesConflictThrowsSchemaException(): void
+    {
+        $this->expectException(SchemaException::class);
+        $this->expectExceptionMessageMatches('/Conflicting default values for property .name./');
+
+        $this->generateClassFromFile('PropertyLevelDefaultValuesConflict.json');
+    }
+
     // -------------------------------------------------------------------------
     // Root-level pointer assertions (no /allOf/ segment)
     // -------------------------------------------------------------------------

--- a/tests/Objects/RefSiblingsTest.php
+++ b/tests/Objects/RefSiblingsTest.php
@@ -308,6 +308,137 @@ class RefSiblingsTest extends AbstractPHPModelGeneratorTestCase
     }
 
     // -------------------------------------------------------------------------
+    // Object-level type intersection (Draft 2019-09+)
+    // -------------------------------------------------------------------------
+
+    /**
+     * Draft 2019-09+: when a property is declared by both the $ref'd object and a sibling
+     * 'properties' entry, the effective type is their allOf intersection. Here the ref
+     * contributes 'count: number' and the sibling contributes 'count: integer'; the
+     * intersection (integer ⊂ number) narrows the type to int. Float values must be rejected.
+     */
+    #[ApplicableDrafts(from: JsonSchemaDraft::DRAFT_2019_09)]
+    public function testObjectLevelTypeIntersectionNarrowsToInteger(): void
+    {
+        $className = $this->generateClassFromFile(
+            'ObjectLevelTypeIntersection.json',
+            (new GeneratorConfiguration())->setCollectErrors(false),
+        );
+
+        $object = new $className(['count' => 5]);
+        $this->assertSame(5, $object->getCount());
+
+        // float not accepted after narrowing to integer
+        $this->expectException(ValidationException::class);
+
+        new $className(['count' => 1.5]);
+    }
+
+    /**
+     * Draft 2019-09+: the ref's minimum: 0 constraint is preserved after the integer
+     * narrowing — the allOf intersection applies both type and value constraints.
+     */
+    #[ApplicableDrafts(from: JsonSchemaDraft::DRAFT_2019_09)]
+    public function testObjectLevelTypeIntersectionPreservesRefConstraints(): void
+    {
+        $className = $this->generateClassFromFile(
+            'ObjectLevelTypeIntersection.json',
+            (new GeneratorConfiguration())->setCollectErrors(false),
+        );
+
+        $this->expectException(ValidationException::class);
+
+        new $className(['count' => -1]); // violates ref minimum: 0
+    }
+
+    /**
+     * Draft 07: the sibling 'count: integer' entry is silently ignored. The ref's
+     * 'count: number' type (float in PHP) is used as-is, so float values are accepted.
+     */
+    #[ApplicableDrafts(until: JsonSchemaDraft::DRAFT_07)]
+    public function testObjectLevelTypeIntersectionSiblingIgnoredDraft07(): void
+    {
+        $className = $this->generateClassFromFile(
+            'ObjectLevelTypeIntersection.json',
+            (new GeneratorConfiguration())->setCollectErrors(false),
+        );
+
+        // float is accepted: sibling integer narrowing is ignored
+        $object = new $className(['count' => 1.5]);
+        $this->assertSame(1.5, $object->getCount());
+    }
+
+    // -------------------------------------------------------------------------
+    // Default value parity for overlapping $ref + sibling properties (Draft 2019-09+)
+    // -------------------------------------------------------------------------
+
+    /**
+     * Draft 2019-09+: when the $ref'd object and the sibling 'properties' entry declare
+     * the same default for a shared property, generation succeeds and the default is applied.
+     */
+    #[ApplicableDrafts(from: JsonSchemaDraft::DRAFT_2019_09)]
+    public function testDefaultValuesAgreeNoError(): void
+    {
+        $className = $this->generateClassFromFile(
+            'DefaultValuesAgree.json',
+            (new GeneratorConfiguration())->setCollectErrors(false),
+        );
+
+        // Default 'World' applied when property is absent from input
+        $object = new $className([]);
+        $this->assertSame('World', $object->getName());
+    }
+
+    /**
+     * Draft 2019-09+: when the $ref'd object and the sibling 'properties' entry declare
+     * conflicting defaults for the same property, generation must fail with a SchemaException
+     * that cites the authored property pointers — never a synthetic allOf/N path.
+     */
+    #[ApplicableDrafts(from: JsonSchemaDraft::DRAFT_2019_09)]
+    public function testDefaultValuesConflictThrowsSchemaException(): void
+    {
+        $this->expectException(SchemaException::class);
+        $this->expectExceptionMessageMatches('/Conflicting default values for property .name./');
+
+        $this->generateClassFromFile('DefaultValuesConflict.json');
+    }
+
+    /**
+     * Draft 07: sibling 'properties' are ignored, so the conflicting defaults are never
+     * compared and no SchemaException is thrown. Only the ref's default ('Alice') applies.
+     */
+    #[ApplicableDrafts(until: JsonSchemaDraft::DRAFT_07)]
+    public function testDefaultConflictIgnoredDraft07(): void
+    {
+        $className = $this->generateClassFromFile(
+            'DefaultValuesConflict.json',
+            (new GeneratorConfiguration())->setCollectErrors(false),
+        );
+
+        // Sibling default 'Bob' is ignored; only ref default 'Alice' is active.
+        $object = new $className([]);
+        $this->assertSame('Alice', $object->getName());
+    }
+
+    /**
+     * Draft 2019-09+: when a property is declared by the $ref'd object with a default
+     * value and the sibling 'properties' entry for the same property has no default,
+     * the ref's default is propagated to the merged property.
+     */
+    #[ApplicableDrafts(from: JsonSchemaDraft::DRAFT_2019_09)]
+    public function testDefaultValuePropagatedFromRef(): void
+    {
+        $className = $this->generateClassFromFile(
+            'DefaultValuePropagation.json',
+            (new GeneratorConfiguration())->setCollectErrors(false),
+        );
+
+        // Ref's default 'World' propagated even though sibling declared 'name' without a default.
+        $object = new $className([]);
+        $this->assertSame('World', $object->getName());
+    }
+
+    // -------------------------------------------------------------------------
     // Root-level pointer assertions (no /allOf/ segment)
     // -------------------------------------------------------------------------
 

--- a/tests/Objects/RefSiblingsTest.php
+++ b/tests/Objects/RefSiblingsTest.php
@@ -4,14 +4,17 @@ declare(strict_types=1);
 
 namespace PHPModelGenerator\Tests\Objects;
 
+use PHPModelGenerator\Attributes\JsonSchema as JsonSchemaAttribute;
 use PHPModelGenerator\Exception\ErrorRegistryException;
 use PHPModelGenerator\Exception\SchemaException;
 use PHPModelGenerator\Exception\ValidationException;
+use PHPModelGenerator\Model\Attributes\PhpAttribute;
 use PHPModelGenerator\Model\GeneratorConfiguration;
 use PHPModelGenerator\Tests\AbstractPHPModelGeneratorTestCase;
 use PHPModelGenerator\Tests\Support\ApplicableDrafts;
 use PHPModelGenerator\Tests\Support\JsonSchemaDraft;
 use PHPUnit\Framework\Attributes\DataProvider;
+use ReflectionClass;
 
 /**
  * Tests for property-level $ref + non-structural sibling keywords, type parity, and pointer
@@ -20,6 +23,7 @@ use PHPUnit\Framework\Attributes\DataProvider;
  */
 class RefSiblingsTest extends AbstractPHPModelGeneratorTestCase
 {
+    protected const EXTERNAL_JSON_DIRECTORIES = ['../RefSiblingsTest_external'];
     // -------------------------------------------------------------------------
     // $ref alone — unchanged behavior across all drafts
     // -------------------------------------------------------------------------
@@ -465,5 +469,169 @@ class RefSiblingsTest extends AbstractPHPModelGeneratorTestCase
         $this->assertPropertyHasJsonPointer($object, 'withMinLength', '/properties/withMinLength');
         $this->assertPropertyHasJsonPointer($object, 'withEnum', '/properties/withEnum');
         $this->assertPropertyHasJsonPointer($object, 'withConst', '/properties/withConst');
+    }
+
+    // -------------------------------------------------------------------------
+    // Recursive $ref with siblings — no crash (Draft 2019-09+)
+    // -------------------------------------------------------------------------
+
+    /**
+     * Draft 2019-09+: when the $ref'd object contains a recursive self-reference (next →
+     * node), adding a sibling 'label' property at the root must not crash. All three
+     * properties — from the ref (value, next) and from the sibling (label) — must be
+     * accessible on the generated class.
+     */
+    #[ApplicableDrafts(from: JsonSchemaDraft::DRAFT_2019_09)]
+    public function testRecursiveRefWithSiblingsMergesCorrectly(): void
+    {
+        $className = $this->generateClassFromFile('RecursiveRefSiblings.json');
+
+        // All properties — from ref (value, next) and from sibling (label) — must be present.
+        $object = new $className(['value' => 'root', 'label' => 'tag']);
+        $this->assertSame('root', $object->getValue());
+        $this->assertSame('tag', $object->getLabel());
+        $this->assertNull($object->getNext());
+    }
+
+    /**
+     * Draft 07: sibling 'label' is silently ignored; only properties from the $ref'd
+     * recursive object (value, next) appear on the generated class.
+     */
+    #[ApplicableDrafts(until: JsonSchemaDraft::DRAFT_07)]
+    public function testRecursiveRefDraft07SiblingIgnored(): void
+    {
+        $className = $this->generateClassFromFile('RecursiveRefSiblings.json');
+
+        // Only ref properties (value, next) are present; sibling label is absent.
+        $object = new $className(['value' => 'root']);
+        $this->assertSame('root', $object->getValue());
+        $this->assertFalse(method_exists($object, 'getLabel'));
+    }
+
+    // -------------------------------------------------------------------------
+    // External-file $ref with siblings (Draft 2019-09+)
+    // -------------------------------------------------------------------------
+
+    /**
+     * Draft 2019-09+: when the root $ref resolves to an external JSON file and the schema
+     * has sibling 'properties' (city), the generated class must expose both properties from
+     * the external file (street, required) and from the sibling (city, optional).
+     */
+    #[ApplicableDrafts(from: JsonSchemaDraft::DRAFT_2019_09)]
+    public function testExternalFileRefWithSiblingsMerged(): void
+    {
+        $className = $this->generateClassFromFile('ExternalRefSiblings.json');
+
+        // street (from external ref, required) and city (from sibling) both accessible.
+        $object = new $className(['street' => 'Main St', 'city' => 'Berlin']);
+        $this->assertSame('Main St', $object->getStreet());
+        $this->assertSame('Berlin', $object->getCity());
+    }
+
+    /**
+     * Draft 2019-09+: the external ref's required constraint (street) is enforced.
+     */
+    #[ApplicableDrafts(from: JsonSchemaDraft::DRAFT_2019_09)]
+    public function testExternalFileRefEnforcesRefConstraints(): void
+    {
+        $className = $this->generateClassFromFile(
+            'ExternalRefSiblings.json',
+            (new GeneratorConfiguration())->setCollectErrors(true),
+        );
+
+        $this->expectException(ErrorRegistryException::class);
+
+        new $className(['city' => 'Berlin']); // missing required 'street' from external ref
+    }
+
+    /**
+     * Draft 07: sibling 'city' is silently ignored; only properties from the external
+     * $ref file (street) appear on the generated class.
+     */
+    #[ApplicableDrafts(until: JsonSchemaDraft::DRAFT_07)]
+    public function testExternalFileRefDraft07SiblingIgnored(): void
+    {
+        $className = $this->generateClassFromFile('ExternalRefSiblings.json');
+
+        // Only ref property 'street' is present; sibling 'city' is absent.
+        $object = new $className(['street' => 'Main St']);
+        $this->assertSame('Main St', $object->getStreet());
+        $this->assertFalse(method_exists($object, 'getCity'));
+    }
+
+    // -------------------------------------------------------------------------
+    // {$ref, siblings} nested inside a real allOf branch (Draft 2019-09+)
+    // -------------------------------------------------------------------------
+
+    /**
+     * Draft 2019-09+: when an allOf branch contains {$ref → location, properties: {city}},
+     * the branch is treated as an object×object merge — the resulting nested class for
+     * 'address' exposes both properties from the ref (street) and from the sibling (city).
+     */
+    #[ApplicableDrafts(from: JsonSchemaDraft::DRAFT_2019_09)]
+    public function testRefSiblingsInsideAllOfBranchMerged(): void
+    {
+        $className = $this->generateClassFromFile('RefSiblingsInsideAllOf.json');
+
+        $object  = new $className(['address' => ['street' => 'Main St', 'city' => 'Berlin']]);
+        $address = $object->getAddress();
+
+        $this->assertSame('Main St', $address->getStreet());
+        $this->assertSame('Berlin', $address->getCity());
+    }
+
+    /**
+     * Draft 07: when an allOf branch contains {$ref → location, properties: {city}}, the
+     * sibling 'city' is silently ignored (ExclusiveProducer). Only the ref's property
+     * 'street' is present on the nested address object.
+     */
+    #[ApplicableDrafts(until: JsonSchemaDraft::DRAFT_07)]
+    public function testRefSiblingsInsideAllOfBranchDraft07SiblingIgnored(): void
+    {
+        $className = $this->generateClassFromFile('RefSiblingsInsideAllOf.json');
+
+        $object  = new $className(['address' => ['street' => 'Main St']]);
+        $address = $object->getAddress();
+
+        $this->assertSame('Main St', $address->getStreet());
+        $this->assertFalse(method_exists($address, 'getCity'));
+    }
+
+    // -------------------------------------------------------------------------
+    // #[JsonSchema] attribute reflects authored schema, not synthetic allOf
+    // -------------------------------------------------------------------------
+
+    /**
+     * Draft 2019-09+: the #[JsonSchema] PHP attribute attached to the generated class must
+     * encode the authored schema (with $ref and properties at the top level), not a
+     * synthetic allOf wrapper that the old JsonSchema constructor used to inject.
+     */
+    #[ApplicableDrafts(from: JsonSchemaDraft::DRAFT_2019_09)]
+    public function testJsonSchemaAttributeReflectsAuthoredSchema(): void
+    {
+        $configuration = (new GeneratorConfiguration())
+            ->setCollectErrors(false)
+            ->setEnabledAttributes(PhpAttribute::JSON_SCHEMA | PhpAttribute::JSON_POINTER);
+
+        $className = $this->generateClassFromFile('ObjectLevelTypeIntersection.json', $configuration);
+
+        $classAttributes = (new ReflectionClass($className))->getAttributes();
+
+        $jsonSchemaAttr = null;
+        foreach ($classAttributes as $attr) {
+            if ($attr->getName() === JsonSchemaAttribute::class) {
+                $jsonSchemaAttr = $attr;
+                break;
+            }
+        }
+
+        $this->assertNotNull($jsonSchemaAttr, '#[JsonSchema] attribute missing from generated class');
+
+        $jsonSchemaArg = $jsonSchemaAttr->getArguments()[0];
+
+        // The authored $ref must be present at the top level of the embedded schema.
+        $this->assertStringContainsString('"$ref"', $jsonSchemaArg);
+        // A synthetic allOf wrapper must not appear — the schema is authored directly.
+        $this->assertStringNotContainsString('"allOf"', $jsonSchemaArg);
     }
 }

--- a/tests/Objects/RefSiblingsTest.php
+++ b/tests/Objects/RefSiblingsTest.php
@@ -598,6 +598,55 @@ class RefSiblingsTest extends AbstractPHPModelGeneratorTestCase
     }
 
     // -------------------------------------------------------------------------
+    // Object-level multi-type collision — reapplyTypeSpecificRefConstraints no-op
+    // -------------------------------------------------------------------------
+
+    /**
+     * Draft 2019-09+: when a property is declared by both the root schema and the $ref'd
+     * object with identical multi-type arrays (["string", "integer"]), the type intersection
+     * equals the existing type — no narrowing occurs. reapplyTypeSpecificRefConstraints returns
+     * early because the effective type is multi-type (not a single scalar), so the property
+     * continues to accept both string and integer values.
+     */
+    #[ApplicableDrafts(from: JsonSchemaDraft::DRAFT_2019_09)]
+    public function testObjectLevelMultiTypeCollisionPreservesMultiType(): void
+    {
+        $className = $this->generateClassFromFile(
+            'ObjectLevelMultiTypeCollision.json',
+            (new GeneratorConfiguration())->setCollectErrors(false),
+        );
+
+        $objectWithString = new $className(['count' => 'hello']);
+        $this->assertSame('hello', $objectWithString->getCount());
+
+        $objectWithInt = new $className(['count' => 42]);
+        $this->assertSame(42, $objectWithInt->getCount());
+    }
+
+    // -------------------------------------------------------------------------
+    // Untyped $ref with scalar sibling — applyScalarSiblingMerge early return
+    // -------------------------------------------------------------------------
+
+    /**
+     * Draft 2019-09+: when a $ref definition carries no 'type' keyword and the property also
+     * has scalar sibling keywords (minLength), the effective type cannot be determined from the
+     * ref. The scalar merge path transfers the ref's own validators (none, since an untyped ref
+     * does not produce type-specific validators) and returns without applying the sibling's
+     * type-specific constraints. Generation must succeed without error.
+     */
+    #[ApplicableDrafts(from: JsonSchemaDraft::DRAFT_2019_09)]
+    public function testUntypedRefWithScalarSiblingGeneratesSuccessfully(): void
+    {
+        $className = $this->generateClassFromFile(
+            'UntypedRefWithScalarSibling.json',
+            (new GeneratorConfiguration())->setCollectErrors(false),
+        );
+
+        $object = new $className(['name' => 'hello']);
+        $this->assertSame('hello', $object->getName());
+    }
+
+    // -------------------------------------------------------------------------
     // #[JsonSchema] attribute reflects authored schema, not synthetic allOf
     // -------------------------------------------------------------------------
 

--- a/tests/Objects/RefSiblingsTest.php
+++ b/tests/Objects/RefSiblingsTest.php
@@ -442,6 +442,45 @@ class RefSiblingsTest extends AbstractPHPModelGeneratorTestCase
         $this->assertSame('World', $object->getName());
     }
 
+    /**
+     * Draft 2019-09+: PropertyMerger::merge() reconciles defaults on every path that can merge a
+     * $ref'd property into a sibling-declared slot, not just the typed intersection path exercised
+     * by testDefaultValuesConflictThrowsSchemaException() above. When the $ref'd definition's
+     * property carries no type keyword at all (genuinely untyped, not an explicit "type":"null"
+     * branch), it still merges via the same allOf-style path and its default must still be
+     * reconciled against the sibling's.
+     */
+    #[ApplicableDrafts(from: JsonSchemaDraft::DRAFT_2019_09)]
+    public function testDefaultValuesConflictWithUntypedRefPropertyThrowsSchemaException(): void
+    {
+        $this->expectException(SchemaException::class);
+        $this->expectExceptionMessageMatches('/Conflicting default values for property .name./');
+
+        $this->generateClassFromFile('DefaultValuesConflictUntypedRef.json');
+    }
+
+    /**
+     * Draft 2019-09+: analogous to testDefaultValuePropagatedFromRef() above, but for the
+     * null-type-sibling merge path — the sibling declares "name" as an explicit "type":"null"
+     * with no default, which is merged via PropertyMerger::mergeIntoExistingNull() rather than
+     * the typed-intersection path, and must still propagate the ref's default onto the merged
+     * (now nullable-string) property. A true conflict can't be constructed for this path: a
+     * "type":"null" property is rejected earlier in the pipeline if it declares any non-null
+     * default, so the only reachable pairing is "no default" vs "a default" — propagation.
+     */
+    #[ApplicableDrafts(from: JsonSchemaDraft::DRAFT_2019_09)]
+    public function testDefaultValuePropagatedFromRefWithNullTypedSibling(): void
+    {
+        $className = $this->generateClassFromFile(
+            'DefaultValuePropagationWithNullTypedSibling.json',
+            (new GeneratorConfiguration())->setCollectErrors(false),
+        );
+
+        // Ref's default 'Alice' propagated even though the null-typed sibling had none.
+        $object = new $className([]);
+        $this->assertSame('Alice', $object->getName());
+    }
+
     // -------------------------------------------------------------------------
     // Root-level pointer assertions (no /allOf/ segment)
     // -------------------------------------------------------------------------

--- a/tests/Objects/ReferencePropertyTest.php
+++ b/tests/Objects/ReferencePropertyTest.php
@@ -1215,4 +1215,119 @@ class ReferencePropertyTest extends AbstractPHPModelGeneratorTestCase
         $this->expectException(ErrorRegistryException::class);
         new $className([]);
     }
+
+    // Draft 2019-09+: $ref with scalar/array sibling constraints.
+
+    /**
+     * Draft 2019-09+: a sibling minLength alongside a string $ref is enforced. The property
+     * accepts any string when the constraint is met and rejects strings that are too short.
+     *
+     * @throws FileSystemException
+     * @throws RenderException
+     * @throws SchemaException
+     */
+    #[ApplicableDrafts(from: JsonSchemaDraft::DRAFT_2019_09)]
+    public function testRefWithPropertyLevelScalarSiblingsApplyForDraft201909(): void
+    {
+        $className = $this->generateClassFromFile(
+            'RefWithPropertyLevelScalarSiblings.json',
+            (new GeneratorConfiguration())->setCollectErrors(true),
+        );
+
+        // Happy path: name is absent (optional) or at least 3 characters long.
+        $object = new $className([]);
+        $this->assertNull($object->getName());
+
+        $object = new $className(['name' => 'Alice']);
+        $this->assertSame('Alice', $object->getName());
+
+        // Violation: name is present but shorter than minLength: 3.
+        $this->expectException(ErrorRegistryException::class);
+        $this->expectExceptionMessage('Value for name must not be shorter than 3');
+        new $className(['name' => 'Jo']);
+    }
+
+    /**
+     * Draft 07: a sibling minLength alongside a string $ref is silently ignored. Short strings
+     * that would violate the sibling constraint are accepted.
+     *
+     * @throws FileSystemException
+     * @throws RenderException
+     * @throws SchemaException
+     */
+    #[ApplicableDrafts(until: JsonSchemaDraft::DRAFT_07)]
+    public function testRefWithPropertyLevelScalarSiblingsIgnoredForDraft07(): void
+    {
+        $className = $this->generateClassFromFile('RefWithPropertyLevelScalarSiblings.json');
+
+        // The sibling minLength is not applied under Draft 07, so short strings are accepted.
+        $object = new $className(['name' => 'Jo']);
+        $this->assertSame('Jo', $object->getName());
+    }
+
+    /**
+     * Draft 2019-09+: a sibling 'type: integer' alongside a 'number' $ref narrows the
+     * effective type to integer. Float values are rejected by the TypeCheck validator.
+     *
+     * @throws FileSystemException
+     * @throws RenderException
+     * @throws SchemaException
+     */
+    #[ApplicableDrafts(from: JsonSchemaDraft::DRAFT_2019_09)]
+    public function testRefWithPropertyLevelTypeNarrowingForDraft201909(): void
+    {
+        $className = $this->generateClassFromFile(
+            'RefWithPropertyLevelTypeNarrowing.json',
+            (new GeneratorConfiguration())->setCollectErrors(true),
+        );
+
+        // Integer value satisfies both the $ref number type and the sibling integer type.
+        $object = new $className(['score' => 42]);
+        $this->assertSame(42, $object->getScore());
+
+        // Float value is rejected: the effective type after intersection is integer only.
+        $this->expectException(ErrorRegistryException::class);
+        $this->expectExceptionMessage('Invalid type for score. Requires int, got double');
+        new $className(['score' => 42.5]);
+    }
+
+    /**
+     * Draft 07: a sibling 'type' alongside a $ref is silently ignored. The effective type
+     * remains the $ref type (number), so float values are accepted.
+     *
+     * @throws FileSystemException
+     * @throws RenderException
+     * @throws SchemaException
+     */
+    #[ApplicableDrafts(until: JsonSchemaDraft::DRAFT_07)]
+    public function testRefWithPropertyLevelTypeNarrowingIgnoredForDraft07(): void
+    {
+        $className = $this->generateClassFromFile('RefWithPropertyLevelTypeNarrowing.json');
+
+        // Under Draft 07 the sibling type is ignored: the $ref number type accepts floats.
+        $object = new $className(['score' => 42.5]);
+        $this->assertSame(42.5, $object->getScore());
+    }
+
+    /**
+     * Draft 2019-09+: a sibling 'type' that is incompatible with the $ref type produces a
+     * SchemaException at generation time.
+     *
+     * @throws FileSystemException
+     * @throws RenderException
+     * @throws SchemaException
+     */
+    #[ApplicableDrafts(from: JsonSchemaDraft::DRAFT_2019_09)]
+    public function testRefWithPropertyLevelTypeConflictThrowsForDraft201909(): void
+    {
+        $this->expectException(SchemaException::class);
+        // The exception is thrown against the temp-copy of the schema (the test harness
+        // copies schemas to a session temp directory before processing). The file path
+        // in the message is the temp-copy path, so match only the invariant parts.
+        $this->expectExceptionMessageMatches(<<<'PATTERN'
+            /Property 'name' in file '.*': \$ref resolves to type 'string' but sibling 'type' declares 'integer'; the types are incompatible/
+            PATTERN);
+
+        $this->generateClassFromFile('RefWithPropertyLevelTypeConflict.json');
+    }
 }

--- a/tests/Objects/ReferencePropertyTest.php
+++ b/tests/Objects/ReferencePropertyTest.php
@@ -44,8 +44,12 @@ class ReferencePropertyTest extends AbstractPHPModelGeneratorTestCase
     public static function internalReferenceProvider(): array
     {
         return [
-            'Internal path reference' => ['#/definitions/person'],
+            'Internal path reference'  => ['#/definitions/person'],
             'Internal direct reference' => ['#person'],
+            // Empty string: getDefinition('') returns null (not via exception) because an empty
+            // JSON schema file path is falsy — exercises the throw at the end of resolveReference
+            // rather than the catch-rethrow path above it.
+            'Empty string reference'   => [''],
         ];
     }
 

--- a/tests/Objects/ReferencePropertyTest.php
+++ b/tests/Objects/ReferencePropertyTest.php
@@ -1486,7 +1486,6 @@ class ReferencePropertyTest extends AbstractPHPModelGeneratorTestCase
         // but 'single' (an optional plain property) must keep its own nullable getter type hint
         // rather than inheriting the array item's non-nullable one.
         $itemClass = $object->getList()[0]::class;
-        $returnType = (new ReflectionClass($className))->getMethod('getSingle')->getReturnType();
-        $this->assertSame('?' . $itemClass, (string) $returnType);
+        $this->assertSame([$itemClass, 'null'], $this->getReturnTypeNames($className, 'getSingle'));
     }
 }

--- a/tests/Objects/ReferencePropertyTest.php
+++ b/tests/Objects/ReferencePropertyTest.php
@@ -1462,4 +1462,31 @@ class ReferencePropertyTest extends AbstractPHPModelGeneratorTestCase
 
         $this->generateClassFromFile('RefWithPropertyLevelTypeConflict.json');
     }
+
+    /**
+     * The same $ref used both as an array's `items` and as a plain optional object property must
+     * not share metadata (isArrayItem, isRequired) between the two usages, even when implicit
+     * null is disabled (the default). SchemaDefinition::resolveReference() caches the resolved
+     * property per (path, required, isArrayItem, dependencies); dropping isArrayItem from that
+     * key whenever implicit null is off would collide these two usages onto one shared property,
+     * silently flipping the optional 'single' property's generated getter from nullable to
+     * non-nullable because RenderHelper::isPropertyNullable() bases output-type nullability on
+     * !isRequired() regardless of the implicit-null setting. Implicit null is explicitly disabled
+     * here since that is precisely the condition under which such a gated key would collide.
+     */
+    public function testSharedRefAsArrayItemAndObjectPropertyKeepIndependentNullability(): void
+    {
+        $className = $this->generateClassFromFile('SharedRefAsArrayItemAndObjectProperty.json', implicitNull: false);
+
+        $object = new $className(['list' => [['name' => 'Alice']]]);
+        $this->assertNull($object->getSingle());
+        $this->assertSame('Alice', $object->getList()[0]->getName());
+
+        // 'list' items and 'single' resolve the same $ref and must share one generated class,
+        // but 'single' (an optional plain property) must keep its own nullable getter type hint
+        // rather than inheriting the array item's non-nullable one.
+        $itemClass = $object->getList()[0]::class;
+        $returnType = (new ReflectionClass($className))->getMethod('getSingle')->getReturnType();
+        $this->assertSame('?' . $itemClass, (string) $returnType);
+    }
 }

--- a/tests/Objects/ReferencePropertyTest.php
+++ b/tests/Objects/ReferencePropertyTest.php
@@ -1280,7 +1280,7 @@ class ReferencePropertyTest extends AbstractPHPModelGeneratorTestCase
 
         // Violation: name is present but shorter than minLength: 3.
         $this->expectException(ErrorRegistryException::class);
-        $this->expectExceptionMessage('Value for name must not be shorter than 3');
+        $this->expectExceptionMessage("Value for 'name' must not be shorter than 3");
         new $className(['name' => 'Jo']);
     }
 
@@ -1324,7 +1324,7 @@ class ReferencePropertyTest extends AbstractPHPModelGeneratorTestCase
 
         // Float value is rejected: the effective type after intersection is integer only.
         $this->expectException(ErrorRegistryException::class);
-        $this->expectExceptionMessage('Invalid type for score. Requires int, got double');
+        $this->expectExceptionMessage("Invalid type for 'score': requires 'int', got 'double'");
         new $className(['score' => 42.5]);
     }
 

--- a/tests/Objects/ReferencePropertyTest.php
+++ b/tests/Objects/ReferencePropertyTest.php
@@ -17,6 +17,7 @@ use ReflectionClass;
 use stdClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPModelGenerator\Tests\Support\ApplicableDrafts;
+use PHPModelGenerator\Tests\Support\JsonSchemaDraft;
 use PHPUnit\Framework\Attributes\WithoutErrorHandler;
 
 /**
@@ -209,7 +210,7 @@ class ReferencePropertyTest extends AbstractPHPModelGeneratorTestCase
         return [
             'Internal path reference' => ['#/definitions/yearBetween1900and2000'],
             'Internal direct reference' => ['#yearBetween1900and2000'],
-            'External path reference' => ['../ReferencePropertyTest_external/library.json#/definitions/yearBetween1900and2000'],
+            'External path reference' => ['../ReferencePropertyTest_external/library.json#/definitions/yearBetween1900and2000'], // phpcs:ignore Generic.Files.LineLength.TooLong
             'External direct reference' => ['../ReferencePropertyTest_external/library.json#yearBetween1900and2000'],
         ];
     }
@@ -264,10 +265,10 @@ class ReferencePropertyTest extends AbstractPHPModelGeneratorTestCase
     public static function recursiveExternalReferenceProvider(): array
     {
         return [
-            'external path reference to direct recursion' => ['../ReferencePropertyTest_external/recursiveLibrary.json#/definitions/personDirect'],
-            'external direct reference to direct recursion' => ['../ReferencePropertyTest_external/recursiveLibrary.json#personDirect'],
-            'external path reference to path recursion' => ['../ReferencePropertyTest_external/recursiveLibrary.json#/definitions/personPath'],
-            'external direct reference to path recursion' => ['../ReferencePropertyTest_external/recursiveLibrary.json#personPath'],
+            'external path reference to direct recursion' => ['../ReferencePropertyTest_external/recursiveLibrary.json#/definitions/personDirect'], // phpcs:ignore Generic.Files.LineLength.TooLong
+            'external direct reference to direct recursion' => ['../ReferencePropertyTest_external/recursiveLibrary.json#personDirect'], // phpcs:ignore Generic.Files.LineLength.TooLong
+            'external path reference to path recursion' => ['../ReferencePropertyTest_external/recursiveLibrary.json#/definitions/personPath'], // phpcs:ignore Generic.Files.LineLength.TooLong
+            'external direct reference to path recursion' => ['../ReferencePropertyTest_external/recursiveLibrary.json#personPath'], // phpcs:ignore Generic.Files.LineLength.TooLong
         ];
     }
 
@@ -276,7 +277,10 @@ class ReferencePropertyTest extends AbstractPHPModelGeneratorTestCase
         return array_merge(
             self::combineDataProvider(self::internalReferenceProvider(), self::internalReferenceProvider()),
             self::combineDataProvider(static::recursiveExternalReferenceProvider(), self::internalReferenceProvider()),
-            self::combineDataProvider(static::recursiveExternalReferenceProvider(), static::recursiveExternalReferenceProvider()),
+            self::combineDataProvider(
+                static::recursiveExternalReferenceProvider(),
+                static::recursiveExternalReferenceProvider(),
+            ),
         );
     }
 
@@ -685,7 +689,7 @@ class ReferencePropertyTest extends AbstractPHPModelGeneratorTestCase
             ],
             'network reference - absolute path to full URL $id' => [
                 $baseURL . 'ReferencePropertyTest/NestedExternalReference.json',
-                '/wol-soft/php-json-schema-model-generator/master/tests/Schema/ReferencePropertyTest_external/library.json',
+                '/wol-soft/php-json-schema-model-generator/master/tests/Schema/ReferencePropertyTest_external/library.json', // phpcs:ignore Generic.Files.LineLength.TooLong
             ],
         ];
     }
@@ -696,7 +700,10 @@ class ReferencePropertyTest extends AbstractPHPModelGeneratorTestCase
     {
         $this->expectException(SchemaException::class);
         $this->expectExceptionMessageMatches(
-            sprintf('/Unresolved Reference %s#\/definitions\/family in file .*\.json/', str_replace('/', '\/', $reference)),
+            sprintf(
+                '/Unresolved Reference %s#\/definitions\/family in file .*\.json/',
+                str_replace('/', '\/', $reference),
+            ),
         );
 
         $this->generateClassFromFileTemplate('NestedExternalReference.json', [$id, $reference]);
@@ -725,7 +732,7 @@ class ReferencePropertyTest extends AbstractPHPModelGeneratorTestCase
             ],
             'network reference - absolute path to full URL $id' => [
                 $baseURL . 'ReferencePropertyTest/NestedExternalReference.json',
-                '/wol-soft/php-json-schema-model-generator/master/tests/Schema/ReferencePropertyTest_external/nonexistent.json',
+                '/wol-soft/php-json-schema-model-generator/master/tests/Schema/ReferencePropertyTest_external/nonexistent.json', // phpcs:ignore Generic.Files.LineLength.TooLong
             ],
         ];
     }
@@ -1100,5 +1107,112 @@ class ReferencePropertyTest extends AbstractPHPModelGeneratorTestCase
         $object = new $className([]);
         $this->assertPropertyHasJsonPointer($object, 'label', '/properties/label');
         $this->assertPropertyHasJsonPointer($object, 'child', '/properties/child');
+    }
+
+    // Draft 2019-09+: $ref and sibling keywords apply simultaneously (conjunction).
+
+    /**
+     * Draft 2019-09+: both ref properties and sibling properties appear on the generated class;
+     * pointers reflect the authored schema locations without a synthetic /allOf/ segment.
+     *
+     * @throws FileSystemException
+     * @throws RenderException
+     * @throws SchemaException
+     */
+    #[ApplicableDrafts(from: JsonSchemaDraft::DRAFT_2019_09)]
+    public function testRefWithSiblingsBothApplyForDraft201909(): void
+    {
+        $className = $this->generateClassFromFile('RefWithSiblings.json');
+
+        $object = new $className(['name' => 'Alice', 'street' => 'Main St']);
+
+        // Both ref properties (street, city) and sibling properties (name, zip) are present.
+        $this->assertSame('Alice', $object->getName());
+        $this->assertSame('Main St', $object->getStreet());
+        $this->assertNull($object->getZip());
+        $this->assertNull($object->getCity());
+
+        // Sibling properties point to where they appear in the authored schema.
+        $this->assertPropertyHasJsonPointer($object, 'name', '/properties/name');
+        $this->assertPropertyHasJsonPointer($object, 'zip', '/properties/zip');
+
+        // Ref properties point into the referenced definition, not into a synthetic /allOf.
+        $this->assertPropertyHasJsonPointer($object, 'street', '/definitions/address/properties/street');
+        $this->assertPropertyHasJsonPointer($object, 'city', '/definitions/address/properties/city');
+    }
+
+    /**
+     * Draft 2019-09+: missing required fields (from either the ref or the sibling) trigger a
+     * validation error.
+     *
+     * @throws FileSystemException
+     * @throws RenderException
+     * @throws SchemaException
+     */
+    #[ApplicableDrafts(from: JsonSchemaDraft::DRAFT_2019_09)]
+    #[DataProvider('invalidRefWithSiblingsDataProvider')]
+    public function testRefWithSiblingsMissingRequiredThrowsForDraft201909(array $data): void
+    {
+        $className = $this->generateClassFromFile(
+            'RefWithSiblings.json',
+            (new GeneratorConfiguration())->setCollectErrors(true),
+        );
+
+        $this->expectException(ErrorRegistryException::class);
+
+        new $className($data);
+    }
+
+    public static function invalidRefWithSiblingsDataProvider(): array
+    {
+        return [
+            // Sibling-required field missing
+            'missing sibling-required name' => [['street' => 'Main St']],
+            // Ref-required field missing
+            'missing ref-required street'   => [['name' => 'Alice']],
+            // Both required fields missing
+            'missing both required'         => [[]],
+            // Sibling property with wrong type
+            'invalid zip type'              => [['name' => 'Alice', 'street' => 'Main St', 'zip' => 'ABC']],
+            // Ref property with wrong type
+            'invalid city type'             => [['name' => 'Alice', 'street' => 'Main St', 'city' => 42]],
+        ];
+    }
+
+    /**
+     * Draft 07: $ref siblings are silently ignored — only the referenced schema's properties
+     * appear on the generated class and only the ref's required constraint is enforced.
+     *
+     * @throws FileSystemException
+     * @throws RenderException
+     * @throws SchemaException
+     */
+    #[ApplicableDrafts(until: JsonSchemaDraft::DRAFT_07)]
+    public function testRefWithSiblingsSilentlyDroppedForDraft07(): void
+    {
+        // Section 1: sibling properties (name, zip) and sibling-required (name) are absent.
+        $className = $this->generateClassFromFile('RefWithSiblings.json');
+
+        $object = new $className(['street' => 'Main St']);
+
+        $this->assertSame('Main St', $object->getStreet());
+        $this->assertNull($object->getCity());
+        $this->assertFalse(method_exists($object, 'getName'));
+        $this->assertFalse(method_exists($object, 'getZip'));
+
+        // Section 2: with error collection — sibling-required (name) is dropped, but
+        // ref-required (street) is still enforced.
+        $className = $this->generateClassFromFile(
+            'RefWithSiblings.json',
+            (new GeneratorConfiguration())->setCollectErrors(true),
+        );
+
+        // name is a sibling-required field, so providing no name is valid under Draft 07.
+        $object = new $className(['street' => 'Main St']);
+        $this->assertSame('Main St', $object->getStreet());
+
+        // Ref-required constraint on street still fires.
+        $this->expectException(ErrorRegistryException::class);
+        new $className([]);
     }
 }

--- a/tests/Objects/ReferencePropertyTest.php
+++ b/tests/Objects/ReferencePropertyTest.php
@@ -46,11 +46,19 @@ class ReferencePropertyTest extends AbstractPHPModelGeneratorTestCase
         return [
             'Internal path reference'  => ['#/definitions/person'],
             'Internal direct reference' => ['#person'],
-            // Empty string: getDefinition('') returns null (not via exception) because an empty
-            // JSON schema file path is falsy — exercises the throw at the end of resolveReference
-            // rather than the catch-rethrow path above it.
-            'Empty string reference'   => [''],
         ];
+    }
+
+    /**
+     * internalReferenceProvider() plus the empty-string $ref form, for use at a position nested
+     * inside the "person" $id scope (e.g. the "children" array's items). There, an empty $ref
+     * resolves to the enclosing "#person" scope (RFC 3986 base-URI scoping) and is a real,
+     * spec-valid recursive-schema idiom - unlike at the document's own top level (see
+     * internalReferenceProvider()), it is not a stand-in for a named reference.
+     */
+    public static function recursiveInternalReferenceProvider(): array
+    {
+        return self::internalReferenceProvider() + ['Empty string reference' => ['']];
     }
 
     public static function externalReferenceProvider(): array
@@ -133,6 +141,30 @@ class ReferencePropertyTest extends AbstractPHPModelGeneratorTestCase
                 'Null' => [null, 'null'],
             ],
         );
+    }
+
+    /**
+     * A property-level $ref: "" resolves to the enclosing document's own root (RFC 3986
+     * §5.2.2's empty path/fragment case), not to a named "person" definition living elsewhere in
+     * the same file - "person" ends up typed as another instance of the outer schema itself
+     * (which only has a "person" property), not as the definitions.person shape (which has
+     * name/age). This is a distinct, legitimate recursive pattern, not an alias for the named
+     * forms covered by validReferenceObjectInputProvider() above.
+     *
+     * @throws FileSystemException
+     * @throws RenderException
+     * @throws SchemaException
+     */
+    public function testPropertyReferencingDocumentRootIsValid(): void
+    {
+        $className = $this->generateClassFromFileTemplate('ObjectReference.json', ['']);
+
+        $object = new $className([]);
+        $this->assertNull($object->getPerson());
+
+        $object = new $className(['person' => ['person' => null]]);
+        $this->assertInstanceOf($className, $object->getPerson());
+        $this->assertNull($object->getPerson()->getPerson());
     }
 
     /**
@@ -288,7 +320,7 @@ class ReferencePropertyTest extends AbstractPHPModelGeneratorTestCase
     public static function combinedReferenceProvider(): array
     {
         return array_merge(
-            self::combineDataProvider(self::internalReferenceProvider(), self::internalReferenceProvider()),
+            self::combineDataProvider(self::recursiveInternalReferenceProvider(), self::internalReferenceProvider()),
             self::combineDataProvider(static::recursiveExternalReferenceProvider(), self::internalReferenceProvider()),
             self::combineDataProvider(
                 static::recursiveExternalReferenceProvider(),
@@ -393,7 +425,7 @@ class ReferencePropertyTest extends AbstractPHPModelGeneratorTestCase
         // external definition the internal definition is never used and thus can be ignored
         return array_merge(
             self::combineDataProvider(
-                self::internalReferenceProvider(),
+                self::recursiveInternalReferenceProvider(),
                 self::invalidInternalReferenceObjectPropertyTypeDataProvider(),
             ),
             self::combineDataProvider(
@@ -401,7 +433,7 @@ class ReferencePropertyTest extends AbstractPHPModelGeneratorTestCase
                 self::invalidInternalReferenceObjectPropertyTypeDataProvider(),
             ),
             self::combineDataProvider(
-                self::internalReferenceProvider(),
+                self::recursiveInternalReferenceProvider(),
                 self::combineDataProvider(
                     static::recursiveExternalReferenceProvider(),
                     static::invalidObjectPropertyTypeDataProvider(),
@@ -752,12 +784,69 @@ class ReferencePropertyTest extends AbstractPHPModelGeneratorTestCase
         ];
     }
 
+    /**
+     * An absolute external $ref written inside a $id-scoped subschema (here: definitions.person)
+     * resolves against that scope's own $id, not the document's top-level $id (there is none in
+     * this schema) - proving SchemaDefinitionDictionary::parseExternalFile() picks up
+     * JsonSchema::getBaseId() (the nearest enclosing $id) rather than always the document root's.
+     * An absolute-style ref is used deliberately (mirroring
+     * testNestedExternalReference()'s "absolute path to full URL $id" case): it can never
+     * coincidentally resolve via the local-file fallback the way a relative ref could, since
+     * getLocalRefPath() would need a matching ancestor directory literally named "wol-soft" -
+     * this makes success possible only via the network URL built from the correct $id.
+     *
+     * @throws FileSystemException
+     * @throws RenderException
+     * @throws SchemaException
+     */
+    public function testNestedIdScopedExternalReferenceIsResolvedAgainstItsOwnId(): void
+    {
+        $baseURL = 'https://raw.githubusercontent.com/wol-soft/php-json-schema-model-generator/master/tests/Schema/';
+
+        $className = $this->generateClassFromFileTemplate(
+            'NestedIdScopedExternalReference.json',
+            [$baseURL . 'ReferencePropertyTest/NestedExternalReference.json'],
+        );
+
+        $object = new $className(['person' => ['colleague' => ['name' => 'Hannes', 'age' => 42]]]);
+
+        $this->assertSame('Hannes', $object->getPerson()->getColleague()->getName());
+        $this->assertSame(42, $object->getPerson()->getColleague()->getAge());
+    }
+
     public function testInvalidBaseReferenceThrowsAnException(): void
     {
         $this->expectException(SchemaException::class);
         $this->expectExceptionMessage('A referenced schema on base level must provide an object definition');
 
         $this->generateClassFromFile('InvalidBaseReference.json');
+    }
+
+    /**
+     * '' and '#' both resolve to the schema's own document root (RFC 3986 §5.2.2's empty
+     * path/fragment case). Referencing it at the base level would merge the schema with itself,
+     * which has no fixed point - PropertyProxy::getNestedSchema() would need to fully resolve the
+     * schema in order to build the schema. Unlike the same forms at a nested property position
+     * (see testPropertyReferencingDocumentRootIsValid()), there is no containment boundary here
+     * to give instance data a way to terminate, so this is rejected outright.
+     */
+    #[DataProvider('baseReferenceSelfReferenceProvider')]
+    public function testBaseReferenceSelfReferenceThrowsAnException(string $reference): void
+    {
+        $this->expectException(SchemaException::class);
+        $this->expectExceptionMessageMatches(
+            "/^A referenced schema on base level must not reference itself for property '.+' in file .+\.json$/",
+        );
+
+        $this->generateClassFromFileTemplate('BaseReference.json', [$reference]);
+    }
+
+    public static function baseReferenceSelfReferenceProvider(): array
+    {
+        return [
+            'Empty string reference' => [''],
+            'Root fragment reference' => ['#'],
+        ];
     }
 
     /**

--- a/tests/Objects/ReferencePropertyTest.php
+++ b/tests/Objects/ReferencePropertyTest.php
@@ -1324,9 +1324,11 @@ class ReferencePropertyTest extends AbstractPHPModelGeneratorTestCase
         // The exception is thrown against the temp-copy of the schema (the test harness
         // copies schemas to a session temp directory before processing). The file path
         // in the message is the temp-copy path, so match only the invariant parts.
-        $this->expectExceptionMessageMatches(<<<'PATTERN'
-            /Property 'name' in file '.*': \$ref resolves to type 'string' but sibling 'type' declares 'integer'; the types are incompatible/
-            PATTERN);
+        $this->expectExceptionMessageMatches(
+            '/Property \'name\' in file \'.*\':'
+            . ' \$ref resolves to type \'string\' but sibling \'type\' declares \'integer\';'
+            . ' the types are incompatible/',
+        );
 
         $this->generateClassFromFile('RefWithPropertyLevelTypeConflict.json');
     }

--- a/tests/PostProcessor/EnumPostProcessorTest.php
+++ b/tests/PostProcessor/EnumPostProcessorTest.php
@@ -635,6 +635,27 @@ class EnumPostProcessorTest extends AbstractPHPModelGeneratorTestCase
         ];
     }
 
+    /**
+     * When two anyOf branches both point to the same $ref definition carrying an enum, the
+     * branches share a single underlying Property via the SchemaDefinition cache. The first
+     * branch has the EnumFilter applied; when the post-processor reaches the second branch,
+     * hasEnumFilterAlreadyApplied() returns true and skips re-conversion. Exactly one enum
+     * class must be generated and the property must accept valid enum values.
+     */
+    public function testEnumFilterNotAppliedTwiceWhenTwoBranchesShareSameRef(): void
+    {
+        $this->addPostProcessor();
+
+        $className = $this->generateClassFromFile('EnumRefSharedByTwoBranches.json');
+
+        $this->assertGeneratedEnums(1);
+
+        // Both branches share the same $ref and therefore the same enum definition.
+        // Generation must succeed and valid enum values must be accepted.
+        $object = new $className(['state' => 'active']);
+        $this->assertNotNull($object->getState());
+    }
+
     private function draftAwareEnumConfig(): array
     {
         $draft = DraftRunContext::getDraftForDataName(static::class, $this->name(), (string) $this->dataName());

--- a/tests/Schema/DraftExtensibilityTest/MutuallyExclusiveProducers.json
+++ b/tests/Schema/DraftExtensibilityTest/MutuallyExclusiveProducers.json
@@ -1,0 +1,14 @@
+{
+  "type": "object",
+  "properties": {
+    "value": {
+      "$ref": "#/definitions/Foo",
+      "$secondRef": "#/definitions/Foo"
+    }
+  },
+  "definitions": {
+    "Foo": {
+      "type": "string"
+    }
+  }
+}

--- a/tests/Schema/EnumPostProcessorTest/EnumRefSharedByTwoBranches.json
+++ b/tests/Schema/EnumPostProcessorTest/EnumRefSharedByTwoBranches.json
@@ -1,0 +1,24 @@
+{
+  "definitions": {
+    "status": {
+      "type": "string",
+      "enum": [
+        "active",
+        "inactive"
+      ]
+    }
+  },
+  "type": "object",
+  "properties": {
+    "state": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/status"
+        },
+        {
+          "$ref": "#/definitions/status"
+        }
+      ]
+    }
+  }
+}

--- a/tests/Schema/RefSiblingsPropertyLevelTest/PropertyLevelObjectCollision.json
+++ b/tests/Schema/RefSiblingsPropertyLevelTest/PropertyLevelObjectCollision.json
@@ -1,0 +1,33 @@
+{
+  "definitions": {
+    "location": {
+      "type": "object",
+      "properties": {
+        "street": {
+          "type": "string"
+        },
+        "zip": {
+          "type": "integer"
+        }
+      },
+      "required": [
+        "street"
+      ]
+    }
+  },
+  "type": "object",
+  "properties": {
+    "address": {
+      "$ref": "#/definitions/location",
+      "properties": {
+        "street": {
+          "type": "string",
+          "minLength": 3
+        },
+        "city": {
+          "type": "string"
+        }
+      }
+    }
+  }
+}

--- a/tests/Schema/RefSiblingsPropertyLevelTest/PropertyLevelObjectCollisionTypeNarrowing.json
+++ b/tests/Schema/RefSiblingsPropertyLevelTest/PropertyLevelObjectCollisionTypeNarrowing.json
@@ -1,0 +1,24 @@
+{
+  "definitions": {
+    "location": {
+      "type": "object",
+      "properties": {
+        "zip": {
+          "type": "number",
+          "minimum": 0
+        }
+      }
+    }
+  },
+  "type": "object",
+  "properties": {
+    "address": {
+      "$ref": "#/definitions/location",
+      "properties": {
+        "zip": {
+          "type": "integer"
+        }
+      }
+    }
+  }
+}

--- a/tests/Schema/RefSiblingsPropertyLevelTest/PropertyLevelObjectMerge.json
+++ b/tests/Schema/RefSiblingsPropertyLevelTest/PropertyLevelObjectMerge.json
@@ -1,0 +1,32 @@
+{
+  "definitions": {
+    "location": {
+      "type": "object",
+      "properties": {
+        "street": {
+          "type": "string"
+        },
+        "zip": {
+          "type": "integer"
+        }
+      },
+      "required": [
+        "street"
+      ]
+    }
+  },
+  "type": "object",
+  "properties": {
+    "address": {
+      "$ref": "#/definitions/location",
+      "properties": {
+        "city": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "city"
+      ]
+    }
+  }
+}

--- a/tests/Schema/RefSiblingsPropertyLevelTest/PropertyLevelStructuralSiblingNonObjectRef.json
+++ b/tests/Schema/RefSiblingsPropertyLevelTest/PropertyLevelStructuralSiblingNonObjectRef.json
@@ -1,0 +1,19 @@
+{
+  "definitions": {
+    "name": {
+      "type": "string",
+      "minLength": 1
+    }
+  },
+  "type": "object",
+  "properties": {
+    "person": {
+      "$ref": "#/definitions/name",
+      "properties": {
+        "firstName": {
+          "type": "string"
+        }
+      }
+    }
+  }
+}

--- a/tests/Schema/RefSiblingsTest/DefaultValuePropagation.json
+++ b/tests/Schema/RefSiblingsTest/DefaultValuePropagation.json
@@ -1,0 +1,20 @@
+{
+  "definitions": {
+    "base": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string",
+          "default": "World"
+        }
+      }
+    }
+  },
+  "$ref": "#/definitions/base",
+  "type": "object",
+  "properties": {
+    "name": {
+      "type": "string"
+    }
+  }
+}

--- a/tests/Schema/RefSiblingsTest/DefaultValuePropagationWithNullTypedSibling.json
+++ b/tests/Schema/RefSiblingsTest/DefaultValuePropagationWithNullTypedSibling.json
@@ -1,0 +1,20 @@
+{
+  "definitions": {
+    "base": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string",
+          "default": "Alice"
+        }
+      }
+    }
+  },
+  "$ref": "#/definitions/base",
+  "type": "object",
+  "properties": {
+    "name": {
+      "type": "null"
+    }
+  }
+}

--- a/tests/Schema/RefSiblingsTest/DefaultValuesAgree.json
+++ b/tests/Schema/RefSiblingsTest/DefaultValuesAgree.json
@@ -1,0 +1,21 @@
+{
+  "definitions": {
+    "base": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string",
+          "default": "World"
+        }
+      }
+    }
+  },
+  "$ref": "#/definitions/base",
+  "type": "object",
+  "properties": {
+    "name": {
+      "type": "string",
+      "default": "World"
+    }
+  }
+}

--- a/tests/Schema/RefSiblingsTest/DefaultValuesConflict.json
+++ b/tests/Schema/RefSiblingsTest/DefaultValuesConflict.json
@@ -1,0 +1,21 @@
+{
+  "definitions": {
+    "base": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string",
+          "default": "Alice"
+        }
+      }
+    }
+  },
+  "$ref": "#/definitions/base",
+  "type": "object",
+  "properties": {
+    "name": {
+      "type": "string",
+      "default": "Bob"
+    }
+  }
+}

--- a/tests/Schema/RefSiblingsTest/DefaultValuesConflictUntypedRef.json
+++ b/tests/Schema/RefSiblingsTest/DefaultValuesConflictUntypedRef.json
@@ -1,0 +1,20 @@
+{
+  "definitions": {
+    "base": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "default": "Alice"
+        }
+      }
+    }
+  },
+  "$ref": "#/definitions/base",
+  "type": "object",
+  "properties": {
+    "name": {
+      "type": "string",
+      "default": "Bob"
+    }
+  }
+}

--- a/tests/Schema/RefSiblingsTest/ExternalRefSiblings.json
+++ b/tests/Schema/RefSiblingsTest/ExternalRefSiblings.json
@@ -1,0 +1,9 @@
+{
+  "$ref": "../RefSiblingsTest_external/Base.json",
+  "type": "object",
+  "properties": {
+    "city": {
+      "type": "string"
+    }
+  }
+}

--- a/tests/Schema/RefSiblingsTest/NonStructuralPropertySiblings.json
+++ b/tests/Schema/RefSiblingsTest/NonStructuralPropertySiblings.json
@@ -1,0 +1,27 @@
+{
+  "definitions": {
+    "baseString": {
+      "type": "string",
+      "minLength": 1
+    }
+  },
+  "type": "object",
+  "properties": {
+    "withMinLength": {
+      "$ref": "#/definitions/baseString",
+      "minLength": 5
+    },
+    "withEnum": {
+      "$ref": "#/definitions/baseString",
+      "enum": [
+        "Alice",
+        "Bob",
+        "Charlie"
+      ]
+    },
+    "withConst": {
+      "$ref": "#/definitions/baseString",
+      "const": "fixed"
+    }
+  }
+}

--- a/tests/Schema/RefSiblingsTest/ObjectLevelMultiTypeCollision.json
+++ b/tests/Schema/RefSiblingsTest/ObjectLevelMultiTypeCollision.json
@@ -1,0 +1,28 @@
+{
+  "definitions": {
+    "base": {
+      "type": "object",
+      "properties": {
+        "count": {
+          "type": [
+            "string",
+            "integer"
+          ]
+        }
+      },
+      "required": [
+        "count"
+      ]
+    }
+  },
+  "$ref": "#/definitions/base",
+  "type": "object",
+  "properties": {
+    "count": {
+      "type": [
+        "string",
+        "integer"
+      ]
+    }
+  }
+}

--- a/tests/Schema/RefSiblingsTest/ObjectLevelTypeIntersection.json
+++ b/tests/Schema/RefSiblingsTest/ObjectLevelTypeIntersection.json
@@ -1,0 +1,21 @@
+{
+  "definitions": {
+    "base": {
+      "type": "object",
+      "properties": {
+        "count": {
+          "type": "number",
+          "minimum": 0
+        }
+      },
+      "required": ["count"]
+    }
+  },
+  "$ref": "#/definitions/base",
+  "type": "object",
+  "properties": {
+    "count": {
+      "type": "integer"
+    }
+  }
+}

--- a/tests/Schema/RefSiblingsTest/PropertyLevelDefaultValuesConflict.json
+++ b/tests/Schema/RefSiblingsTest/PropertyLevelDefaultValuesConflict.json
@@ -1,0 +1,16 @@
+{
+  "definitions": {
+    "nameDef": {
+      "type": "string",
+      "default": "Alice"
+    }
+  },
+  "type": "object",
+  "properties": {
+    "name": {
+      "$ref": "#/definitions/nameDef",
+      "type": "string",
+      "default": "Bob"
+    }
+  }
+}

--- a/tests/Schema/RefSiblingsTest/RecursiveRefSiblings.json
+++ b/tests/Schema/RefSiblingsTest/RecursiveRefSiblings.json
@@ -1,0 +1,23 @@
+{
+  "definitions": {
+    "node": {
+      "type": "object",
+      "properties": {
+        "value": {
+          "type": "string"
+        },
+        "next": {
+          "$ref": "#/definitions/node"
+        }
+      },
+      "required": ["value"]
+    }
+  },
+  "$ref": "#/definitions/node",
+  "type": "object",
+  "properties": {
+    "label": {
+      "type": "string"
+    }
+  }
+}

--- a/tests/Schema/RefSiblingsTest/RefAlone.json
+++ b/tests/Schema/RefSiblingsTest/RefAlone.json
@@ -1,0 +1,14 @@
+{
+  "definitions": {
+    "strDef": {
+      "type": "string",
+      "minLength": 2
+    }
+  },
+  "type": "object",
+  "properties": {
+    "name": {
+      "$ref": "#/definitions/strDef"
+    }
+  }
+}

--- a/tests/Schema/RefSiblingsTest/RefSiblingsInsideAllOf.json
+++ b/tests/Schema/RefSiblingsTest/RefSiblingsInsideAllOf.json
@@ -1,0 +1,27 @@
+{
+  "type": "object",
+  "properties": {
+    "address": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/location",
+          "properties": {
+            "city": {
+              "type": "string"
+            }
+          }
+        }
+      ]
+    }
+  },
+  "definitions": {
+    "location": {
+      "type": "object",
+      "properties": {
+        "street": {
+          "type": "string"
+        }
+      }
+    }
+  }
+}

--- a/tests/Schema/RefSiblingsTest/ScalarTypeConflict.json
+++ b/tests/Schema/RefSiblingsTest/ScalarTypeConflict.json
@@ -1,0 +1,14 @@
+{
+  "definitions": {
+    "stringDef": {
+      "type": "string"
+    }
+  },
+  "type": "object",
+  "properties": {
+    "value": {
+      "$ref": "#/definitions/stringDef",
+      "type": "integer"
+    }
+  }
+}

--- a/tests/Schema/RefSiblingsTest/ScalarTypeMerge.json
+++ b/tests/Schema/RefSiblingsTest/ScalarTypeMerge.json
@@ -1,0 +1,26 @@
+{
+  "definitions": {
+    "numberDef": {
+      "type": "number",
+      "minimum": 0
+    },
+    "nullableString": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "minLength": 1
+    }
+  },
+  "type": "object",
+  "properties": {
+    "count": {
+      "$ref": "#/definitions/numberDef",
+      "type": "integer"
+    },
+    "label": {
+      "$ref": "#/definitions/nullableString",
+      "type": "string"
+    }
+  }
+}

--- a/tests/Schema/RefSiblingsTest/UntypedRefWithScalarSibling.json
+++ b/tests/Schema/RefSiblingsTest/UntypedRefWithScalarSibling.json
@@ -1,0 +1,14 @@
+{
+  "definitions": {
+    "flexible": {
+      "minLength": 1
+    }
+  },
+  "type": "object",
+  "properties": {
+    "name": {
+      "$ref": "#/definitions/flexible",
+      "minLength": 3
+    }
+  }
+}

--- a/tests/Schema/RefSiblingsTest_external/Base.json
+++ b/tests/Schema/RefSiblingsTest_external/Base.json
@@ -1,0 +1,9 @@
+{
+  "type": "object",
+  "properties": {
+    "street": {
+      "type": "string"
+    }
+  },
+  "required": ["street"]
+}

--- a/tests/Schema/ReferencePropertyTest/NestedIdScopedExternalReference.json
+++ b/tests/Schema/ReferencePropertyTest/NestedIdScopedExternalReference.json
@@ -1,0 +1,19 @@
+{
+  "type": "object",
+  "definitions": {
+    "person": {
+      "$id": "%s",
+      "type": "object",
+      "properties": {
+        "colleague": {
+          "$ref": "/wol-soft/php-json-schema-model-generator/master/tests/Schema/ReferencePropertyTest_external/library.json#/definitions/person"
+        }
+      }
+    }
+  },
+  "properties": {
+    "person": {
+      "$ref": "#/definitions/person"
+    }
+  }
+}

--- a/tests/Schema/ReferencePropertyTest/RefWithPropertyLevelScalarSiblings.json
+++ b/tests/Schema/ReferencePropertyTest/RefWithPropertyLevelScalarSiblings.json
@@ -1,0 +1,14 @@
+{
+  "definitions": {
+    "name": {
+      "type": "string"
+    }
+  },
+  "type": "object",
+  "properties": {
+    "name": {
+      "$ref": "#/definitions/name",
+      "minLength": 3
+    }
+  }
+}

--- a/tests/Schema/ReferencePropertyTest/RefWithPropertyLevelTypeConflict.json
+++ b/tests/Schema/ReferencePropertyTest/RefWithPropertyLevelTypeConflict.json
@@ -1,0 +1,14 @@
+{
+  "definitions": {
+    "name": {
+      "type": "string"
+    }
+  },
+  "type": "object",
+  "properties": {
+    "name": {
+      "$ref": "#/definitions/name",
+      "type": "integer"
+    }
+  }
+}

--- a/tests/Schema/ReferencePropertyTest/RefWithPropertyLevelTypeNarrowing.json
+++ b/tests/Schema/ReferencePropertyTest/RefWithPropertyLevelTypeNarrowing.json
@@ -1,0 +1,14 @@
+{
+  "definitions": {
+    "score": {
+      "type": "number"
+    }
+  },
+  "type": "object",
+  "properties": {
+    "score": {
+      "$ref": "#/definitions/score",
+      "type": "integer"
+    }
+  }
+}

--- a/tests/Schema/ReferencePropertyTest/RefWithSiblings.json
+++ b/tests/Schema/ReferencePropertyTest/RefWithSiblings.json
@@ -1,0 +1,30 @@
+{
+  "definitions": {
+    "address": {
+      "type": "object",
+      "properties": {
+        "street": {
+          "type": "string"
+        },
+        "city": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "street"
+      ]
+    }
+  },
+  "$ref": "#/definitions/address",
+  "properties": {
+    "name": {
+      "type": "string"
+    },
+    "zip": {
+      "type": "integer"
+    }
+  },
+  "required": [
+    "name"
+  ]
+}

--- a/tests/Schema/ReferencePropertyTest/SharedRefAsArrayItemAndObjectProperty.json
+++ b/tests/Schema/ReferencePropertyTest/SharedRefAsArrayItemAndObjectProperty.json
@@ -1,0 +1,24 @@
+{
+  "definitions": {
+    "item": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string"
+        }
+      }
+    }
+  },
+  "type": "object",
+  "properties": {
+    "list": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/item"
+      }
+    },
+    "single": {
+      "$ref": "#/definitions/item"
+    }
+  }
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -25,11 +25,16 @@ register_shutdown_function(static function (): void {
         RecursiveIteratorIterator::CHILD_FIRST,
     );
 
+    // Suppressed: this runs after the last test has finished, so no TestCase is on the call
+    // stack. Since PHPUnit 13.2.0, an unsuppressed warning raised outside of a running test
+    // (e.g. a locked file that can't be deleted yet) makes PHPUnit's error handler throw
+    // NoTestCaseObjectOnCallStackException, crashing the whole run instead of just leaving the
+    // temp directory behind.
     foreach ($iterator as $file) {
-        $file->isDir() ? rmdir($file->getRealPath()) : unlink($file->getRealPath());
+        $file->isDir() ? @rmdir($file->getRealPath()) : @unlink($file->getRealPath());
     }
 
-    rmdir(TEST_BASE_DIR);
+    @rmdir(TEST_BASE_DIR);
 });
 
 require_once __DIR__ . '/../vendor/autoload.php';


### PR DESCRIPTION
## Summary

Implements draft-aware \`$ref\`+sibling keyword handling for JSON Schema Draft 2019-09 and later, where \`$ref\` no longer discards sibling keywords but merges them with the referenced schema.

- **\`$ref\` producer contract** (\`RefProducerInterface\`): a new dispatch layer in \`PropertyFactory\` lets drafts inject a producer that controls how the resolved \`$ref\` property is returned — enabling sibling merge for 2019-09+ while leaving Draft 7 behaviour unchanged.
- **Base-level merge**: object-level sibling keywords (\`type\`, \`required\`, \`properties\`, defaults, \`description\`) declared alongside \`$ref\` are intersected with (not overridden by) the referenced schema; conflicting types or duplicate properties with unresolvable type conflicts throw \`SchemaException\` at generation time.
- **Property-level scalar sibling merge**: scalar sibling constraints (\`minimum\`, \`maximum\`, \`minLength\`, \`maxLength\`, \`pattern\`, \`enum\`, \`const\`, \`format\`, and all other modifier-applied keywords) are applied on top of the \`$ref\`-resolved property for Draft 2019-09+.
- **Implicit-null guard fix**: the \`$ref\`-resolved array item property's implicit-null decorator was being conditionally re-applied even when the resolved property already carried it from the reference definition; the fix deduplicates the decorator.
- **Documentation**: \`docs/source/generic/references.rst\` documents the draft-dependent behaviour and the generation-time schema validation rules.

## Test plan

- [ ] \`./vendor/bin/phpunit tests/Basic/ReferencePropertyTest.php\` — core \`$ref\`+sibling tests (scalar merge, base merge, conflict detection)
- [ ] \`PHPUNIT_FULL_DRAFT_COVERAGE=1 ./vendor/bin/phpunit tests/Basic/ReferencePropertyTest.php\` — verify Draft 7 continues to ignore siblings
- [ ] \`./vendor/bin/phpunit\` — full suite green

🤖 Generated with [Claude Code](https://claude.com/claude-code)